### PR TITLE
Clarify documentation for LicenseUsageSummary parameters.

### DIFF
--- a/identity-server/src/IdentityServer/Licensing/LicenseUsageSummary.cs
+++ b/identity-server/src/IdentityServer/Licensing/LicenseUsageSummary.cs
@@ -8,12 +8,12 @@ using System.Collections.Generic;
 namespace Duende.IdentityServer.Licensing;
 
 /// <summary>
-/// Usage summary for the current license.
+/// Usage summary for the current IdentityServer instance intended for auditing purposes.
 /// </summary>
-/// <param name="LicenseEdition"></param>
-/// <param name="ClientsUsed"></param>
-/// <param name="IssuersUsed"></param>
-/// <param name="FeaturesUsed"></param>
+/// <param name="LicenseEdition">License edition retrieved from license key.</param>
+/// <param name="ClientsUsed">Clients used in the current IdentityServer instance.</param>
+/// <param name="IssuersUsed">Issuers used in the current IdentityServer instance.</param>
+/// <param name="FeaturesUsed">Features used in the current IdentityServer instance.</param>
 public record LicenseUsageSummary(
     string LicenseEdition,
     IReadOnlyCollection<string> ClientsUsed,


### PR DESCRIPTION
This pull request includes a change to the `LicenseUsageSummary` class in the `identity-server` project. The change improves the documentation by providing more detailed descriptions of the parameters for auditing purposes.

Documentation improvements:

* [`identity-server/src/IdentityServer/Licensing/LicenseUsageSummary.cs`](diffhunk://#diff-a336444554692961327584e6f0a72e07c1bb5481c36ce959cfc3a8257cbc3425L11-R16): Enhanced the documentation comments to include detailed descriptions of the `LicenseEdition`, `ClientsUsed`, `IssuersUsed`, and `FeaturesUsed` parameters.