### PR TITLE
phase out fluent assertions in favor of shouldly

### DIFF
--- a/bff/test/Duende.Bff.EntityFramework.Tests/Duende.Bff.EntityFramework.Tests.csproj
+++ b/bff/test/Duende.Bff.EntityFramework.Tests/Duende.Bff.EntityFramework.Tests.csproj
@@ -5,12 +5,12 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Shouldly" Version="4.2.1" />
         <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="FluentAssertions" />
         <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>

--- a/bff/test/Duende.Bff.EntityFramework.Tests/UserSessionStoreTests.cs
+++ b/bff/test/Duende.Bff.EntityFramework.Tests/UserSessionStoreTests.cs
@@ -1,13 +1,13 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
-using FluentAssertions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Shouldly;
 using Xunit;
 
 namespace Duende.Bff.EntityFramework.Tests
@@ -31,7 +31,7 @@ namespace Duende.Bff.EntityFramework.Tests
         [Fact]
         public async Task CreateUserSessionAsync_should_succeed()
         {
-            _database.UserSessions.Count().Should().Be(0);
+            _database.UserSessions.Count().ShouldBe(0);
 
             await _subject.CreateUserSessionAsync(new UserSession
             {
@@ -44,7 +44,7 @@ namespace Duende.Bff.EntityFramework.Tests
                 Ticket = "ticket"
             });
 
-            _database.UserSessions.Count().Should().Be(1);
+            _database.UserSessions.Count().ShouldBe(1);
         }
 
 
@@ -64,20 +64,20 @@ namespace Duende.Bff.EntityFramework.Tests
 
             var item = await _subject.GetUserSessionAsync("key123");
 
-            item.Should().NotBeNull();
-            item.Key.Should().Be("key123");
-            item.SubjectId.Should().Be("sub");
-            item.SessionId.Should().Be("sid");
-            item.Ticket.Should().Be("ticket");
-            item.Created.Should().Be(new DateTime(2020, 3, 1, 9, 12, 33, DateTimeKind.Utc));
-            item.Renewed.Should().Be(new DateTime(2021, 4, 2, 10, 13, 34, DateTimeKind.Utc));
-            item.Expires.Should().Be(new DateTime(2022, 5, 3, 11, 14, 35, DateTimeKind.Utc));
+            item.ShouldNotBeNull();
+            item.Key.ShouldBe("key123");
+            item.SubjectId.ShouldBe("sub");
+            item.SessionId.ShouldBe("sid");
+            item.Ticket.ShouldBe("ticket");
+            item.Created.ShouldBe(new DateTime(2020, 3, 1, 9, 12, 33, DateTimeKind.Utc));
+            item.Renewed.ShouldBe(new DateTime(2021, 4, 2, 10, 13, 34, DateTimeKind.Utc));
+            item.Expires.ShouldBe(new DateTime(2022, 5, 3, 11, 14, 35, DateTimeKind.Utc));
         }
         [Fact]
         public async Task GetUserSessionAsync_for_invalid_key_should_return_null()
         {
             var item = await _subject.GetUserSessionAsync("invalid");
-            item.Should().BeNull();
+            item.ShouldBeNull();
         }
 
 
@@ -107,14 +107,14 @@ namespace Duende.Bff.EntityFramework.Tests
                 });
 
                 var item = await _subject.GetUserSessionAsync("key123");
-                item.Should().NotBeNull();
-                item.Key.Should().Be("key123");
-                item.SubjectId.Should().Be("sub");
-                item.SessionId.Should().Be("sid");
-                item.Ticket.Should().Be("ticket2");
-                item.Created.Should().Be(new DateTime(2020, 3, 1, 9, 12, 33, DateTimeKind.Utc));
-                item.Renewed.Should().Be(new DateTime(2024, 1, 3, 5, 7, 9, DateTimeKind.Utc));
-                item.Expires.Should().Be(new DateTime(2025, 2, 4, 6, 8, 10, DateTimeKind.Utc));
+                item.ShouldNotBeNull();
+                item.Key.ShouldBe("key123");
+                item.SubjectId.ShouldBe("sub");
+                item.SessionId.ShouldBe("sid");
+                item.Ticket.ShouldBe("ticket2");
+                item.Created.ShouldBe(new DateTime(2020, 3, 1, 9, 12, 33, DateTimeKind.Utc));
+                item.Renewed.ShouldBe(new DateTime(2024, 1, 3, 5, 7, 9, DateTimeKind.Utc));
+                item.Expires.ShouldBe(new DateTime(2025, 2, 4, 6, 8, 10, DateTimeKind.Utc));
             }
             {
                 await _subject.UpdateUserSessionAsync("key123", new UserSessionUpdate
@@ -128,14 +128,14 @@ namespace Duende.Bff.EntityFramework.Tests
                 });
 
                 var item = await _subject.GetUserSessionAsync("key123");
-                item.Should().NotBeNull();
-                item.Key.Should().Be("key123");
-                item.SubjectId.Should().Be("sub2");
-                item.SessionId.Should().Be("sid2");
-                item.Ticket.Should().Be("ticket3");
-                item.Created.Should().Be(new DateTime(2022, 3, 1, 9, 12, 33, DateTimeKind.Utc));
-                item.Renewed.Should().Be(new DateTime(2024, 1, 3, 5, 7, 9, DateTimeKind.Utc));
-                item.Expires.Should().Be(new DateTime(2025, 2, 4, 6, 8, 10, DateTimeKind.Utc));
+                item.ShouldNotBeNull();
+                item.Key.ShouldBe("key123");
+                item.SubjectId.ShouldBe("sub2");
+                item.SessionId.ShouldBe("sid2");
+                item.Ticket.ShouldBe("ticket3");
+                item.Created.ShouldBe(new DateTime(2022, 3, 1, 9, 12, 33, DateTimeKind.Utc));
+                item.Renewed.ShouldBe(new DateTime(2024, 1, 3, 5, 7, 9, DateTimeKind.Utc));
+                item.Expires.ShouldBe(new DateTime(2025, 2, 4, 6, 8, 10, DateTimeKind.Utc));
             }
         }
         [Fact]
@@ -149,7 +149,7 @@ namespace Duende.Bff.EntityFramework.Tests
             });
 
             var item = await _subject.GetUserSessionAsync("key123");
-            item.Should().BeNull();
+            item.ShouldBeNull();
         }
 
 
@@ -162,11 +162,11 @@ namespace Duende.Bff.EntityFramework.Tests
                 SessionId = "session",
                 Ticket = "ticket",
             });
-            _database.UserSessions.Count().Should().Be(1);
+            _database.UserSessions.Count().ShouldBe(1);
 
             await _subject.DeleteUserSessionAsync("key123");
             
-            _database.UserSessions.Count().Should().Be(0);
+            _database.UserSessions.Count().ShouldBe(0);
         }
         [Fact]
         public async Task DeleteUserSessionAsync_for_invalid_key_should_succeed()
@@ -222,9 +222,9 @@ namespace Duende.Bff.EntityFramework.Tests
             });
 
             var items = await _subject.GetUserSessionsAsync(new UserSessionsFilter { SubjectId = "sub2" });
-            items.Count().Should().Be(3);
-            items.Select(x => x.SubjectId).Distinct().Should().BeEquivalentTo(new[] { "sub2" });
-            items.Select(x => x.SessionId).Should().BeEquivalentTo(new[] { "sid2_1", "sid2_2", "sid2_3", });
+            items.Count().ShouldBe(3);
+            items.Select(x => x.SubjectId).Distinct().ToArray().ShouldBeEquivalentTo(new[] { "sub2" });
+            items.Select(x => x.SessionId).ToArray().ShouldBeEquivalentTo(new[] { "sid2_1", "sid2_2", "sid2_3", });
         }
         [Fact]
         public async Task GetUserSessionsAsync_for_invalid_sub_should_return_empty()
@@ -273,7 +273,7 @@ namespace Duende.Bff.EntityFramework.Tests
             });
 
             var items = await _subject.GetUserSessionsAsync(new UserSessionsFilter { SubjectId = "invalid" });
-            items.Count().Should().Be(0);
+            items.Count().ShouldBe(0);
         }
         [Fact]
         public async Task GetUserSessionsAsync_for_valid_sid_should_succeed()
@@ -322,9 +322,9 @@ namespace Duende.Bff.EntityFramework.Tests
             });
 
             var items = await _subject.GetUserSessionsAsync(new UserSessionsFilter { SessionId = "sid2_2" });
-            items.Count().Should().Be(1);
-            items.Select(x => x.SubjectId).Should().BeEquivalentTo(new[] { "sub2" });
-            items.Select(x => x.SessionId).Should().BeEquivalentTo(new[] { "sid2_2" });
+            items.Count().ShouldBe(1);
+            items.Select(x => x.SubjectId).ToArray().ShouldBeEquivalentTo(new[] { "sub2" });
+            items.Select(x => x.SessionId).ToArray().ShouldBeEquivalentTo(new[] { "sid2_2" });
         }
         [Fact]
         public async Task GetUserSessionsAsync_for_invalid_sid_should_return_empty()
@@ -373,7 +373,7 @@ namespace Duende.Bff.EntityFramework.Tests
             });
 
             var items = await _subject.GetUserSessionsAsync(new UserSessionsFilter { SessionId = "invalid" });
-            items.Count().Should().Be(0);
+            items.Count().ShouldBe(0);
         }
         [Fact]
         public async Task GetUserSessionsAsync_for_valid_sub_and_sid_should_succeed()
@@ -422,9 +422,9 @@ namespace Duende.Bff.EntityFramework.Tests
             });
 
             var items = await _subject.GetUserSessionsAsync(new UserSessionsFilter { SubjectId = "sub2", SessionId = "sid2_2" });
-            items.Count().Should().Be(1);
-            items.Select(x => x.SubjectId).Should().BeEquivalentTo(new[] { "sub2" });
-            items.Select(x => x.SessionId).Should().BeEquivalentTo(new[] { "sid2_2" });
+            items.Count().ShouldBe(1);
+            items.Select(x => x.SubjectId).ToArray().ShouldBeEquivalentTo(new[] { "sub2" });
+            items.Select(x => x.SessionId).ToArray().ShouldBeEquivalentTo(new[] { "sid2_2" });
         }
         [Fact]
         public async Task GetUserSessionsAsync_for_invalid_sub_and_sid_should_succeed()
@@ -474,22 +474,22 @@ namespace Duende.Bff.EntityFramework.Tests
 
             {
                 var items = await _subject.GetUserSessionsAsync(new UserSessionsFilter { SubjectId = "invalid", SessionId = "invalid" });
-                items.Count().Should().Be(0);
+                items.Count().ShouldBe(0);
             }
             {
                 var items = await _subject.GetUserSessionsAsync(new UserSessionsFilter { SubjectId = "sub1", SessionId = "invalid" });
-                items.Count().Should().Be(0);
+                items.Count().ShouldBe(0);
             }
             {
                 var items = await _subject.GetUserSessionsAsync(new UserSessionsFilter { SubjectId = "invalid", SessionId = "sid1_1" });
-                items.Count().Should().Be(0);
+                items.Count().ShouldBe(0);
             }
         }
         [Fact]
         public async Task GetUserSessionsAsync_for_missing_sub_and_sid_should_throw()
         {
             Func<Task> f = () => _subject.GetUserSessionsAsync(new UserSessionsFilter());
-            await f.Should().ThrowAsync<Exception>();
+            await f.ShouldThrowAsync<Exception>();
         }
 
 
@@ -540,8 +540,8 @@ namespace Duende.Bff.EntityFramework.Tests
             });
 
             await _subject.DeleteUserSessionsAsync(new UserSessionsFilter { SubjectId = "sub2" });
-            _database.UserSessions.Count().Should().Be(3);
-            _database.UserSessions.Count(x => x.SubjectId == "sub2").Should().Be(0);
+            _database.UserSessions.Count().ShouldBe(3);
+            _database.UserSessions.Count(x => x.SubjectId == "sub2").ShouldBe(0);
         }
         [Fact]
         public async Task DeleteUserSessionsAsync_for_invalid_sub_should_do_nothing()
@@ -590,7 +590,7 @@ namespace Duende.Bff.EntityFramework.Tests
             });
 
             await _subject.DeleteUserSessionsAsync(new UserSessionsFilter { SubjectId = "invalid" });
-            _database.UserSessions.Count().Should().Be(6);
+            _database.UserSessions.Count().ShouldBe(6);
         }
         [Fact]
         public async Task DeleteUserSessionsAsync_for_valid_sid_should_succeed()
@@ -639,8 +639,8 @@ namespace Duende.Bff.EntityFramework.Tests
             });
 
             await _subject.DeleteUserSessionsAsync(new UserSessionsFilter { SessionId = "sid2_2" });
-            _database.UserSessions.Count().Should().Be(5);
-            _database.UserSessions.Count(x => x.SessionId == "sid2_2").Should().Be(0);
+            _database.UserSessions.Count().ShouldBe(5);
+            _database.UserSessions.Count(x => x.SessionId == "sid2_2").ShouldBe(0);
         }
         [Fact]
         public async Task DeleteUserSessionsAsync_for_invalid_sid_should_do_nothing()
@@ -689,7 +689,7 @@ namespace Duende.Bff.EntityFramework.Tests
             });
 
             await _subject.DeleteUserSessionsAsync(new UserSessionsFilter { SessionId = "invalid" });
