### PR TITLE
remove one of the IsMissing extensions and move to ArgumentException.ThrowIfNullOrWhiteSpace

### DIFF
--- a/identity-server/src/IdentityServer/IdentityServerUser.cs
+++ b/identity-server/src/IdentityServer/IdentityServerUser.cs
@@ -59,8 +59,7 @@ public class IdentityServerUser
     /// <param name="subjectId">The subject ID</param>
     public IdentityServerUser(string subjectId)
     {
-        if (subjectId.IsMissing()) throw new ArgumentException("SubjectId is mandatory", nameof(subjectId));
-
+        ArgumentException.ThrowIfNullOrWhiteSpace(subjectId);
         SubjectId = subjectId;
     }
 
@@ -71,7 +70,6 @@ public class IdentityServerUser
     /// <exception cref="ArgumentNullException"></exception>
     public ClaimsPrincipal CreatePrincipal()
     {
-        if (SubjectId.IsMissing()) throw new ArgumentException("SubjectId is mandatory", nameof(SubjectId));
         var claims = new List<Claim> { new Claim(JwtClaimTypes.Subject, SubjectId) };
 
         if (DisplayName.IsPresent())

--- a/identity-server/src/IdentityServer/Models/Contexts/IsActiveContext.cs
+++ b/identity-server/src/IdentityServer/Models/Contexts/IsActiveContext.cs
@@ -22,7 +22,7 @@ public class IsActiveContext
     {
         ArgumentNullException.ThrowIfNull(subject);
         ArgumentNullException.ThrowIfNull(client);
-        if (caller.IsMissing()) throw new ArgumentNullException(nameof(caller));
+        ArgumentNullException.ThrowIfNullOrWhiteSpace(caller);
 
         Subject = subject;
         Client = client;

--- a/identity-server/src/IdentityServer/Stores/Default/DefaultGrantStore.cs
+++ b/identity-server/src/IdentityServer/Stores/Default/DefaultGrantStore.cs
@@ -62,7 +62,7 @@ public class DefaultGrantStore<T>
         IHandleGenerationService handleGenerationService,
         ILogger logger)
     {
-        if (grantType.IsMissing()) throw new ArgumentNullException(nameof(grantType));
+        ArgumentException.ThrowIfNullOrWhiteSpace(grantType);
 
         GrantType = grantType;
         Store = store;

--- a/identity-server/src/Storage/Extensions/StringsExtensions.cs
+++ b/identity-server/src/Storage/Extensions/StringsExtensions.cs
@@ -9,12 +9,6 @@ namespace Duende.IdentityServer.Extensions;
 internal static class StringExtensions
 {
     [DebuggerStepThrough]
-    public static bool IsMissing(this string value)
-    {
-        return string.IsNullOrWhiteSpace(value);
-    }
-
-    [DebuggerStepThrough]
     public static bool IsPresent(this string value)
     {
         return !string.IsNullOrWhiteSpace(value);

--- a/identity-server/src/Storage/IdentityServerUser.cs
+++ b/identity-server/src/Storage/IdentityServerUser.cs
@@ -54,7 +54,7 @@ internal class IdentityServerUser
     /// <param name="subjectId">The subject ID</param>
     public IdentityServerUser(string subjectId)
     {
-        if (subjectId.IsMissing()) throw new ArgumentException("SubjectId is mandatory", nameof(subjectId));
+        ArgumentException.ThrowIfNullOrWhiteSpace(subjectId);
 
         SubjectId = subjectId;
     }
@@ -66,7 +66,6 @@ internal class IdentityServerUser
     /// <exception cref="ArgumentNullException"></exception>
     public ClaimsPrincipal CreatePrincipal()
     {
-        if (SubjectId.IsMissing()) throw new ArgumentException("SubjectId is mandatory", nameof(SubjectId));
         var claims = new List<Claim> { new Claim(JwtClaimTypes.Subject, SubjectId) };
 
         if (DisplayName.IsPresent())

--- a/identity-server/src/Storage/Models/ApiResource.cs
+++ b/identity-server/src/Storage/Models/ApiResource.cs
@@ -64,7 +64,7 @@ public class ApiResource : Resource
     /// <exception cref="System.ArgumentNullException">name</exception>
     public ApiResource(string name, string? displayName, IEnumerable<string>? userClaims)
     {
-        if (name.IsMissing()) throw new ArgumentNullException(nameof(name));
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
 
         Name = name;
         DisplayName = displayName;

--- a/identity-server/src/Storage/Models/ApiScope.cs
+++ b/identity-server/src/Storage/Models/ApiScope.cs
@@ -64,7 +64,7 @@ public class ApiScope : Resource
     /// <exception cref="System.ArgumentNullException">name</exception>
     public ApiScope(string name, string displayName, IEnumerable<string>? userClaims)
     {
-        if (name.IsMissing()) throw new ArgumentNullException(nameof(name));
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
 
         Name = name;
         DisplayName = displayName;

--- a/identity-server/src/Storage/Models/IdentityResource.cs
+++ b/identity-server/src/Storage/Models/IdentityResource.cs
@@ -46,7 +46,7 @@ public class IdentityResource : Resource
     /// <exception cref="System.ArgumentException">Must provide at least one claim type - claimTypes</exception>
     public IdentityResource(string name, string displayName, IEnumerable<string> userClaims)
     {
-        if (name.IsMissing()) throw new ArgumentNullException(nameof(name));
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
         if (userClaims.IsNullOrEmpty()) throw new ArgumentException("Must provide at least one claim type", nameof(userClaims));
 
         Name = name;


### PR DESCRIPTION
also removes 2x redundant ArgumentException check in CreatePrincipal since SubjectId is immutable and guarded in the constructor