### PR TITLE
Disable tag builds (temporary)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,8 @@ on:
     branches:
     - main
     - features/**
-    tags:
-    - '*.*.*'
+    # tags:
+    # - '*.*.*'
     paths: 
     - 'identity-server/**'
   pull_request:


### PR DESCRIPTION
I'm about to bulk rename tags, and don't want that to kick off dozens of builds.