-            _database.UserSessions.Count().Should().Be(6);
+            _database.UserSessions.Count().ShouldBe(6);
         }
         [Fact]
         public async Task DeleteUserSessionsAsync_for_valid_sub_and_sid_should_succeed()
@@ -738,8 +738,8 @@ namespace Duende.Bff.EntityFramework.Tests
             });
 
             await _subject.DeleteUserSessionsAsync(new UserSessionsFilter { SubjectId = "sub2", SessionId = "sid2_2" });
-            _database.UserSessions.Count().Should().Be(5);
-            _database.UserSessions.Count(x => x.SubjectId == "sub2" && x.SessionId == "sid2_2").Should().Be(0);
+            _database.UserSessions.Count().ShouldBe(5);
+            _database.UserSessions.Count(x => x.SubjectId == "sub2" && x.SessionId == "sid2_2").ShouldBe(0);
         }
         [Fact]
         public async Task DeleteUserSessionsAsync_for_invalid_sub_and_sid_should_succeed()
@@ -789,22 +789,22 @@ namespace Duende.Bff.EntityFramework.Tests
 
             {
                 await _subject.DeleteUserSessionsAsync(new UserSessionsFilter { SubjectId = "invalid", SessionId = "invalid" });
-                _database.UserSessions.Count().Should().Be(6);
+                _database.UserSessions.Count().ShouldBe(6);
             }
             {
                 await _subject.DeleteUserSessionsAsync(new UserSessionsFilter { SubjectId = "sub1", SessionId = "invalid" });
-                _database.UserSessions.Count().Should().Be(6);
+                _database.UserSessions.Count().ShouldBe(6);
             }
             {
                 await _subject.DeleteUserSessionsAsync(new UserSessionsFilter { SubjectId = "invalid", SessionId = "sid1_1" });
-                _database.UserSessions.Count().Should().Be(6);
+                _database.UserSessions.Count().ShouldBe(6);
             }
         }
         [Fact]
         public async Task DeleteUserSessionsAsync_for_missing_sub_and_sid_should_throw()
         {
             Func<Task> f = () => _subject.DeleteUserSessionsAsync(new UserSessionsFilter());
-            await f.Should().ThrowAsync<Exception>();
+            await f.ShouldThrowAsync<Exception>();
         }
         
         [Fact]
@@ -841,7 +841,7 @@ namespace Duende.Bff.EntityFramework.Tests
             await ctx1.SaveChangesAsync();
 
             Func<Task> f1 = async () => await ctx2.SaveChangesAsync();
-            await f1.Should().ThrowAsync<DbUpdateConcurrencyException>();
+            await f1.ShouldThrowAsync<DbUpdateConcurrencyException>();
 
             try
             {

--- a/bff/test/Duende.Bff.Tests/Duende.Bff.Tests.csproj
+++ b/bff/test/Duende.Bff.Tests/Duende.Bff.Tests.csproj
@@ -6,12 +6,12 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Shouldly" Version="4.2.1" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" />
     <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/bff/test/Duende.Bff.Tests/Endpoints/LocalEndpointTests.cs
+++ b/bff/test/Duende.Bff.Tests/Endpoints/LocalEndpointTests.cs
@@ -3,13 +3,13 @@
 
 using Duende.Bff.Tests.TestFramework;
 using Duende.Bff.Tests.TestHosts;
-using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Shouldly;
 using Xunit;
 
 namespace Duende.Bff.Tests.Endpoints
@@ -25,13 +25,13 @@ namespace Duende.Bff.Tests.Endpoints
             req.Headers.Add("x-csrf", "1");
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.IsSuccessStatusCode.Should().BeTrue();
-            response.Content.Headers.ContentType.MediaType.Should().Be("application/json");
+            response.IsSuccessStatusCode.ShouldBeTrue();
+            response.Content.Headers.ContentType.MediaType.ShouldBe("application/json");
             var json = await response.Content.ReadAsStringAsync();
             var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
-            apiResult.Method.Should().Be("GET");
-            apiResult.Path.Should().Be("/local_authz");
-            apiResult.Sub.Should().Be("alice");
+            apiResult.Method.ShouldBe("GET");
+            apiResult.Path.ShouldBe("/local_authz");
+            apiResult.Sub.ShouldBe("alice");
         }
         
         [Fact]
@@ -42,13 +42,13 @@ namespace Duende.Bff.Tests.Endpoints
             var req = new HttpRequestMessage(HttpMethod.Get, BffHost.Url("/local_authz_no_csrf"));
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.IsSuccessStatusCode.Should().BeTrue();
-            response.Content.Headers.ContentType.MediaType.Should().Be("application/json");
+            response.IsSuccessStatusCode.ShouldBeTrue();
+            response.Content.Headers.ContentType.MediaType.ShouldBe("application/json");
             var json = await response.Content.ReadAsStringAsync();
             var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
-            apiResult.Method.Should().Be("GET");
-            apiResult.Path.Should().Be("/local_authz_no_csrf");
-            apiResult.Sub.Should().Be("alice");
+            apiResult.Method.ShouldBe("GET");
+            apiResult.Path.ShouldBe("/local_authz_no_csrf");
+            apiResult.Sub.ShouldBe("alice");
         }
         
         [Fact]
@@ -58,7 +58,7 @@ namespace Duende.Bff.Tests.Endpoints
             req.Headers.Add("x-csrf", "1");
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+            response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
         }
 
         [Fact]
@@ -67,7 +67,7 @@ namespace Duende.Bff.Tests.Endpoints
             var req = new HttpRequestMessage(HttpMethod.Get, BffHost.Url("/local_anon"));
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+            response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
         }
         
         [Fact]
@@ -76,7 +76,7 @@ namespace Duende.Bff.Tests.Endpoints
             var req = new HttpRequestMessage(HttpMethod.Get, BffHost.Url("/local_anon_no_csrf"));
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            response.StatusCode.ShouldBe(HttpStatusCode.OK);
         }
 
         [Fact]
@@ -86,13 +86,13 @@ namespace Duende.Bff.Tests.Endpoints
             req.Headers.Add("x-csrf", "1");
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.IsSuccessStatusCode.Should().BeTrue();
-            response.Content.Headers.ContentType.MediaType.Should().Be("application/json");
+            response.IsSuccessStatusCode.ShouldBeTrue();
+            response.Content.Headers.ContentType.MediaType.ShouldBe("application/json");
             var json = await response.Content.ReadAsStringAsync();
             var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
-            apiResult.Method.Should().Be("GET");
-            apiResult.Path.Should().Be("/local_anon");
-            apiResult.Sub.Should().BeNull();
+            apiResult.Method.ShouldBe("GET");
+            apiResult.Path.ShouldBe("/local_anon");
+            apiResult.Sub.ShouldBeNull();
         }
 
         [Fact]
@@ -105,15 +105,15 @@ namespace Duende.Bff.Tests.Endpoints
             req.Content = new StringContent(JsonSerializer.Serialize(new TestPayload("hello test api")), Encoding.UTF8, "application/json");
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.IsSuccessStatusCode.Should().BeTrue();
-            response.Content.Headers.ContentType.MediaType.Should().Be("application/json");
+            response.IsSuccessStatusCode.ShouldBeTrue();
+            response.Content.Headers.ContentType.MediaType.ShouldBe("application/json");
             var json = await response.Content.ReadAsStringAsync();
             var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
-            apiResult.Method.Should().Be("PUT");
-            apiResult.Path.Should().Be("/local_authz");
-            apiResult.Sub.Should().Be("alice");
+            apiResult.Method.ShouldBe("PUT");
+            apiResult.Path.ShouldBe("/local_authz");
+            apiResult.Sub.ShouldBe("alice");
             var body = JsonSerializer.Deserialize<TestPayload>(apiResult.Body);
-            body.message.Should().Be("hello test api");
+            body.message.ShouldBe("hello test api");
         }
 
         [Fact]
@@ -123,8 +123,8 @@ namespace Duende.Bff.Tests.Endpoints
             req.Headers.Add("x-csrf", "1");
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.StatusCode.Should().Be(HttpStatusCode.Redirect);
-            response.Headers.Location.ToString().ToLowerInvariant().Should().StartWith(IdentityServerHost.Url("/connect/authorize"));
+            response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            response.Headers.Location.ToString().ToLowerInvariant().ShouldStartWith(IdentityServerHost.Url("/connect/authorize"));
         }
 
         [Fact]
@@ -134,7 +134,7 @@ namespace Duende.Bff.Tests.Endpoints
             req.Headers.Add("x-csrf", "1");
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+            response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
         }
         
         [Fact]
@@ -146,7 +146,7 @@ namespace Duende.Bff.Tests.Endpoints
             req.Headers.Add("x-csrf", "1");
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+            response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
         }
 
         [Fact]
@@ -159,7 +159,7 @@ namespace Duende.Bff.Tests.Endpoints
             req.Headers.Add("x-csrf", "1");
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+            response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
         }
 
         [Fact]
@@ -172,7 +172,7 @@ namespace Duende.Bff.Tests.Endpoints
             req.Headers.Add("x-csrf", "1");
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+            response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
         }
 
         [Fact]
@@ -184,7 +184,7 @@ namespace Duende.Bff.Tests.Endpoints
             var req = new HttpRequestMessage(HttpMethod.Get, BffHost.Url("/local_anon_no_csrf_no_response_handling"));
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.StatusCode.Should().Be(HttpStatusCode.Redirect);
+            response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
         }
 
 
@@ -204,7 +204,7 @@ namespace Duende.Bff.Tests.Endpoints
             await BffHost.InitializeAsync();
 
             var response = await BffHost.HttpClient.GetAsync(BffHost.Url("/not-found"));
-            response.StatusCode.Should().NotBe(HttpStatusCode.InternalServerError);
+            response.StatusCode.ShouldNotBe(HttpStatusCode.InternalServerError);
         }
     }
 }

--- a/bff/test/Duende.Bff.Tests/Endpoints/Management/BackchannelLogoutEndpointTests.cs
+++ b/bff/test/Duende.Bff.Tests/Endpoints/Management/BackchannelLogoutEndpointTests.cs
@@ -2,11 +2,11 @@
 // See LICENSE in the project root for license information.
 
 using Duende.Bff.Tests.TestHosts;
-using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using Shouldly;
 using Xunit;
 
 namespace Duende.Bff.Tests.Endpoints.Management
@@ -29,7 +29,7 @@ namespace Duende.Bff.Tests.Endpoints.Management
             await BffHost.InitializeAsync();
 
             var response = await BffHost.HttpClient.PostAsync(BffHost.Url("/bff/backchannel"), null);
-            response.StatusCode.Should().NotBe(HttpStatusCode.Unauthorized);
+            response.StatusCode.ShouldNotBe(HttpStatusCode.Unauthorized);
         }
 
         [Fact]
@@ -39,7 +39,7 @@ namespace Duende.Bff.Tests.Endpoints.Management
 
             await IdentityServerHost.RevokeSessionCookieAsync();
 
-            (await BffHost.GetIsUserLoggedInAsync()).Should().BeFalse();
+            (await BffHost.GetIsUserLoggedInAsync()).ShouldBeFalse();
         }
 
         [Fact]
@@ -51,7 +51,7 @@ namespace Duende.Bff.Tests.Endpoints.Management
 
             await IdentityServerHost.RevokeSessionCookieAsync();
 
-            (await BffHost.GetIsUserLoggedInAsync()).Should().BeTrue();
+            (await BffHost.GetIsUserLoggedInAsync()).ShouldBeTrue();
         }
 
         [Fact]
@@ -63,7 +63,7 @@ namespace Duende.Bff.Tests.Endpoints.Management
 
             await IdentityServerHost.RevokeSessionCookieAsync();
 
-            (await BffHost.GetIsUserLoggedInAsync()).Should().BeTrue();
+            (await BffHost.GetIsUserLoggedInAsync()).ShouldBeTrue();
         }
 
 
@@ -79,7 +79,7 @@ namespace Duende.Bff.Tests.Endpoints.Management
             {
                 var store = BffHost.Resolve<IUserSessionStore>();
                 var sessions = await store.GetUserSessionsAsync(new UserSessionsFilter { SubjectId = "alice" });
-                sessions.Count().Should().Be(2);
+                sessions.Count().ShouldBe(2);
             }
             
             await IdentityServerHost.RevokeSessionCookieAsync();
@@ -88,7 +88,7 @@ namespace Duende.Bff.Tests.Endpoints.Management
                 var store = BffHost.Resolve<IUserSessionStore>();
                 var sessions = await store.GetUserSessionsAsync(new UserSessionsFilter { SubjectId = "alice" });
                 var session = sessions.Single();
-                session.SessionId.Should().Be("sid1");
+                session.SessionId.ShouldBe("sid1");
             }
         }
 
@@ -104,7 +104,7 @@ namespace Duende.Bff.Tests.Endpoints.Management
             {
                 var store = BffHost.Resolve<IUserSessionStore>();
                 var sessions = await store.GetUserSessionsAsync(new UserSessionsFilter { SubjectId = "alice" });
-                sessions.Count().Should().Be(2);
+                sessions.Count().ShouldBe(2);
             }
 
             await IdentityServerHost.RevokeSessionCookieAsync();
