### PR TITLE
fix(error-redirect): use query-safe fragment as recommended in the latest OAuth 2 security best practices

### DIFF
--- a/identity-server/src/IdentityServer/Endpoints/Results/AuthorizeResult.cs
+++ b/identity-server/src/IdentityServer/Endpoints/Results/AuthorizeResult.cs
@@ -177,8 +177,8 @@ public class AuthorizeHttpWriter : IHttpResponseWriter<AuthorizeResult>
 
         if (response.IsError && !uri.Contains('#'))
         {
-            // https://tools.ietf.org/html/draft-bradley-oauth-open-redirector-00
-            uri += "#_=_";
+            // https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics-29#section-4.1.3
+            uri += "#_";
         }
 
         return uri;


### PR DESCRIPTION
This PR adjusts the fragment that is added to error redirect responses, which is supposed to prevent browsers from reattaching existing ones.

The previous fragment `#_=_` is an invalid query selector and can not be used as is on the receiving end, hence it has been adjusted to the recommended `#_`.

Additionally, I adjusted the link to the respective latest active internet draft.

This looks like a minor thing, but one can run into issues caused by the browsers behavior of carrying along fragments.