@@ -112,7 +112,7 @@ namespace Duende.Bff.Tests.Endpoints.Management
             {
                 var store = BffHost.Resolve<IUserSessionStore>();
                 var sessions = await store.GetUserSessionsAsync(new UserSessionsFilter { SubjectId = "alice" });
-                sessions.Should().BeEmpty();
+                sessions.ShouldBeEmpty();
             }
         }
     }

--- a/bff/test/Duende.Bff.Tests/Endpoints/Management/LoginEndpointTests.cs
+++ b/bff/test/Duende.Bff.Tests/Endpoints/Management/LoginEndpointTests.cs
@@ -2,11 +2,11 @@
 // See LICENSE in the project root for license information.
 
 using Duende.Bff.Tests.TestHosts;
-using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Net;
 using System.Threading.Tasks;
+using Shouldly;
 using Xunit;
 
 namespace Duende.Bff.Tests.Endpoints.Management
@@ -29,24 +29,24 @@ namespace Duende.Bff.Tests.Endpoints.Management
             await BffHost.InitializeAsync();
 
             var response = await BffHost.BrowserClient.GetAsync(BffHost.Url("/bff/login"));
-            response.StatusCode.Should().NotBe(HttpStatusCode.Unauthorized);
+            response.StatusCode.ShouldNotBe(HttpStatusCode.Unauthorized);
         }
         
         [Fact]
         public async Task login_endpoint_should_challenge_and_redirect_to_root()
         {
             var response = await BffHost.BrowserClient.GetAsync(BffHost.Url("/bff/login"));
-            response.StatusCode.Should().Be(HttpStatusCode.Redirect);
-            response.Headers.Location.ToString().Should().StartWith(IdentityServerHost.Url("/connect/authorize"));
+            response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            response.Headers.Location.ToString().ShouldStartWith(IdentityServerHost.Url("/connect/authorize"));
 
             await IdentityServerHost.IssueSessionCookieAsync("alice");
             response = await IdentityServerHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
-            response.StatusCode.Should().Be(HttpStatusCode.Redirect);
-            response.Headers.Location.ToString().Should().StartWith(BffHost.Url("/signin-oidc"));
+            response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            response.Headers.Location.ToString().ShouldStartWith(BffHost.Url("/signin-oidc"));
 
             response = await BffHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
-            response.StatusCode.Should().Be(HttpStatusCode.Redirect);
-            response.Headers.Location.ToString().Should().Be("/");
+            response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            response.Headers.Location.ToString().ShouldBe("/");
         }
         
         [Fact]
@@ -60,17 +60,17 @@ namespace Duende.Bff.Tests.Endpoints.Management
             await BffHost.InitializeAsync();
             
             var response = await BffHost.BrowserClient.GetAsync(BffHost.Url("/custom/bff/login"));
-            response.StatusCode.Should().Be(HttpStatusCode.Redirect);
-            response.Headers.Location.ToString().Should().StartWith(IdentityServerHost.Url("/connect/authorize"));
+            response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            response.Headers.Location.ToString().ShouldStartWith(IdentityServerHost.Url("/connect/authorize"));
 
             await IdentityServerHost.IssueSessionCookieAsync("alice");
             response = await IdentityServerHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
-            response.StatusCode.Should().Be(HttpStatusCode.Redirect);
-            response.Headers.Location.ToString().Should().StartWith(BffHost.Url("/signin-oidc"));
+            response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            response.Headers.Location.ToString().ShouldStartWith(BffHost.Url("/signin-oidc"));
 
             response = await BffHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
-            response.StatusCode.Should().Be(HttpStatusCode.Redirect);
-            response.Headers.Location.ToString().Should().Be("/");
+            response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            response.Headers.Location.ToString().ShouldBe("/");
         }
         
         [Fact]
@@ -84,17 +84,17 @@ namespace Duende.Bff.Tests.Endpoints.Management
             await BffHost.InitializeAsync();
             
             var response = await BffHost.BrowserClient.GetAsync(BffHost.Url("/custom/bff/login"));
-            response.StatusCode.Should().Be(HttpStatusCode.Redirect);
-            response.Headers.Location.ToString().Should().StartWith(IdentityServerHost.Url("/connect/authorize"));
+            response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            response.Headers.Location.ToString().ShouldStartWith(IdentityServerHost.Url("/connect/authorize"));
 
             await IdentityServerHost.IssueSessionCookieAsync("alice");
             response = await IdentityServerHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
-            response.StatusCode.Should().Be(HttpStatusCode.Redirect);
-            response.Headers.Location.ToString().Should().StartWith(BffHost.Url("/signin-oidc"));
+            response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            response.Headers.Location.ToString().ShouldStartWith(BffHost.Url("/signin-oidc"));
 
             response = await BffHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
-            response.StatusCode.Should().Be(HttpStatusCode.Redirect);
-            response.Headers.Location.ToString().Should().Be("/");
+            response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            response.Headers.Location.ToString().ShouldBe("/");
         }
         
         [Fact]
@@ -108,17 +108,17 @@ namespace Duende.Bff.Tests.Endpoints.Management
             await BffHost.InitializeAsync();
             
             var response = await BffHost.BrowserClient.GetAsync(BffHost.Url("/login"));
-            response.StatusCode.Should().Be(HttpStatusCode.Redirect);
-            response.Headers.Location.ToString().Should().StartWith(IdentityServerHost.Url("/connect/authorize"));
+            response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            response.Headers.Location.ToString().ShouldStartWith(IdentityServerHost.Url("/connect/authorize"));
 
             await IdentityServerHost.IssueSessionCookieAsync("alice");
             response = await IdentityServerHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
-            response.StatusCode.Should().Be(HttpStatusCode.Redirect);
-            response.Headers.Location.ToString().Should().StartWith(BffHost.Url("/signin-oidc"));
+            response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            response.Headers.Location.ToString().ShouldStartWith(BffHost.Url("/signin-oidc"));
 
             response = await BffHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
-            response.StatusCode.Should().Be(HttpStatusCode.Redirect);
-            response.Headers.Location.ToString().Should().Be("/");
+            response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            response.Headers.Location.ToString().ShouldBe("/");
         }
         
         [Fact]
@@ -127,32 +127,33 @@ namespace Duende.Bff.Tests.Endpoints.Management
             await BffHost.BffLoginAsync("alice");
 
             var response = await BffHost.BrowserClient.GetAsync(BffHost.Url("/bff/login"));
-            response.StatusCode.Should().Be(HttpStatusCode.Redirect);
-            response.Headers.Location.ToString().Should().StartWith(IdentityServerHost.Url("/connect/authorize"));
+            response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            response.Headers.Location.ToString().ShouldStartWith(IdentityServerHost.Url("/connect/authorize"));
         }
 
         [Fact]
         public async Task login_endpoint_should_accept_returnUrl()
         {
             var response = await BffHost.BrowserClient.GetAsync(BffHost.Url("/bff/login") + "?returnUrl=/foo");
-            response.StatusCode.Should().Be(HttpStatusCode.Redirect);
-            response.Headers.Location.ToString().Should().StartWith(IdentityServerHost.Url("/connect/authorize"));
+            response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            response.Headers.Location.ToString().ShouldStartWith(IdentityServerHost.Url("/connect/authorize"));
 
             await IdentityServerHost.IssueSessionCookieAsync("alice");
             response = await IdentityServerHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
-            response.StatusCode.Should().Be(HttpStatusCode.Redirect);
-            response.Headers.Location.ToString().Should().StartWith(BffHost.Url("/signin-oidc"));
+            response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            response.Headers.Location.ToString().ShouldStartWith(BffHost.Url("/signin-oidc"));
 
             response = await BffHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
-            response.StatusCode.Should().Be(HttpStatusCode.Redirect);
-            response.Headers.Location.ToString().Should().Be("/foo");
+            response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            response.Headers.Location.ToString().ShouldBe("/foo");
         }
 
         [Fact]
         public async Task login_endpoint_should_not_accept_non_local_returnUrl()
         {
             Func<Task> f = () => BffHost.BrowserClient.GetAsync(BffHost.Url("/bff/login") + "?returnUrl=https://foo");
-            (await f.Should().ThrowAsync<Exception>()).And.Message.Should().Contain("returnUrl");
+            var exception = (await f.ShouldThrowAsync<Exception>());
+            exception.Message.ShouldContain("returnUrl");
         }
     }
 }

--- a/bff/test/Duende.Bff.Tests/Endpoints/Management/LogoutEndpointTests.cs
+++ b/bff/test/Duende.Bff.Tests/Endpoints/Management/LogoutEndpointTests.cs
@@ -2,11 +2,11 @@
 // See LICENSE in the project root for license information.
 
 using Duende.Bff.Tests.TestHosts;
-using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Net;
 using System.Threading.Tasks;
+using Shouldly;
 using Xunit;
 
 namespace Duende.Bff.Tests.Endpoints.Management
@@ -29,7 +29,7 @@ namespace Duende.Bff.Tests.Endpoints.Management
             await BffHost.InitializeAsync();
 
             var response = await BffHost.BrowserClient.GetAsync(BffHost.Url("/bff/logout"));
-            response.StatusCode.Should().NotBe(HttpStatusCode.Unauthorized);
+            response.StatusCode.ShouldNotBe(HttpStatusCode.Unauthorized);
         }
 
         [Fact]
@@ -39,7 +39,7 @@ namespace Duende.Bff.Tests.Endpoints.Management
             
             await BffHost.BffLogoutAsync("sid123");
 
-            (await BffHost.GetIsUserLoggedInAsync()).Should().BeFalse();
+            (await BffHost.GetIsUserLoggedInAsync()).ShouldBeFalse();
         }
 
         [Fact]
@@ -48,9 +48,9 @@ namespace Duende.Bff.Tests.Endpoints.Management
             await BffHost.BffLoginAsync("alice", "sid123");
 
             Func<Task> f = () => BffHost.BffLogoutAsync();
-            await f.Should().ThrowAsync<Exception>();
+            await f.ShouldThrowAsync<Exception>();
 
-            (await BffHost.GetIsUserLoggedInAsync()).Should().BeTrue();
+            (await BffHost.GetIsUserLoggedInAsync()).ShouldBeTrue();
         }
         
         [Fact]
@@ -61,8 +61,8 @@ namespace Duende.Bff.Tests.Endpoints.Management
             BffHost.BffOptions.RequireLogoutSessionId = false;
 
             var response = await BffHost.BrowserClient.GetAsync(BffHost.Url("/bff/logout"));
-            response.StatusCode.Should().Be(HttpStatusCode.Redirect); // endsession
-            response.Headers.Location.ToString().ToLowerInvariant().Should().StartWith(IdentityServerHost.Url("/connect/endsession"));
+            response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // endsession
+            response.Headers.Location.ToString().ToLowerInvariant().ShouldStartWith(IdentityServerHost.Url("/connect/endsession"));
         }
 
         [Fact]
@@ -79,16 +79,16 @@ namespace Duende.Bff.Tests.Endpoints.Management
             await BffHost.IssueSessionCookieAsync("alice");
 
             var response = await BffHost.BrowserClient.GetAsync(BffHost.Url("/bff/logout"));
-            response.StatusCode.Should().Be(HttpStatusCode.Redirect); // endsession
-            response.Headers.Location.ToString().ToLowerInvariant().Should().StartWith(IdentityServerHost.Url("/connect/endsession"));
+            response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // endsession
+            response.Headers.Location.ToString().ToLowerInvariant().ShouldStartWith(IdentityServerHost.Url("/connect/endsession"));
         }
 
         [Fact]
         public async Task logout_endpoint_for_anonymous_user_without_sid_should_succeed()
         {
             var response = await BffHost.BrowserClient.GetAsync(BffHost.Url("/bff/logout"));
-            response.StatusCode.Should().Be(HttpStatusCode.Redirect); // endsession
-            response.Headers.Location.ToString().ToLowerInvariant().Should().StartWith(IdentityServerHost.Url("/connect/endsession"));
+            response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // endsession
+            response.Headers.Location.ToString().ToLowerInvariant().ShouldStartWith(IdentityServerHost.Url("/connect/endsession"));
         }
 
         [Fact]
@@ -98,8 +98,8 @@ namespace Duende.Bff.Tests.Endpoints.Management
             
             await BffHost.BffLogoutAsync("sid123");
             
-            BffHost.BrowserClient.CurrentUri.ToString().ToLowerInvariant().Should().Be(BffHost.Url("/"));
-            (await BffHost.GetIsUserLoggedInAsync()).Should().BeFalse();
+            BffHost.BrowserClient.CurrentUri.ToString().ToLowerInvariant().ShouldBe(BffHost.Url("/"));
+            (await BffHost.GetIsUserLoggedInAsync()).ShouldBeFalse();
         }
 
         [Fact]
@@ -108,20 +108,20 @@ namespace Duende.Bff.Tests.Endpoints.Management
             await BffHost.BffLoginAsync("alice", "sid123");
 
             var response = await BffHost.BrowserClient.GetAsync(BffHost.Url("/bff/logout") + "?sid=sid123&returnUrl=/foo");
-            response.StatusCode.Should().Be(HttpStatusCode.Redirect); // endsession
-            response.Headers.Location.ToString().ToLowerInvariant().Should().StartWith(IdentityServerHost.Url("/connect/endsession"));
+            response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // endsession
+            response.Headers.Location.ToString().ToLowerInvariant().ShouldStartWith(IdentityServerHost.Url("/connect/endsession"));
 
             response = await IdentityServerHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
-            response.StatusCode.Should().Be(HttpStatusCode.Redirect); // logout
-            response.Headers.Location.ToString().ToLowerInvariant().Should().StartWith(IdentityServerHost.Url("/account/logout"));
+            response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // logout
+            response.Headers.Location.ToString().ToLowerInvariant().ShouldStartWith(IdentityServerHost.Url("/account/logout"));
 
             response = await IdentityServerHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
-            response.StatusCode.Should().Be(HttpStatusCode.Redirect); // post logout redirect uri
-            response.Headers.Location.ToString().ToLowerInvariant().Should().StartWith(BffHost.Url("/signout-callback-oidc"));
+            response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // post logout redirect uri
+            response.Headers.Location.ToString().ToLowerInvariant().ShouldStartWith(BffHost.Url("/signout-callback-oidc"));
 
             response = await BffHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
-            response.StatusCode.Should().Be(HttpStatusCode.Redirect); // root
-            response.Headers.Location.ToString().ToLowerInvariant().Should().Be("/foo");
+            response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // root
+            response.Headers.Location.ToString().ToLowerInvariant().ShouldBe("/foo");
         }
 
         [Fact]
@@ -130,7 +130,9 @@ namespace Duende.Bff.Tests.Endpoints.Management
             await BffHost.BffLoginAsync("alice", "sid123");
 
             Func<Task> f = () => BffHost.BrowserClient.GetAsync(BffHost.Url("/bff/logout") + "?sid=sid123&returnUrl=https://foo");
-            (await f.Should().ThrowAsync<Exception>()).And.Message.Should().Contain("returnUrl");
+            var exception = await f.ShouldThrowAsync<Exception>();
+
+            exception.Message.ShouldContain("returnUrl");
         }
     }
 }

--- a/bff/test/Duende.Bff.Tests/Endpoints/Management/ManagementBasePathTests.cs
+++ b/bff/test/Duende.Bff.Tests/Endpoints/Management/ManagementBasePathTests.cs
@@ -2,13 +2,13 @@
 // See LICENSE in the project root for license information.
 
 using Duende.Bff.Tests.TestHosts;
-using FluentAssertions;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Xunit;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using System.Net;
+using Shouldly;
 
 namespace Duende.Bff.Tests.Endpoints.Management
 {
@@ -34,7 +34,7 @@ namespace Duende.Bff.Tests.Endpoints.Management
 
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.StatusCode.Should().NotBe(HttpStatusCode.NotFound);
+            response.StatusCode.ShouldNotBe(HttpStatusCode.NotFound);
         }
     }
 }

--- a/bff/test/Duende.Bff.Tests/Endpoints/Management/UserEndpointTests.cs
+++ b/bff/test/Duende.Bff.Tests/Endpoints/Management/UserEndpointTests.cs
@@ -3,12 +3,12 @@
 
 using System.Linq;
 using Duende.Bff.Tests.TestHosts;
-using FluentAssertions;
 using System.Net.Http;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Xunit;
 using System.Net;
+using Shouldly;
 
 namespace Duende.Bff.Tests.Endpoints.Management
 {
@@ -24,15 +24,15 @@ namespace Duende.Bff.Tests.Endpoints.Management
 
             var data = await BffHost.CallUserEndpointAsync();
 
-            data.Count.Should().Be(4);
-            data.First(d => d.type == "sub").value.GetString().Should().Be("alice");
+            data.Count.ShouldBe(4);
+            data.First(d => d.type == "sub").value.GetString().ShouldBe("alice");
 
             var foos = data.Where(d => d.type == "foo");
-            foos.Count().Should().Be(2);
-            foos.First().value.GetString().Should().Be("foo1");
-            foos.Skip(1).First().value.GetString().Should().Be("foo2");
+            foos.Count().ShouldBe(2);
+            foos.First().value.GetString().ShouldBe("foo1");
+            foos.Skip(1).First().value.GetString().ShouldBe("foo2");
 
-            data.First(d => d.type == Constants.ClaimTypes.SessionExpiresIn).value.GetInt32().Should().BePositive();
+            data.First(d => d.type == Constants.ClaimTypes.SessionExpiresIn).value.GetInt32().ShouldBePositive();
         }
         
         [Fact]
@@ -44,11 +44,11 @@ namespace Duende.Bff.Tests.Endpoints.Management
         
             var data = await BffHost.CallUserEndpointAsync();
 
-            data.Count.Should().Be(4);
-            data.First(d => d.type == "sub").value.GetString().Should().Be("alice");
-            data.First(d => d.type == "sid").value.GetString().Should().Be("123");
-            data.First(d => d.type == Constants.ClaimTypes.LogoutUrl).value.GetString().Should().Be("/bff/logout?sid=123");
-            data.First(d => d.type == Constants.ClaimTypes.SessionExpiresIn).value.GetInt32().Should().BePositive();
+            data.Count.ShouldBe(4);
+            data.First(d => d.type == "sub").value.GetString().ShouldBe("alice");
+            data.First(d => d.type == "sid").value.GetString().ShouldBe("123");
+            data.First(d => d.type == Constants.ClaimTypes.LogoutUrl).value.GetString().ShouldBe("/bff/logout?sid=123");
+            data.First(d => d.type == Constants.ClaimTypes.SessionExpiresIn).value.GetInt32().ShouldBePositive();
         }
 
         [Fact]
@@ -59,7 +59,7 @@ namespace Duende.Bff.Tests.Endpoints.Management
             var req = new HttpRequestMessage(HttpMethod.Get, BffHost.Url("/bff/user"));
             var response = await BffHost.BrowserClient.SendAsync(req);
             
-            response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+            response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
         }
 
         [Fact]
@@ -69,7 +69,7 @@ namespace Duende.Bff.Tests.Endpoints.Management
             req.Headers.Add("x-csrf", "1");
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+            response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
         }
 
         [Fact]
@@ -78,7 +78,7 @@ namespace Duende.Bff.Tests.Endpoints.Management
             BffHost.BffOptions.AnonymousSessionResponse = AnonymousSessionResponse.Response200;
 
             var data = await BffHost.CallUserEndpointAsync();
-            data.Should().BeNull();
+            data.ShouldBeNull();
         }
     }
 }

--- a/bff/test/Duende.Bff.Tests/Endpoints/RemoteEndpointTests.cs
+++ b/bff/test/Duende.Bff.Tests/Endpoints/RemoteEndpointTests.cs
@@ -3,7 +3,6 @@
 
 using Duende.Bff.Tests.TestFramework;
 using Duende.Bff.Tests.TestHosts;
-using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Tokens;
 using System;
@@ -14,6 +13,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Shouldly;
 using Xunit;
 
 namespace Duende.Bff.Tests.Endpoints
@@ -27,7 +27,7 @@ namespace Duende.Bff.Tests.Endpoints
             req.Headers.Add("x-csrf", "1");
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+            response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
         }
 
         [Fact]
@@ -39,14 +39,14 @@ namespace Duende.Bff.Tests.Endpoints
             req.Headers.Add("x-csrf", "1");
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.IsSuccessStatusCode.Should().BeTrue();
-            response.Content.Headers.ContentType.MediaType.Should().Be("application/json");
+            response.IsSuccessStatusCode.ShouldBeTrue();
+            response.Content.Headers.ContentType.MediaType.ShouldBe("application/json");
             var json = await response.Content.ReadAsStringAsync();
             var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
-            apiResult.Method.Should().Be("GET");
-            apiResult.Path.Should().Be("/test");
-            apiResult.Sub.Should().Be("alice");
-            apiResult.ClientId.Should().Be("spa");
+            apiResult.Method.ShouldBe("GET");
+            apiResult.Path.ShouldBe("/test");
+            apiResult.Sub.ShouldBe("alice");
+            apiResult.ClientId.ShouldBe("spa");
         }
 
         [Fact]
@@ -58,14 +58,14 @@ namespace Duende.Bff.Tests.Endpoints
             req.Headers.Add("x-csrf", "1");
             var response = await BffHostWithNamedTokens.BrowserClient.SendAsync(req);
 
-            response.IsSuccessStatusCode.Should().BeTrue();
-            response.Content.Headers.ContentType.MediaType.Should().Be("application/json");
+            response.IsSuccessStatusCode.ShouldBeTrue();
+            response.Content.Headers.ContentType.MediaType.ShouldBe("application/json");
             var json = await response.Content.ReadAsStringAsync();
             var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
-            apiResult.Method.Should().Be("GET");
-            apiResult.Path.Should().Be("/test");
-            apiResult.Sub.Should().Be("alice");
-            apiResult.ClientId.Should().Be("spa");
+            apiResult.Method.ShouldBe("GET");
+            apiResult.Path.ShouldBe("/test");
+            apiResult.Sub.ShouldBe("alice");
+            apiResult.ClientId.ShouldBe("spa");
         }
 
         [Fact]
@@ -77,7 +77,7 @@ namespace Duende.Bff.Tests.Endpoints
             req.Headers.Add("x-csrf", "1");
 
             var response = await BffHostWithNamedTokens.BrowserClient.SendAsync(req);
-            response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+            response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
         }
 
         [Fact]
@@ -90,16 +90,16 @@ namespace Duende.Bff.Tests.Endpoints
             req.Content = new StringContent(JsonSerializer.Serialize(new TestPayload("hello test api")), Encoding.UTF8, "application/json");
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.IsSuccessStatusCode.Should().BeTrue();
-            response.Content.Headers.ContentType.MediaType.Should().Be("application/json");
+            response.IsSuccessStatusCode.ShouldBeTrue();
+            response.Content.Headers.ContentType.MediaType.ShouldBe("application/json");
             var json = await response.Content.ReadAsStringAsync();
             var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
-            apiResult.Method.Should().Be("PUT");
-            apiResult.Path.Should().Be("/test");
-            apiResult.Sub.Should().Be("alice");
-            apiResult.ClientId.Should().Be("spa");
+            apiResult.Method.ShouldBe("PUT");
+            apiResult.Path.ShouldBe("/test");
+            apiResult.Sub.ShouldBe("alice");
+            apiResult.ClientId.ShouldBe("spa");
             var body = JsonSerializer.Deserialize<TestPayload>(apiResult.Body);
-            body.message.Should().Be("hello test api");
+            body.message.ShouldBe("hello test api");
         }
         
         [Fact]
@@ -112,16 +112,16 @@ namespace Duende.Bff.Tests.Endpoints
             req.Content = new StringContent(JsonSerializer.Serialize(new TestPayload("hello test api")), Encoding.UTF8, "application/json");
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.IsSuccessStatusCode.Should().BeTrue();
-            response.Content.Headers.ContentType.MediaType.Should().Be("application/json");
+            response.IsSuccessStatusCode.ShouldBeTrue();
+            response.Content.Headers.ContentType.MediaType.ShouldBe("application/json");
             var json = await response.Content.ReadAsStringAsync();
             var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
-            apiResult.Method.Should().Be("POST");
-            apiResult.Path.Should().Be("/test");
-            apiResult.Sub.Should().Be("alice");
-            apiResult.ClientId.Should().Be("spa");
+            apiResult.Method.ShouldBe("POST");
+            apiResult.Path.ShouldBe("/test");
+            apiResult.Sub.ShouldBe("alice");
+            apiResult.ClientId.ShouldBe("spa");
             var body = JsonSerializer.Deserialize<TestPayload>(apiResult.Body);
-            body.message.Should().Be("hello test api");
+            body.message.ShouldBe("hello test api");
         }
 
 
@@ -134,14 +134,14 @@ namespace Duende.Bff.Tests.Endpoints
                 req.Headers.Add("x-csrf", "1");
                 var response = await BffHost.BrowserClient.SendAsync(req);
 
-                response.IsSuccessStatusCode.Should().BeTrue();
-                response.Content.Headers.ContentType.MediaType.Should().Be("application/json");
+                response.IsSuccessStatusCode.ShouldBeTrue();
+                response.Content.Headers.ContentType.MediaType.ShouldBe("application/json");
                 var json = await response.Content.ReadAsStringAsync();
                 var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
-                apiResult.Method.Should().Be("GET");
-                apiResult.Path.Should().Be("/test");
-                apiResult.Sub.Should().BeNull();
-                apiResult.ClientId.Should().BeNull();
+                apiResult.Method.ShouldBe("GET");
+                apiResult.Path.ShouldBe("/test");
+                apiResult.Sub.ShouldBeNull();
+                apiResult.ClientId.ShouldBeNull();
             }
 
             {
@@ -151,14 +151,14 @@ namespace Duende.Bff.Tests.Endpoints
                 req.Headers.Add("x-csrf", "1");
                 var response = await BffHost.BrowserClient.SendAsync(req);
 
-                response.IsSuccessStatusCode.Should().BeTrue();
-                response.Content.Headers.ContentType.MediaType.Should().Be("application/json");
+                response.IsSuccessStatusCode.ShouldBeTrue();
+                response.Content.Headers.ContentType.MediaType.ShouldBe("application/json");
                 var json = await response.Content.ReadAsStringAsync();
                 var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
-                apiResult.Method.Should().Be("GET");
-                apiResult.Path.Should().Be("/test");
-                apiResult.Sub.Should().Be("alice");
-                apiResult.ClientId.Should().Be("spa");
+                apiResult.Method.ShouldBe("GET");
+                apiResult.Path.ShouldBe("/test");
+                apiResult.Sub.ShouldBe("alice");
+                apiResult.ClientId.ShouldBe("spa");
             }
         }
 
@@ -171,14 +171,14 @@ namespace Duende.Bff.Tests.Endpoints
             req.Headers.Add("x-csrf", "1");
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.IsSuccessStatusCode.Should().BeTrue();
-            response.Content.Headers.ContentType.MediaType.Should().Be("application/json");
+            response.IsSuccessStatusCode.ShouldBeTrue();
+            response.Content.Headers.ContentType.MediaType.ShouldBe("application/json");
             var json = await response.Content.ReadAsStringAsync();
             var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
-            apiResult.Method.Should().Be("GET");
-            apiResult.Path.Should().Be("/test");
-            apiResult.Sub.Should().BeNull();
-            apiResult.ClientId.Should().Be("spa");
+            apiResult.Method.ShouldBe("GET");
+            apiResult.Path.ShouldBe("/test");
+            apiResult.Sub.ShouldBeNull();
+            apiResult.ClientId.ShouldBe("spa");
         }
 
         [Fact]
@@ -190,7 +190,7 @@ namespace Duende.Bff.Tests.Endpoints
             req.Headers.Add("x-csrf", "1");
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+            response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
         }
 
         [Fact]
@@ -204,8 +204,8 @@ namespace Duende.Bff.Tests.Endpoints
 
             var json = await response.Content.ReadAsStringAsync();
             var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
-            apiResult.Sub.Should().Be("123");
-            apiResult.ClientId.Should().Be("fake-client");
+            apiResult.Sub.ShouldBe("123");
+            apiResult.ClientId.ShouldBe("fake-client");
         }
 
         [Fact]
@@ -216,14 +216,14 @@ namespace Duende.Bff.Tests.Endpoints
                 req.Headers.Add("x-csrf", "1");
                 var response = await BffHost.BrowserClient.SendAsync(req);
 
-                response.IsSuccessStatusCode.Should().BeTrue();
-                response.Content.Headers.ContentType.MediaType.Should().Be("application/json");
+                response.IsSuccessStatusCode.ShouldBeTrue();
+                response.Content.Headers.ContentType.MediaType.ShouldBe("application/json");
                 var json = await response.Content.ReadAsStringAsync();
                 var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
-                apiResult.Method.Should().Be("GET");
-                apiResult.Path.Should().Be("/test");
-                apiResult.Sub.Should().BeNull();
-                apiResult.ClientId.Should().Be("spa");
+                apiResult.Method.ShouldBe("GET");
+                apiResult.Path.ShouldBe("/test");
+                apiResult.Sub.ShouldBeNull();
+                apiResult.ClientId.ShouldBe("spa");
             }
 
             {
@@ -233,14 +233,14 @@ namespace Duende.Bff.Tests.Endpoints
                 req.Headers.Add("x-csrf", "1");
                 var response = await BffHost.BrowserClient.SendAsync(req);
 
-                response.IsSuccessStatusCode.Should().BeTrue();
-                response.Content.Headers.ContentType.MediaType.Should().Be("application/json");
+                response.IsSuccessStatusCode.ShouldBeTrue();
+                response.Content.Headers.ContentType.MediaType.ShouldBe("application/json");
                 var json = await response.Content.ReadAsStringAsync();
                 var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
-                apiResult.Method.Should().Be("GET");
-                apiResult.Path.Should().Be("/test");
-                apiResult.Sub.Should().Be("alice");
-                apiResult.ClientId.Should().Be("spa");
+                apiResult.Method.ShouldBe("GET");
+                apiResult.Path.ShouldBe("/test");
+                apiResult.Sub.ShouldBe("alice");
+                apiResult.ClientId.ShouldBe("spa");
             }
         }
 
@@ -252,14 +252,14 @@ namespace Duende.Bff.Tests.Endpoints
                 req.Headers.Add("x-csrf", "1");
                 var response = await BffHost.BrowserClient.SendAsync(req);
 
-                response.IsSuccessStatusCode.Should().BeTrue();
-                response.Content.Headers.ContentType.MediaType.Should().Be("application/json");
+                response.IsSuccessStatusCode.ShouldBeTrue();
+                response.Content.Headers.ContentType.MediaType.ShouldBe("application/json");
                 var json = await response.Content.ReadAsStringAsync();
                 var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
-                apiResult.Method.Should().Be("GET");
-                apiResult.Path.Should().Be("/test");
-                apiResult.Sub.Should().BeNull();
-                apiResult.ClientId.Should().BeNull();
+                apiResult.Method.ShouldBe("GET");
+                apiResult.Path.ShouldBe("/test");
+                apiResult.Sub.ShouldBeNull();
+                apiResult.ClientId.ShouldBeNull();
             }
 
             {
@@ -269,14 +269,14 @@ namespace Duende.Bff.Tests.Endpoints
                 req.Headers.Add("x-csrf", "1");
                 var response = await BffHost.BrowserClient.SendAsync(req);
 
-                response.IsSuccessStatusCode.Should().BeTrue();
-                response.Content.Headers.ContentType.MediaType.Should().Be("application/json");
+                response.IsSuccessStatusCode.ShouldBeTrue();
+                response.Content.Headers.ContentType.MediaType.ShouldBe("application/json");
                 var json = await response.Content.ReadAsStringAsync();
                 var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
-                apiResult.Method.Should().Be("GET");
-                apiResult.Path.Should().Be("/test");
-                apiResult.Sub.Should().BeNull();
-                apiResult.ClientId.Should().BeNull();
+                apiResult.Method.ShouldBe("GET");
+                apiResult.Path.ShouldBe("/test");
+                apiResult.Sub.ShouldBeNull();
+                apiResult.ClientId.ShouldBeNull();
             }
         }
 
@@ -292,7 +292,7 @@ namespace Duende.Bff.Tests.Endpoints
                 req.Headers.Add("x-csrf", "1");
                 var response = await BffHost.BrowserClient.SendAsync(req);
 
-                response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+                response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
             }
 
             {
@@ -300,7 +300,7 @@ namespace Duende.Bff.Tests.Endpoints
                 req.Headers.Add("x-csrf", "1");
                 var response = await BffHost.BrowserClient.SendAsync(req);
 
-                response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+                response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
             }
         }
 
@@ -315,7 +315,7 @@ namespace Duende.Bff.Tests.Endpoints
             req.Headers.Add("x-csrf", "1");
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+            response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
         }
 
         [Fact]
@@ -328,7 +328,7 @@ namespace Duende.Bff.Tests.Endpoints
             req.Headers.Add("x-csrf", "1");
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+            response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
         }
 
 
@@ -339,7 +339,7 @@ namespace Duende.Bff.Tests.Endpoints
             var req = new HttpRequestMessage(HttpMethod.Get, BffHost.Url("/api_user_or_client/test"));
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+            response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
         }
 
         [Fact]
@@ -350,14 +350,14 @@ namespace Duende.Bff.Tests.Endpoints
             var req = new HttpRequestMessage(HttpMethod.Get, BffHost.Url("/api_user_no_csrf/test"));
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.IsSuccessStatusCode.Should().BeTrue();
-            response.Content.Headers.ContentType.MediaType.Should().Be("application/json");
+            response.IsSuccessStatusCode.ShouldBeTrue();
+            response.Content.Headers.ContentType.MediaType.ShouldBe("application/json");
             var json = await response.Content.ReadAsStringAsync();
             var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
-            apiResult.Method.Should().Be("GET");
-            apiResult.Path.Should().Be("/test");
-            apiResult.Sub.Should().Be("alice");
-            apiResult.ClientId.Should().Be("spa");
+            apiResult.Method.ShouldBe("GET");
+            apiResult.Path.ShouldBe("/test");
+            apiResult.Sub.ShouldBe("alice");
+            apiResult.ClientId.ShouldBe("spa");
         }
 
         [Fact]
@@ -366,7 +366,7 @@ namespace Duende.Bff.Tests.Endpoints
             var req = new HttpRequestMessage(HttpMethod.Get, BffHost.Url("/not_bff_endpoint"));
 
             Func<Task> f = () => BffHost.BrowserClient.SendAsync(req);
-            await f.Should().ThrowAsync<Exception>();
+            await f.ShouldThrowAsync<Exception>();
         }
         
         [Fact]
@@ -375,7 +375,7 @@ namespace Duende.Bff.Tests.Endpoints
             var req = new HttpRequestMessage(HttpMethod.Get, BffHost.Url("/invalid_endpoint/test"));
 
             Func<Task> f = () => BffHost.BrowserClient.SendAsync(req);
-            await f.Should().ThrowAsync<Exception>();
+            await f.ShouldThrowAsync<Exception>();
         }
 
         [Fact]
@@ -399,12 +399,12 @@ namespace Duende.Bff.Tests.Endpoints
             req.Headers.Add("x-csrf", "1");
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.IsSuccessStatusCode.Should().BeTrue();
-            response.Content.Headers.ContentType.MediaType.Should().Be("application/json");
+            response.IsSuccessStatusCode.ShouldBeTrue();
+            response.Content.Headers.ContentType.MediaType.ShouldBe("application/json");
             var json = await response.Content.ReadAsStringAsync();
             var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
-            apiResult.RequestHeaders["DPoP"].First().Should().NotBeNullOrEmpty();
-            apiResult.RequestHeaders["Authorization"].First().StartsWith("DPoP ").Should().BeTrue();
+            apiResult.RequestHeaders["DPoP"].First().ShouldNotBeNullOrEmpty();
+            apiResult.RequestHeaders["Authorization"].First().StartsWith("DPoP ").ShouldBeTrue();
         }
     }
 }

--- a/bff/test/Duende.Bff.Tests/Endpoints/YarpRemoteEndpointTests.cs
+++ b/bff/test/Duende.Bff.Tests/Endpoints/YarpRemoteEndpointTests.cs
@@ -2,12 +2,12 @@
 // See LICENSE in the project root for license information.
 
 using Duende.Bff.Tests.TestHosts;
-using FluentAssertions;
 using System.Net;
 using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Duende.Bff.Tests.TestFramework;
+using Shouldly;
 using Xunit;
 
 namespace Duende.Bff.Tests.Endpoints
@@ -20,7 +20,7 @@ namespace Duende.Bff.Tests.Endpoints
             var req = new HttpRequestMessage(HttpMethod.Get, BffHost.Url("/api_anon_no_csrf/test"));
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            response.StatusCode.ShouldBe(HttpStatusCode.OK);
         }
         
         [Fact]
@@ -29,7 +29,7 @@ namespace Duende.Bff.Tests.Endpoints
             var req = new HttpRequestMessage(HttpMethod.Get, BffHost.Url("/api_anon/test"));
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+            response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
         }
         
         [Fact]
@@ -39,7 +39,7 @@ namespace Duende.Bff.Tests.Endpoints
             req.Headers.Add("x-csrf", "1");
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            response.StatusCode.ShouldBe(HttpStatusCode.OK);
         }
         
         [Fact]
@@ -49,7 +49,7 @@ namespace Duende.Bff.Tests.Endpoints
             req.Headers.Add("x-csrf", "1");
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+            response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
         }
 
         [Fact]
@@ -59,14 +59,14 @@ namespace Duende.Bff.Tests.Endpoints
             req.Headers.Add("x-csrf", "1");
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.IsSuccessStatusCode.Should().BeTrue();
-            response.Content.Headers.ContentType.MediaType.Should().Be("application/json");
+            response.IsSuccessStatusCode.ShouldBeTrue();
+            response.Content.Headers.ContentType.MediaType.ShouldBe("application/json");
             var json = await response.Content.ReadAsStringAsync();
             var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
-            apiResult.Method.Should().Be("GET");
-            apiResult.Path.Should().Be("/api_optional_user/test");
-            apiResult.Sub.Should().BeNull();
-            apiResult.ClientId.Should().BeNull();
+            apiResult.Method.ShouldBe("GET");
+            apiResult.Path.ShouldBe("/api_optional_user/test");
+            apiResult.Sub.ShouldBeNull();
+            apiResult.ClientId.ShouldBeNull();
         }
 
         [Theory]
@@ -80,14 +80,14 @@ namespace Duende.Bff.Tests.Endpoints
             req.Headers.Add("x-csrf", "1");
             var response = await BffHost.BrowserClient.SendAsync(req);
         
-            response.IsSuccessStatusCode.Should().BeTrue();
-            response.Content.Headers.ContentType.MediaType.Should().Be("application/json");
+            response.IsSuccessStatusCode.ShouldBeTrue();
+            response.Content.Headers.ContentType.MediaType.ShouldBe("application/json");
             var json = await response.Content.ReadAsStringAsync();
             var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
-            apiResult.Method.Should().Be("GET");
-            apiResult.Path.Should().Be(route);
-            apiResult.Sub.Should().Be("alice");
-            apiResult.ClientId.Should().Be("spa");
+            apiResult.Method.ShouldBe("GET");
+            apiResult.Path.ShouldBe(route);
+            apiResult.Sub.ShouldBe("alice");
+            apiResult.ClientId.ShouldBe("spa");
         }
         
         [Theory]
@@ -101,14 +101,14 @@ namespace Duende.Bff.Tests.Endpoints
             req.Headers.Add("x-csrf", "1");
             var response = await BffHost.BrowserClient.SendAsync(req);
         
-            response.IsSuccessStatusCode.Should().BeTrue();
-            response.Content.Headers.ContentType.MediaType.Should().Be("application/json");
+            response.IsSuccessStatusCode.ShouldBeTrue();
+            response.Content.Headers.ContentType.MediaType.ShouldBe("application/json");
             var json = await response.Content.ReadAsStringAsync();
             var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
-            apiResult.Method.Should().Be("PUT");
-            apiResult.Path.Should().Be(route);
-            apiResult.Sub.Should().Be("alice");
-            apiResult.ClientId.Should().Be("spa");
+            apiResult.Method.ShouldBe("PUT");
+            apiResult.Path.ShouldBe(route);
+            apiResult.Sub.ShouldBe("alice");
+            apiResult.ClientId.ShouldBe("spa");
         }
 
         [Theory]
@@ -122,14 +122,14 @@ namespace Duende.Bff.Tests.Endpoints
             req.Headers.Add("x-csrf", "1");
             var response = await BffHost.BrowserClient.SendAsync(req);
         
-            response.IsSuccessStatusCode.Should().BeTrue();
-            response.Content.Headers.ContentType.MediaType.Should().Be("application/json");
+            response.IsSuccessStatusCode.ShouldBeTrue();
+            response.Content.Headers.ContentType.MediaType.ShouldBe("application/json");
             var json = await response.Content.ReadAsStringAsync();
             var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
-            apiResult.Method.Should().Be("POST");
-            apiResult.Path.Should().Be(route);
-            apiResult.Sub.Should().Be("alice");
-            apiResult.ClientId.Should().Be("spa");
+            apiResult.Method.ShouldBe("POST");
+            apiResult.Path.ShouldBe(route);
+            apiResult.Sub.ShouldBe("alice");
+            apiResult.ClientId.ShouldBe("spa");
         }
         
         [Fact]
@@ -141,14 +141,14 @@ namespace Duende.Bff.Tests.Endpoints
             req.Headers.Add("x-csrf", "1");
             var response = await BffHost.BrowserClient.SendAsync(req);
         
-            response.IsSuccessStatusCode.Should().BeTrue();
-            response.Content.Headers.ContentType.MediaType.Should().Be("application/json");
+            response.IsSuccessStatusCode.ShouldBeTrue();
+            response.Content.Headers.ContentType.MediaType.ShouldBe("application/json");
             var json = await response.Content.ReadAsStringAsync();
             var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
-            apiResult.Method.Should().Be("GET");
-            apiResult.Path.Should().Be("/api_client/test");
-            apiResult.Sub.Should().BeNull();
-            apiResult.ClientId.Should().Be("spa");
+            apiResult.Method.ShouldBe("GET");
+            apiResult.Path.ShouldBe("/api_client/test");
+            apiResult.Sub.ShouldBeNull();
+            apiResult.ClientId.ShouldBe("spa");
         }
         
         [Fact]
@@ -159,14 +159,14 @@ namespace Duende.Bff.Tests.Endpoints
                 req.Headers.Add("x-csrf", "1");
                 var response = await BffHost.BrowserClient.SendAsync(req);
         
-                response.IsSuccessStatusCode.Should().BeTrue();
-                response.Content.Headers.ContentType.MediaType.Should().Be("application/json");
+                response.IsSuccessStatusCode.ShouldBeTrue();
+                response.Content.Headers.ContentType.MediaType.ShouldBe("application/json");
                 var json = await response.Content.ReadAsStringAsync();
                 var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
-                apiResult.Method.Should().Be("GET");
-                apiResult.Path.Should().Be("/api_user_or_client/test");
-                apiResult.Sub.Should().BeNull();
-                apiResult.ClientId.Should().Be("spa");
+                apiResult.Method.ShouldBe("GET");
+                apiResult.Path.ShouldBe("/api_user_or_client/test");
+                apiResult.Sub.ShouldBeNull();
+                apiResult.ClientId.ShouldBe("spa");
             }
         
             {
@@ -176,14 +176,14 @@ namespace Duende.Bff.Tests.Endpoints
                 req.Headers.Add("x-csrf", "1");
                 var response = await BffHost.BrowserClient.SendAsync(req);
         
-                response.IsSuccessStatusCode.Should().BeTrue();
-                response.Content.Headers.ContentType.MediaType.Should().Be("application/json");
+                response.IsSuccessStatusCode.ShouldBeTrue();
+                response.Content.Headers.ContentType.MediaType.ShouldBe("application/json");
                 var json = await response.Content.ReadAsStringAsync();
                 var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
-                apiResult.Method.Should().Be("GET");
-                apiResult.Path.Should().Be("/api_user_or_client/test");
-                apiResult.Sub.Should().Be("alice");
-                apiResult.ClientId.Should().Be("spa");
+                apiResult.Method.ShouldBe("GET");
+                apiResult.Path.ShouldBe("/api_user_or_client/test");
+                apiResult.Sub.ShouldBe("alice");
+                apiResult.ClientId.ShouldBe("spa");
             }
         }
         
@@ -197,7 +197,7 @@ namespace Duende.Bff.Tests.Endpoints
             req.Headers.Add("x-csrf", "1");
             var response = await BffHost.BrowserClient.SendAsync(req);
         
-            response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+            response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
         }
         
         [Fact]
@@ -210,7 +210,7 @@ namespace Duende.Bff.Tests.Endpoints
             req.Headers.Add("x-csrf", "1");
             var response = await BffHost.BrowserClient.SendAsync(req);
         
-            response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+            response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
         }
 
         [Fact]
@@ -219,7 +219,7 @@ namespace Duende.Bff.Tests.Endpoints
             var req = new HttpRequestMessage(HttpMethod.Get, BffHost.Url("/api_invalid/test"));
             var response = await BffHost.BrowserClient.SendAsync(req);
         
-            response.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
+            response.StatusCode.ShouldBe(HttpStatusCode.InternalServerError);
         }
     }
 }

--- a/bff/test/Duende.Bff.Tests/GenericHostTests.cs
+++ b/bff/test/Duende.Bff.Tests/GenericHostTests.cs
@@ -2,10 +2,10 @@
 // See LICENSE in the project root for license information.
 
 using Duende.Bff.Tests.TestFramework;
-using FluentAssertions;
 using Microsoft.AspNetCore.Builder;
 using System.Net;
 using System.Threading.Tasks;
+using Shouldly;
 using Xunit;
 
 namespace Duende.Bff.Tests
@@ -24,7 +24,7 @@ namespace Duende.Bff.Tests
 
             var response = await host.HttpClient.GetAsync("/test");
 
-            response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
         }
     }
 }

--- a/bff/test/Duende.Bff.Tests/Headers/ApiAndBffUseForwardedHeaders.cs
+++ b/bff/test/Duende.Bff.Tests/Headers/ApiAndBffUseForwardedHeaders.cs
@@ -4,7 +4,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using Duende.Bff.Tests.TestFramework;
 using Duende.Bff.Tests.TestHosts;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace Duende.Bff.Tests.Headers
@@ -27,12 +27,12 @@ namespace Duende.Bff.Tests.Headers
             req.Headers.Add("x-csrf", "1");
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.IsSuccessStatusCode.Should().BeTrue();
+            response.IsSuccessStatusCode.ShouldBeTrue();
             var json = await response.Content.ReadAsStringAsync();
             var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
 
             var host = apiResult.RequestHeaders["Host"].Single();
-            host.Should().Be("app");
+            host.ShouldBe("app");
         }
         
         [Fact]
@@ -45,12 +45,12 @@ namespace Duende.Bff.Tests.Headers
             req.Headers.Add("X-Forwarded-Host", "external");
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.IsSuccessStatusCode.Should().BeTrue();
+            response.IsSuccessStatusCode.ShouldBeTrue();
             var json = await response.Content.ReadAsStringAsync();
             var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
 
             var host = apiResult.RequestHeaders["Host"].Single();
-            host.Should().Be("external");
+            host.ShouldBe("external");
         }
         
         [Fact]
@@ -63,12 +63,12 @@ namespace Duende.Bff.Tests.Headers
             req.Headers.Add("X-Forwarded-Host", "external");
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.IsSuccessStatusCode.Should().BeTrue();
+            response.IsSuccessStatusCode.ShouldBeTrue();
             var json = await response.Content.ReadAsStringAsync();
             var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
 
             var host = apiResult.RequestHeaders["Host"].Single();
-            host.Should().Be("external");
+            host.ShouldBe("external");
         }
     }
 }

--- a/bff/test/Duende.Bff.Tests/Headers/ApiUseForwardedHeaders.cs
+++ b/bff/test/Duende.Bff.Tests/Headers/ApiUseForwardedHeaders.cs
@@ -4,7 +4,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using Duende.Bff.Tests.TestFramework;
 using Duende.Bff.Tests.TestHosts;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace Duende.Bff.Tests.Headers
@@ -27,12 +27,12 @@ namespace Duende.Bff.Tests.Headers
             req.Headers.Add("x-csrf", "1");
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.IsSuccessStatusCode.Should().BeTrue();
+            response.IsSuccessStatusCode.ShouldBeTrue();
             var json = await response.Content.ReadAsStringAsync();
             var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
 
             var host = apiResult.RequestHeaders["Host"].Single();
-            host.Should().Be("app");
+            host.ShouldBe("app");
         }
         
         [Fact]
@@ -43,12 +43,12 @@ namespace Duende.Bff.Tests.Headers
             req.Headers.Add("X-Forwarded-Host", "external");
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.IsSuccessStatusCode.Should().BeTrue();
+            response.IsSuccessStatusCode.ShouldBeTrue();
             var json = await response.Content.ReadAsStringAsync();
             var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
 
             var host = apiResult.RequestHeaders["Host"].Single();
-            host.Should().Be("app");
+            host.ShouldBe("app");
         }
     }
 }

--- a/bff/test/Duende.Bff.Tests/Headers/General.cs
+++ b/bff/test/Duende.Bff.Tests/Headers/General.cs
@@ -4,7 +4,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using Duende.Bff.Tests.TestFramework;
 using Duende.Bff.Tests.TestHosts;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace Duende.Bff.Tests.Headers
@@ -18,13 +18,13 @@ namespace Duende.Bff.Tests.Headers
             req.Headers.Add("x-csrf", "1");
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.IsSuccessStatusCode.Should().BeTrue();
+            response.IsSuccessStatusCode.ShouldBeTrue();
             var json = await response.Content.ReadAsStringAsync();
             var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
 
-            apiResult.RequestHeaders.Count.Should().Be(2);
-            apiResult.RequestHeaders["Host"].Single().Should().Be("app");
-            apiResult.RequestHeaders["x-csrf"].Single().Should().Be("1");
+            apiResult.RequestHeaders.Count.ShouldBe(2);
+            apiResult.RequestHeaders["Host"].Single().ShouldBe("app");
+            apiResult.RequestHeaders["x-csrf"].Single().ShouldBe("1");
         }
         
         [Fact]
@@ -37,12 +37,12 @@ namespace Duende.Bff.Tests.Headers
             req.Headers.Add("x-custom", "custom");
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.IsSuccessStatusCode.Should().BeTrue();
+            response.IsSuccessStatusCode.ShouldBeTrue();
             var json = await response.Content.ReadAsStringAsync();
             var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
 
-            apiResult.RequestHeaders["Host"].Single().Should().Be("api");
-            apiResult.RequestHeaders["x-custom"].Single().Should().Be("custom");
+            apiResult.RequestHeaders["Host"].Single().ShouldBe("api");
+            apiResult.RequestHeaders["x-custom"].Single().ShouldBe("custom");
         }
         
         [Fact]
@@ -55,14 +55,14 @@ namespace Duende.Bff.Tests.Headers
             req.Headers.Add("x-custom", "custom");
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.IsSuccessStatusCode.Should().BeTrue();
+            response.IsSuccessStatusCode.ShouldBeTrue();
             var json = await response.Content.ReadAsStringAsync();
             var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
             
-            apiResult.RequestHeaders["X-Forwarded-Host"].Single().Should().Be("app");
-            apiResult.RequestHeaders["X-Forwarded-Proto"].Single().Should().Be("https");
-            apiResult.RequestHeaders["Host"].Single().Should().Be("api");
-            apiResult.RequestHeaders["x-custom"].Single().Should().Be("custom");
+            apiResult.RequestHeaders["X-Forwarded-Host"].Single().ShouldBe("app");
+            apiResult.RequestHeaders["X-Forwarded-Proto"].Single().ShouldBe("https");
+            apiResult.RequestHeaders["Host"].Single().ShouldBe("api");
+            apiResult.RequestHeaders["x-custom"].Single().ShouldBe("custom");
         }
     }
 }

--- a/bff/test/Duende.Bff.Tests/SessionManagement/CookieSlidingTests.cs
+++ b/bff/test/Duende.Bff.Tests/SessionManagement/CookieSlidingTests.cs
@@ -3,7 +3,7 @@
 
 using Duende.Bff.Tests.TestFramework;
 using Duende.Bff.Tests.TestHosts;
-using FluentAssertions;
+using Shouldly;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.Extensions.DependencyInjection;
@@ -47,22 +47,22 @@ namespace Duende.Bff.Tests.SessionManagement
             await BffHost.BffLoginAsync("alice");
 
             var sessions = await _sessionStore.GetUserSessionsAsync(new UserSessionsFilter { SubjectId = "alice" });
-            sessions.Count().Should().Be(1);
+            sessions.Count().ShouldBe(1);
 
             var session = sessions.Single();
 
             var ticketStore = BffHost.Resolve<IServerTicketStore>();
             var firstTicket = await ticketStore.RetrieveAsync(session.Key);
-            firstTicket.Should().NotBeNull();
+            firstTicket.ShouldNotBeNull();
 
             SetClock(TimeSpan.FromMinutes(8));
-            (await BffHost.GetIsUserLoggedInAsync()).Should().BeTrue();
+            (await BffHost.GetIsUserLoggedInAsync()).ShouldBeTrue();
 
             var secondTicket = await ticketStore.RetrieveAsync(session.Key);
-            secondTicket.Should().NotBeNull();
+            secondTicket.ShouldNotBeNull();
 
-            (secondTicket.Properties.IssuedUtc > firstTicket.Properties.IssuedUtc).Should().BeTrue();
-            (secondTicket.Properties.ExpiresUtc > firstTicket.Properties.ExpiresUtc).Should().BeTrue();
+            (secondTicket.Properties.IssuedUtc > firstTicket.Properties.IssuedUtc).ShouldBeTrue();
+            (secondTicket.Properties.ExpiresUtc > firstTicket.Properties.ExpiresUtc).ShouldBeTrue();
         }
 
         [Fact]
@@ -71,22 +71,22 @@ namespace Duende.Bff.Tests.SessionManagement
             await BffHost.BffLoginAsync("alice");
 
             var sessions = await _sessionStore.GetUserSessionsAsync(new UserSessionsFilter { SubjectId = "alice" });
-            sessions.Count().Should().Be(1);
+            sessions.Count().ShouldBe(1);
 
             var session = sessions.Single();
 
             var ticketStore = BffHost.Resolve<IServerTicketStore>();
             var firstTicket = await ticketStore.RetrieveAsync(session.Key);
-            firstTicket.Should().NotBeNull();
+            firstTicket.ShouldNotBeNull();
 
             SetClock(TimeSpan.FromMinutes(8));
-            (await BffHost.GetIsUserLoggedInAsync("slide=false")).Should().BeTrue();
+            (await BffHost.GetIsUserLoggedInAsync("slide=false")).ShouldBeTrue();
 
             var secondTicket = await ticketStore.RetrieveAsync(session.Key);
-            secondTicket.Should().NotBeNull();
+            secondTicket.ShouldNotBeNull();
 
-            (secondTicket.Properties.IssuedUtc == firstTicket.Properties.IssuedUtc).Should().BeTrue();
-            (secondTicket.Properties.ExpiresUtc == firstTicket.Properties.ExpiresUtc).Should().BeTrue();
+            (secondTicket.Properties.IssuedUtc == firstTicket.Properties.IssuedUtc).ShouldBeTrue();
+            (secondTicket.Properties.ExpiresUtc == firstTicket.Properties.ExpiresUtc).ShouldBeTrue();
         }
 
         [Fact]
@@ -110,23 +110,23 @@ namespace Duende.Bff.Tests.SessionManagement
             await BffHost.BffLoginAsync("alice");
 
             var sessions = await _sessionStore.GetUserSessionsAsync(new UserSessionsFilter { SubjectId = "alice" });
-            sessions.Count().Should().Be(1);
+            sessions.Count().ShouldBe(1);
 
             var session = sessions.Single();
 
             var ticketStore = BffHost.Resolve<IServerTicketStore>();
             var firstTicket = await ticketStore.RetrieveAsync(session.Key);
-            firstTicket.Should().NotBeNull();
+            firstTicket.ShouldNotBeNull();
 
             shouldRenew = true;
             SetClock(TimeSpan.FromSeconds(1));
-            (await BffHost.GetIsUserLoggedInAsync()).Should().BeTrue();
+            (await BffHost.GetIsUserLoggedInAsync()).ShouldBeTrue();
 
             var secondTicket = await ticketStore.RetrieveAsync(session.Key);
-            secondTicket.Should().NotBeNull();
+            secondTicket.ShouldNotBeNull();
 
-            (secondTicket.Properties.IssuedUtc > firstTicket.Properties.IssuedUtc).Should().BeTrue();
-            (secondTicket.Properties.ExpiresUtc > firstTicket.Properties.ExpiresUtc).Should().BeTrue();
+            (secondTicket.Properties.IssuedUtc > firstTicket.Properties.IssuedUtc).ShouldBeTrue();
+            (secondTicket.Properties.ExpiresUtc > firstTicket.Properties.ExpiresUtc).ShouldBeTrue();
         }
 
         [Fact]
@@ -151,23 +151,23 @@ namespace Duende.Bff.Tests.SessionManagement
             await BffHost.BffLoginAsync("alice");
 
             var sessions = await _sessionStore.GetUserSessionsAsync(new UserSessionsFilter { SubjectId = "alice" });
-            sessions.Count().Should().Be(1);
+            sessions.Count().ShouldBe(1);
 
             var session = sessions.Single();
 
             var ticketStore = BffHost.Resolve<IServerTicketStore>();
             var firstTicket = await ticketStore.RetrieveAsync(session.Key);
-            firstTicket.Should().NotBeNull();
+            firstTicket.ShouldNotBeNull();
 
             shouldRenew = true;
             SetClock(TimeSpan.FromSeconds(1));
-            (await BffHost.GetIsUserLoggedInAsync("slide=false")).Should().BeTrue();
+            (await BffHost.GetIsUserLoggedInAsync("slide=false")).ShouldBeTrue();
 
             var secondTicket = await ticketStore.RetrieveAsync(session.Key);
-            secondTicket.Should().NotBeNull();
+            secondTicket.ShouldNotBeNull();
 
-            (secondTicket.Properties.IssuedUtc == firstTicket.Properties.IssuedUtc).Should().BeTrue();
-            (secondTicket.Properties.ExpiresUtc == firstTicket.Properties.ExpiresUtc).Should().BeTrue();
+            (secondTicket.Properties.IssuedUtc == firstTicket.Properties.IssuedUtc).ShouldBeTrue();
+            (secondTicket.Properties.ExpiresUtc == firstTicket.Properties.ExpiresUtc).ShouldBeTrue();
         }
     }
 }

--- a/bff/test/Duende.Bff.Tests/SessionManagement/RevokeRefreshTokenTests.cs
+++ b/bff/test/Duende.Bff.Tests/SessionManagement/RevokeRefreshTokenTests.cs
@@ -3,7 +3,7 @@
 
 using Duende.Bff.Tests.TestHosts;
 using Duende.IdentityServer.Stores;
-using FluentAssertions;
+using Shouldly;
 using Microsoft.Extensions.DependencyInjection;
 using System.Linq;
 using System.Threading.Tasks;
@@ -25,7 +25,7 @@ namespace Duende.Bff.Tests.SessionManagement
                     SubjectId = "alice"
                 });
                 var rt = grants.Single(x => x.Type == "refresh_token");
-                rt.Should().NotBeNull();
+                rt.ShouldNotBeNull();
             }
 
             await BffHost.BffLogoutAsync("sid");
@@ -36,7 +36,7 @@ namespace Duende.Bff.Tests.SessionManagement
                 {
                     SubjectId = "alice"
                 });
-                grants.Should().BeEmpty();
+                grants.ShouldBeEmpty();
             }
         }
         
@@ -59,7 +59,7 @@ namespace Duende.Bff.Tests.SessionManagement
                     SubjectId = "alice"
                 });
                 var rt = grants.Single(x => x.Type == "refresh_token");
-                rt.Should().NotBeNull();
+                rt.ShouldNotBeNull();
             }
 
             await BffHost.BffLogoutAsync("sid");
@@ -71,7 +71,7 @@ namespace Duende.Bff.Tests.SessionManagement
                     SubjectId = "alice"
                 });
                 var rt = grants.Single(x => x.Type == "refresh_token");
-                rt.Should().NotBeNull();
+                rt.ShouldNotBeNull();
             }
         }
 
@@ -87,7 +87,7 @@ namespace Duende.Bff.Tests.SessionManagement
                     SubjectId = "alice"
                 });
                 var rt = grants.Single(x => x.Type == "refresh_token");
-                rt.Should().NotBeNull();
+                rt.ShouldNotBeNull();
             }
 
             await IdentityServerHost.RevokeSessionCookieAsync();
@@ -98,7 +98,7 @@ namespace Duende.Bff.Tests.SessionManagement
                 {
                     SubjectId = "alice"
                 });
-                var rt = grants.Should().BeEmpty();
+                grants.ShouldBeEmpty();
             }
         }
 
@@ -121,7 +121,7 @@ namespace Duende.Bff.Tests.SessionManagement
                     SubjectId = "alice"
                 });
                 var rt = grants.Single(x => x.Type == "refresh_token");
-                rt.Should().NotBeNull();
+                rt.ShouldNotBeNull();
             }
 
             await IdentityServerHost.RevokeSessionCookieAsync();
@@ -133,7 +133,7 @@ namespace Duende.Bff.Tests.SessionManagement
                     SubjectId = "alice"
                 });
                 var rt = grants.Single(x => x.Type == "refresh_token");
-                rt.Should().NotBeNull();
+                rt.ShouldNotBeNull();
             }
         }
     }

--- a/bff/test/Duende.Bff.Tests/SessionManagement/ServerSideTicketStoreTests.cs
+++ b/bff/test/Duende.Bff.Tests/SessionManagement/ServerSideTicketStoreTests.cs
@@ -3,7 +3,7 @@
 
 using Duende.Bff.Tests.TestFramework;
 using Duende.Bff.Tests.TestHosts;
-using FluentAssertions;
+using Shouldly;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Linq;
@@ -31,11 +31,11 @@ namespace Duende.Bff.Tests.SessionManagement
             await BffHost.BffLoginAsync("alice");
 
             BffHost.BrowserClient.RemoveCookie("bff");
-            (await _sessionStore.GetUserSessionsAsync(new UserSessionsFilter { SubjectId = "alice" })).Count().Should().Be(1);
+            (await _sessionStore.GetUserSessionsAsync(new UserSessionsFilter { SubjectId = "alice" })).Count().ShouldBe(1);
             
             await BffHost.BffOidcLoginAsync();
 
-            (await _sessionStore.GetUserSessionsAsync(new UserSessionsFilter { SubjectId = "alice" })).Count().Should().Be(1);
+            (await _sessionStore.GetUserSessionsAsync(new UserSessionsFilter { SubjectId = "alice" })).Count().ShouldBe(1);
         }
     }
 }

--- a/bff/test/Duende.Bff.Tests/TestFramework/GenericHost.cs
+++ b/bff/test/Duende.Bff.Tests/TestFramework/GenericHost.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
-using FluentAssertions;
+using Shouldly;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -131,7 +131,7 @@ namespace Duende.Bff.Tests.TestFramework
         public async Task RevokeSessionCookieAsync()
         {
             var response = await BrowserClient.GetAsync(Url("__signout"));
-            response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
         }
 
         void ConfigureSignin(IApplicationBuilder app)
@@ -164,7 +164,7 @@ namespace Duende.Bff.Tests.TestFramework
         {
             _userToSignIn = new ClaimsPrincipal(new ClaimsIdentity(claims, "test", "name", "role"));
             var response = await BrowserClient.GetAsync(Url("__signin"));
-            response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
         }
         public Task IssueSessionCookieAsync(AuthenticationProperties props, params Claim[] claims)
         {

--- a/bff/test/Duende.Bff.Tests/TestHosts/BffHost.cs
+++ b/bff/test/Duende.Bff.Tests/TestHosts/BffHost.cs
@@ -2,7 +2,7 @@
 // See LICENSE in the project root for license information.
 
 using Duende.Bff.Tests.TestFramework;
-using FluentAssertions;
+using Shouldly;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
@@ -455,8 +455,8 @@ public class BffHost : GenericHost
         req.Headers.Add("x-csrf", "1");
         var response = await BrowserClient.SendAsync(req);
 
-        (response.StatusCode == HttpStatusCode.OK || response.StatusCode == HttpStatusCode.Unauthorized).Should()
-            .BeTrue();
+        (response.StatusCode == HttpStatusCode.OK || response.StatusCode == HttpStatusCode.Unauthorized)
+            .ShouldBeTrue();
 
         return response.StatusCode == HttpStatusCode.OK;
     }
@@ -468,8 +468,8 @@ public class BffHost : GenericHost
 
         var response = await BrowserClient.SendAsync(req);
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
-        response.Content.Headers.ContentType.MediaType.Should().Be("application/json");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.Content.Headers.ContentType.MediaType.ShouldBe("application/json");
 
         var json = await response.Content.ReadAsStringAsync();
         return JsonSerializer.Deserialize<List<JsonRecord>>(json);
@@ -484,19 +484,19 @@ public class BffHost : GenericHost
     public async Task<HttpResponseMessage> BffOidcLoginAsync()
     {
         var response = await BrowserClient.GetAsync(Url("/bff/login"));
-        response.StatusCode.Should().Be(HttpStatusCode.Redirect); // authorize
-        response.Headers.Location.ToString().ToLowerInvariant().Should()
-            .StartWith(_identityServerHost.Url("/connect/authorize"));
+        response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // authorize
+        response.Headers.Location.ToString().ToLowerInvariant()
+            .ShouldStartWith(_identityServerHost.Url("/connect/authorize"));
 
         response = await _identityServerHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
-        response.StatusCode.Should().Be(HttpStatusCode.Redirect); // client callback
-        response.Headers.Location.ToString().ToLowerInvariant().Should().StartWith(Url("/signin-oidc"));
+        response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // client callback
+        response.Headers.Location.ToString().ToLowerInvariant().ShouldStartWith(Url("/signin-oidc"));
 
         response = await BrowserClient.GetAsync(response.Headers.Location.ToString());
-        response.StatusCode.Should().Be(HttpStatusCode.Redirect); // root
-        response.Headers.Location.ToString().ToLowerInvariant().Should().Be("/");
+        response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // root
+        response.Headers.Location.ToString().ToLowerInvariant().ShouldBe("/");
 
-        (await GetIsUserLoggedInAsync()).Should().BeTrue();
+        (await GetIsUserLoggedInAsync()).ShouldBeTrue();
 
         response = await BrowserClient.GetAsync(Url(response.Headers.Location.ToString()));
         return response;
@@ -505,24 +505,22 @@ public class BffHost : GenericHost
     public async Task<HttpResponseMessage> BffLogoutAsync(string sid = null)
     {
         var response = await BrowserClient.GetAsync(Url("/bff/logout") + "?sid=" + sid);
-        response.StatusCode.Should().Be(HttpStatusCode.Redirect); // endsession
-        response.Headers.Location.ToString().ToLowerInvariant().Should()
-            .StartWith(_identityServerHost.Url("/connect/endsession"));
+        response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // endsession
+        response.Headers.Location.ToString().ToLowerInvariant().ShouldStartWith(_identityServerHost.Url("/connect/endsession"));
 
         response = await _identityServerHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
-        response.StatusCode.Should().Be(HttpStatusCode.Redirect); // logout
-        response.Headers.Location.ToString().ToLowerInvariant().Should()
-            .StartWith(_identityServerHost.Url("/account/logout"));
+        response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // logout
+        response.Headers.Location.ToString().ToLowerInvariant().ShouldStartWith(_identityServerHost.Url("/account/logout"));
 
         response = await _identityServerHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
-        response.StatusCode.Should().Be(HttpStatusCode.Redirect); // post logout redirect uri
-        response.Headers.Location.ToString().ToLowerInvariant().Should().StartWith(Url("/signout-callback-oidc"));
+        response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // post logout redirect uri
+        response.Headers.Location.ToString().ToLowerInvariant().ShouldStartWith(Url("/signout-callback-oidc"));
 
         response = await BrowserClient.GetAsync(response.Headers.Location.ToString());
-        response.StatusCode.Should().Be(HttpStatusCode.Redirect); // root
-        response.Headers.Location.ToString().ToLowerInvariant().Should().Be("/");
+        response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // root
+        response.Headers.Location.ToString().ToLowerInvariant().ShouldBe("/");
 
-        (await GetIsUserLoggedInAsync()).Should().BeFalse();
+        (await GetIsUserLoggedInAsync()).ShouldBeFalse();
 
         response = await BrowserClient.GetAsync(Url(response.Headers.Location.ToString()));
         return response;

--- a/bff/test/Duende.Bff.Tests/TestHosts/BffHostUsingResourceNamedTokens.cs
+++ b/bff/test/Duende.Bff.Tests/TestHosts/BffHostUsingResourceNamedTokens.cs
@@ -2,7 +2,7 @@
 // See LICENSE in the project root for license information.
 
 using Duende.Bff.Tests.TestFramework;
-using FluentAssertions;
+using Shouldly;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using System;
@@ -164,8 +164,7 @@ namespace Duende.Bff.Tests.TestHosts
             req.Headers.Add("x-csrf", "1");
             var response = await BrowserClient.SendAsync(req);
 
-            (response.StatusCode == HttpStatusCode.OK || response.StatusCode == HttpStatusCode.Unauthorized).Should()
-                .BeTrue();
+            (response.StatusCode == HttpStatusCode.OK || response.StatusCode == HttpStatusCode.Unauthorized).ShouldBeTrue();
 
             return response.StatusCode == HttpStatusCode.OK;
         }
@@ -177,8 +176,8 @@ namespace Duende.Bff.Tests.TestHosts
 
             var response = await BrowserClient.SendAsync(req);
 
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
-            response.Content.Headers.ContentType.MediaType.Should().Be("application/json");
+            response.StatusCode.ShouldBe(HttpStatusCode.OK);
+            response.Content.Headers.ContentType.MediaType.ShouldBe("application/json");
 
             var json = await response.Content.ReadAsStringAsync();
             return JsonSerializer.Deserialize<List<JsonRecord>>(json);
@@ -193,19 +192,18 @@ namespace Duende.Bff.Tests.TestHosts
         public async Task<HttpResponseMessage> BffOidcLoginAsync()
         {
             var response = await BrowserClient.GetAsync(Url("/bff/login"));
-            response.StatusCode.Should().Be(HttpStatusCode.Redirect); // authorize
-            response.Headers.Location.ToString().ToLowerInvariant().Should()
-                .StartWith(_identityServerHost.Url("/connect/authorize"));
+            response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // authorize
+            response.Headers.Location.ToString().ToLowerInvariant().ShouldStartWith(_identityServerHost.Url("/connect/authorize"));
 
             response = await _identityServerHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
-            response.StatusCode.Should().Be(HttpStatusCode.Redirect); // client callback
-            response.Headers.Location.ToString().ToLowerInvariant().Should().StartWith(Url("/signin-oidc"));
+            response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // client callback
+            response.Headers.Location.ToString().ToLowerInvariant().ShouldStartWith(Url("/signin-oidc"));
 
             response = await BrowserClient.GetAsync(response.Headers.Location.ToString());
-            response.StatusCode.Should().Be(HttpStatusCode.Redirect); // root
-            response.Headers.Location.ToString().ToLowerInvariant().Should().Be("/");
+            response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // root
+            response.Headers.Location.ToString().ToLowerInvariant().ShouldBe("/");
 
-            (await GetIsUserLoggedInAsync()).Should().BeTrue();
+            (await GetIsUserLoggedInAsync()).ShouldBeTrue();
 
             response = await BrowserClient.GetAsync(Url(response.Headers.Location.ToString()));
             return response;
@@ -214,24 +212,22 @@ namespace Duende.Bff.Tests.TestHosts
         public async Task<HttpResponseMessage> BffLogoutAsync(string sid = null)
         {
             var response = await BrowserClient.GetAsync(Url("/bff/logout") + "?sid=" + sid);
-            response.StatusCode.Should().Be(HttpStatusCode.Redirect); // endsession
-            response.Headers.Location.ToString().ToLowerInvariant().Should()
-                .StartWith(_identityServerHost.Url("/connect/endsession"));
+            response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // endsession
+            response.Headers.Location.ToString().ToLowerInvariant().ShouldStartWith(_identityServerHost.Url("/connect/endsession"));
 
             response = await _identityServerHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
-            response.StatusCode.Should().Be(HttpStatusCode.Redirect); // logout
-            response.Headers.Location.ToString().ToLowerInvariant().Should()
-                .StartWith(_identityServerHost.Url("/account/logout"));
+            response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // logout
+            response.Headers.Location.ToString().ToLowerInvariant().ShouldStartWith(_identityServerHost.Url("/account/logout"));
 
             response = await _identityServerHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
-            response.StatusCode.Should().Be(HttpStatusCode.Redirect); // post logout redirect uri
-            response.Headers.Location.ToString().ToLowerInvariant().Should().StartWith(Url("/signout-callback-oidc"));
+            response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // post logout redirect uri
+            response.Headers.Location.ToString().ToLowerInvariant().ShouldStartWith(Url("/signout-callback-oidc"));
 
             response = await BrowserClient.GetAsync(response.Headers.Location.ToString());
-            response.StatusCode.Should().Be(HttpStatusCode.Redirect); // root
-            response.Headers.Location.ToString().ToLowerInvariant().Should().Be("/");
+            response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // root
+            response.Headers.Location.ToString().ToLowerInvariant().ShouldBe("/");
 
-            (await GetIsUserLoggedInAsync()).Should().BeFalse();
+            (await GetIsUserLoggedInAsync()).ShouldBeFalse();
 
             response = await BrowserClient.GetAsync(Url(response.Headers.Location.ToString()));
             return response;

--- a/bff/test/Duende.Bff.Tests/TestHosts/YarpBffHost.cs
+++ b/bff/test/Duende.Bff.Tests/TestHosts/YarpBffHost.cs
@@ -2,7 +2,7 @@
 // See LICENSE in the project root for license information.
 
 using Duende.Bff.Tests.TestFramework;
-using FluentAssertions;
+using Shouldly;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using System;
@@ -282,8 +282,8 @@ namespace Duende.Bff.Tests.TestHosts
             req.Headers.Add("x-csrf", "1");
             var response = await BrowserClient.SendAsync(req);
 
-            (response.StatusCode == HttpStatusCode.OK || response.StatusCode == HttpStatusCode.Unauthorized).Should()
-                .BeTrue();
+            (response.StatusCode == HttpStatusCode.OK || response.StatusCode == HttpStatusCode.Unauthorized)
+                .ShouldBeTrue();
 
             return response.StatusCode == HttpStatusCode.OK;
         }
@@ -295,8 +295,8 @@ namespace Duende.Bff.Tests.TestHosts
 
             var response = await BrowserClient.SendAsync(req);
 
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
-            response.Content.Headers.ContentType.MediaType.Should().Be("application/json");
+            response.StatusCode.ShouldBe(HttpStatusCode.OK);
+            response.Content.Headers.ContentType.MediaType.ShouldBe("application/json");
 
             var json = await response.Content.ReadAsStringAsync();
             return JsonSerializer.Deserialize<List<JsonRecord>>(json);
@@ -311,19 +311,19 @@ namespace Duende.Bff.Tests.TestHosts
         public async Task<HttpResponseMessage> BffOidcLoginAsync()
         {
             var response = await BrowserClient.GetAsync(Url("/bff/login"));
-            response.StatusCode.Should().Be(HttpStatusCode.Redirect); // authorize
-            response.Headers.Location.ToString().ToLowerInvariant().Should()
-                .StartWith(_identityServerHost.Url("/connect/authorize"));
+            response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // authorize
+            response.Headers.Location.ToString().ToLowerInvariant().
+                ShouldStartWith(_identityServerHost.Url("/connect/authorize"));
 
             response = await _identityServerHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
-            response.StatusCode.Should().Be(HttpStatusCode.Redirect); // client callback
-            response.Headers.Location.ToString().ToLowerInvariant().Should().StartWith(Url("/signin-oidc"));
+            response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // client callback
+            response.Headers.Location.ToString().ToLowerInvariant().ShouldStartWith(Url("/signin-oidc"));
 
             response = await BrowserClient.GetAsync(response.Headers.Location.ToString());
-            response.StatusCode.Should().Be(HttpStatusCode.Redirect); // root
-            response.Headers.Location.ToString().ToLowerInvariant().Should().Be("/");
+            response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // root
+            response.Headers.Location.ToString().ToLowerInvariant().ShouldBe("/");
 
-            (await GetIsUserLoggedInAsync()).Should().BeTrue();
+            (await GetIsUserLoggedInAsync()).ShouldBeTrue();
 
             response = await BrowserClient.GetAsync(Url(response.Headers.Location.ToString()));
             return response;
@@ -332,24 +332,22 @@ namespace Duende.Bff.Tests.TestHosts
         public async Task<HttpResponseMessage> BffLogoutAsync(string sid = null)
         {
             var response = await BrowserClient.GetAsync(Url("/bff/logout") + "?sid=" + sid);
-            response.StatusCode.Should().Be(HttpStatusCode.Redirect); // endsession
-            response.Headers.Location.ToString().ToLowerInvariant().Should()
-                .StartWith(_identityServerHost.Url("/connect/endsession"));
+            response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // endsession
+            response.Headers.Location.ToString().ToLowerInvariant().ShouldStartWith(_identityServerHost.Url("/connect/endsession"));
 
             response = await _identityServerHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
-            response.StatusCode.Should().Be(HttpStatusCode.Redirect); // logout
-            response.Headers.Location.ToString().ToLowerInvariant().Should()
-                .StartWith(_identityServerHost.Url("/account/logout"));
+            response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // logout
+            response.Headers.Location.ToString().ToLowerInvariant().ShouldStartWith(_identityServerHost.Url("/account/logout"));
 
             response = await _identityServerHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
-            response.StatusCode.Should().Be(HttpStatusCode.Redirect); // post logout redirect uri
-            response.Headers.Location.ToString().ToLowerInvariant().Should().StartWith(Url("/signout-callback-oidc"));
+            response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // post logout redirect uri
+            response.Headers.Location.ToString().ToLowerInvariant().ShouldStartWith(Url("/signout-callback-oidc"));
 
             response = await BrowserClient.GetAsync(response.Headers.Location.ToString());
-            response.StatusCode.Should().Be(HttpStatusCode.Redirect); // root
-            response.Headers.Location.ToString().ToLowerInvariant().Should().Be("/");
+            response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // root
+            response.Headers.Location.ToString().ToLowerInvariant().ShouldBe("/");
 
-            (await GetIsUserLoggedInAsync()).Should().BeFalse();
+            (await GetIsUserLoggedInAsync()).ShouldBeFalse();
 
             response = await BrowserClient.GetAsync(Url(response.Headers.Location.ToString()));
             return response;


### PR DESCRIPTION
This PR removes FluentAssertions from the BFF security framework in favor of using Shouldly. This makes the unit testing experience consistent with our other products. 