### PR TITLE
IdentityServer (hosts and templates) - summarize license usage on shutdown

### DIFF
--- a/bff/samples/Bff.DPoP/Bff.DPoP.csproj
+++ b/bff/samples/Bff.DPoP/Bff.DPoP.csproj
@@ -8,7 +8,7 @@
     
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.4" />    
-        <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
+        <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
     </ItemGroup>
     
     <ItemGroup>

--- a/bff/samples/Bff/Bff.csproj
+++ b/bff/samples/Bff/Bff.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
+        <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
     </ItemGroup>
     
     <ItemGroup>

--- a/bff/samples/IdentityServer/IdentityServer.csproj
+++ b/bff/samples/IdentityServer/IdentityServer.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Duende.IdentityServer" />
     <PackageReference Include="Duende.IdentityModel" />
-    <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
   </ItemGroup>
 
 </Project>

--- a/identity-server/clients/src/ConsoleResourceIndicators/Program.cs
+++ b/identity-server/clients/src/ConsoleResourceIndicators/Program.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityModel.Client;
 
 namespace ConsoleResourceIndicators

--- a/identity-server/hosts/AspNetIdentity/Program.cs
+++ b/identity-server/hosts/AspNetIdentity/Program.cs
@@ -1,11 +1,13 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
+using Duende.IdentityServer.Licensing;
 using IdentityServerHost;
 using Serilog;
-using System.Globalization;
 using Serilog.Events;
 using Serilog.Sinks.SystemConsole.Themes;
+using System.Globalization;
+using System.Text;
 
 Console.Title = "IdentityServer (AspNetIdentity)";
 
@@ -36,6 +38,16 @@ try
         .ConfigureServices()
         .ConfigurePipeline();
 
+    if (app.Environment.IsDevelopment())
+    {
+        app.Lifetime.ApplicationStopping.Register(() =>
+        {
+            var usage = app.Services.GetRequiredService<LicenseUsageSummary>();
+            Console.Write(Summary(usage));
+            Console.ReadKey();
+        });
+    }
+
     app.Run();
 }
 catch (Exception ex)
@@ -46,4 +58,17 @@ finally
 {
     Log.Information("Shut down complete");
     Log.CloseAndFlush();
+}
+
+static string Summary(LicenseUsageSummary usage)
+{
+    var sb = new StringBuilder();
+    sb.AppendLine("IdentityServer Usage Summary:");
+    sb.AppendLine(CultureInfo.InvariantCulture, $"  License: {usage.LicenseEdition}");
+    var features = usage.FeaturesUsed.Count > 0 ? string.Join(", ", usage.FeaturesUsed) : "None";
+    sb.AppendLine(CultureInfo.InvariantCulture, $"  Business and Enterprise Edition Features Used: {features}");
+    sb.AppendLine(CultureInfo.InvariantCulture, $"  {usage.ClientsUsed.Count} Client Id(s) Used");
+    sb.AppendLine(CultureInfo.InvariantCulture, $"  {usage.IssuersUsed.Count} Issuer(s) Used");
+
+    return sb.ToString();
 }

--- a/identity-server/hosts/Configuration/Program.cs
+++ b/identity-server/hosts/Configuration/Program.cs
@@ -1,11 +1,13 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
+using Duende.IdentityServer.Licensing;
 using IdentityServerHost;
 using Serilog;
 using Serilog.Events;
 using Serilog.Sinks.SystemConsole.Themes;
 using System.Globalization;
+using System.Text;
 
 Console.Title = "IdentityServer (Configuration)";
 
@@ -36,6 +38,16 @@ try
         .ConfigureServices()
         .ConfigurePipeline();
 
+    if (app.Environment.IsDevelopment())
+    {
+        app.Lifetime.ApplicationStopping.Register(() =>
+        {
+            var usage = app.Services.GetRequiredService<LicenseUsageSummary>();
+            Console.Write(Summary(usage));
+            Console.ReadKey();
+        });
+    }
+
     app.Run();
 }
 catch (Exception ex)
@@ -46,4 +58,17 @@ finally
 {
     Log.Information("Shut down complete");
     Log.CloseAndFlush();
+}
+
+static string Summary(LicenseUsageSummary usage)
+{
+    var sb = new StringBuilder();
+    sb.AppendLine("IdentityServer Usage Summary:");
+    sb.AppendLine(CultureInfo.InvariantCulture, $"  License: {usage.LicenseEdition}");
+    var features = usage.FeaturesUsed.Count > 0 ? string.Join(", ", usage.FeaturesUsed) : "None";
+    sb.AppendLine(CultureInfo.InvariantCulture, $"  Business and Enterprise Edition Features Used: {features}");
+    sb.AppendLine(CultureInfo.InvariantCulture, $"  {usage.ClientsUsed.Count} Client Id(s) Used");
+    sb.AppendLine(CultureInfo.InvariantCulture, $"  {usage.IssuersUsed.Count} Issuer(s) Used");
+
+    return sb.ToString();
 }

--- a/identity-server/hosts/main/Program.cs
+++ b/identity-server/hosts/main/Program.cs
@@ -38,12 +38,17 @@ try
         .ConfigureServices()
         .ConfigurePipeline();
 
-    var usage = app.Services.GetRequiredService<LicenseUsageSummary>();
+    if (app.Environment.IsDevelopment())
+    {
+        app.Lifetime.ApplicationStopping.Register(() =>
+        {
+            var usage = app.Services.GetRequiredService<LicenseUsageSummary>();
+            Console.Write(Summary(usage));
+            Console.ReadKey();
+        });
+    }
 
     app.Run();
-
-    Console.Write(Summary(usage));
-    Console.ReadKey();
 }
 catch (Exception ex)
 {

--- a/templates/src/BffLocalApi/BffLocalApi.csproj
+++ b/templates/src/BffLocalApi/BffLocalApi.csproj
@@ -7,7 +7,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Duende.BFF.Yarp" Version="2.2.0" />
-		<PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
+		<PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
 
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.3" />
 	</ItemGroup>

--- a/templates/src/IdentityServerAspNetIdentity/IdentityServerAspNetIdentity.csproj
+++ b/templates/src/IdentityServerAspNetIdentity/IdentityServerAspNetIdentity.csproj
@@ -7,15 +7,15 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Duende.IdentityServer.AspNetIdentity" version="7.0.6" />
+		<PackageReference Include="Duende.IdentityServer.AspNetIdentity" version="7.1.0-rc.2" />
 
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.3" />
-		<PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.11" />
+		<PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
 
-		<PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.3" />
-		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.3" />
-		<PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.3" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.3" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.3" />
+		<PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.11" />
+		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.11" />
+		<PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.11" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.11" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.11" />
 	</ItemGroup>
 </Project>

--- a/templates/src/IdentityServerAspNetIdentity/Pages/Account/Logout/Index.cshtml.cs
+++ b/templates/src/IdentityServerAspNetIdentity/Pages/Account/Logout/Index.cshtml.cs
@@ -4,7 +4,7 @@
 using Duende.IdentityServer.Events;
 using Duende.IdentityServer.Extensions;
 using Duende.IdentityServer.Services;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServerHost.Models;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;

--- a/templates/src/IdentityServerAspNetIdentity/Pages/Consent/Index.cshtml.cs
+++ b/templates/src/IdentityServerAspNetIdentity/Pages/Consent/Index.cshtml.cs
@@ -6,7 +6,7 @@ using Duende.IdentityServer.Extensions;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services;
 using Duende.IdentityServer.Validation;
-using IdentityModel;
+using Duende.IdentityModel;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;

--- a/templates/src/IdentityServerAspNetIdentity/Pages/Diagnostics/ViewModel.cs
+++ b/templates/src/IdentityServerAspNetIdentity/Pages/Diagnostics/ViewModel.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
-using IdentityModel;
+using Duende.IdentityModel;
 using Microsoft.AspNetCore.Authentication;
 using System.Text;
 using System.Text.Json;

--- a/templates/src/IdentityServerAspNetIdentity/Pages/ExternalLogin/Callback.cshtml.cs
+++ b/templates/src/IdentityServerAspNetIdentity/Pages/ExternalLogin/Callback.cshtml.cs
@@ -5,7 +5,7 @@ using System.Security.Claims;
 using Duende.IdentityServer;
 using Duende.IdentityServer.Events;
 using Duende.IdentityServer.Services;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServerHost.Models;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;

--- a/templates/src/IdentityServerAspNetIdentity/Program.cs
+++ b/templates/src/IdentityServerAspNetIdentity/Program.cs
@@ -1,5 +1,8 @@
-﻿using IdentityServerAspNetIdentity;
+﻿using Duende.IdentityServer.Licensing;
+using IdentityServerAspNetIdentity;
 using Serilog;
+using System.Globalization;
+using System.Text;
 
 Log.Logger = new LoggerConfiguration()
     .WriteTo.Console()
@@ -30,6 +33,16 @@ try
         return;
     }
 
+    if (app.Environment.IsDevelopment())
+    {
+        app.Lifetime.ApplicationStopping.Register(() =>
+        {
+            var usage = app.Services.GetRequiredService<LicenseUsageSummary>();
+            Console.Write(Summary(usage));
+            Console.ReadKey();
+        });
+    }
+
     app.Run();
 }
 catch (Exception ex) when (ex is not HostAbortedException)
@@ -40,4 +53,17 @@ finally
 {
     Log.Information("Shut down complete");
     Log.CloseAndFlush();
+}
+
+static string Summary(LicenseUsageSummary usage)
+{
+    var sb = new StringBuilder();
+    sb.AppendLine("IdentityServer Usage Summary:");
+    sb.AppendLine(CultureInfo.InvariantCulture, $"  License: {usage.LicenseEdition}");
+    var features = usage.FeaturesUsed.Count > 0 ? string.Join(", ", usage.FeaturesUsed) : "None";
+    sb.AppendLine(CultureInfo.InvariantCulture, $"  Business and Enterprise Edition Features Used: {features}");
+    sb.AppendLine(CultureInfo.InvariantCulture, $"  {usage.ClientsUsed.Count} Client Id(s) Used");
+    sb.AppendLine(CultureInfo.InvariantCulture, $"  {usage.IssuersUsed.Count} Issuer(s) Used");
+
+    return sb.ToString();
 }

--- a/templates/src/IdentityServerAspNetIdentity/SeedData.cs
+++ b/templates/src/IdentityServerAspNetIdentity/SeedData.cs
@@ -1,5 +1,5 @@
 ﻿using System.Security.Claims;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServerAspNetIdentity.Data;
 using IdentityServerHost.Models;
 using Microsoft.AspNetCore.Identity;

--- a/templates/src/IdentityServerEmpty/IdentityServerEmpty.csproj
+++ b/templates/src/IdentityServerEmpty/IdentityServerEmpty.csproj
@@ -7,8 +7,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Duende.IdentityServer" version="7.0.6" />
+		<PackageReference Include="Duende.IdentityServer" version="7.1.0-rc.2" />
 
-		<PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
+		<PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
 	</ItemGroup>
 </Project>

--- a/templates/src/IdentityServerEmpty/Program.cs
+++ b/templates/src/IdentityServerEmpty/Program.cs
@@ -1,5 +1,8 @@
-﻿using IdentityServerEmpty;
+﻿using Duende.IdentityServer.Licensing;
+using IdentityServerEmpty;
 using Serilog;
+using System.Globalization;
+using System.Text;
 
 Log.Logger = new LoggerConfiguration()
     .WriteTo.Console()
@@ -19,7 +22,17 @@ try
     var app = builder
         .ConfigureServices()
         .ConfigurePipeline();
-    
+
+    if (app.Environment.IsDevelopment())
+    {
+        app.Lifetime.ApplicationStopping.Register(() =>
+        {
+            var usage = app.Services.GetRequiredService<LicenseUsageSummary>();
+            Console.Write(Summary(usage));
+            Console.ReadKey();
+        });
+    }
+
     app.Run();
 }
 catch (Exception ex)
@@ -30,4 +43,17 @@ finally
 {
     Log.Information("Shut down complete");
     Log.CloseAndFlush();
+}
+
+static string Summary(LicenseUsageSummary usage)
+{
+    var sb = new StringBuilder();
+    sb.AppendLine("IdentityServer Usage Summary:");
+    sb.AppendLine(CultureInfo.InvariantCulture, $"  License: {usage.LicenseEdition}");
+    var features = usage.FeaturesUsed.Count > 0 ? string.Join(", ", usage.FeaturesUsed) : "None";
+    sb.AppendLine(CultureInfo.InvariantCulture, $"  Business and Enterprise Edition Features Used: {features}");
+    sb.AppendLine(CultureInfo.InvariantCulture, $"  {usage.ClientsUsed.Count} Client Id(s) Used");
+    sb.AppendLine(CultureInfo.InvariantCulture, $"  {usage.IssuersUsed.Count} Issuer(s) Used");
+
+    return sb.ToString();
 }

--- a/templates/src/IdentityServerEntityFramework/IdentityServerEntityFramework.csproj
+++ b/templates/src/IdentityServerEntityFramework/IdentityServerEntityFramework.csproj
@@ -7,14 +7,14 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Duende.IdentityServer.EntityFramework" version="7.0.6" />
+		<PackageReference Include="Duende.IdentityServer.EntityFramework" version="7.1.0-rc.2" />
 
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.3" />
-		<PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.11" />
+		<PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
 
-		<PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.3" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.3" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.3" />
+		<PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.11" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.11" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.11" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/templates/src/IdentityServerEntityFramework/Pages/Account/Logout/Index.cshtml.cs
+++ b/templates/src/IdentityServerEntityFramework/Pages/Account/Logout/Index.cshtml.cs
@@ -4,7 +4,7 @@
 using Duende.IdentityServer.Events;
 using Duende.IdentityServer.Extensions;
 using Duende.IdentityServer.Services;
-using IdentityModel;
+using Duende.IdentityModel;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;

--- a/templates/src/IdentityServerEntityFramework/Pages/Admin/Clients/New.cshtml.cs
+++ b/templates/src/IdentityServerEntityFramework/Pages/Admin/Clients/New.cshtml.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
-using IdentityModel;
+using Duende.IdentityModel;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;

--- a/templates/src/IdentityServerEntityFramework/Pages/Consent/Index.cshtml.cs
+++ b/templates/src/IdentityServerEntityFramework/Pages/Consent/Index.cshtml.cs
@@ -6,7 +6,7 @@ using Duende.IdentityServer.Extensions;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services;
 using Duende.IdentityServer.Validation;
-using IdentityModel;
+using Duende.IdentityModel;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;

--- a/templates/src/IdentityServerEntityFramework/Pages/Diagnostics/ViewModel.cs
+++ b/templates/src/IdentityServerEntityFramework/Pages/Diagnostics/ViewModel.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
-using IdentityModel;
+using Duende.IdentityModel;
 using Microsoft.AspNetCore.Authentication;
 using System.Text;
 using System.Text.Json;

--- a/templates/src/IdentityServerEntityFramework/Pages/ExternalLogin/Callback.cshtml.cs
+++ b/templates/src/IdentityServerEntityFramework/Pages/ExternalLogin/Callback.cshtml.cs
@@ -6,7 +6,7 @@ using Duende.IdentityServer;
 using Duende.IdentityServer.Events;
 using Duende.IdentityServer.Services;
 using Duende.IdentityServer.Test;
-using IdentityModel;
+using Duende.IdentityModel;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;

--- a/templates/src/IdentityServerEntityFramework/Pages/TestUsers.cs
+++ b/templates/src/IdentityServerEntityFramework/Pages/TestUsers.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
-using IdentityModel;
+using Duende.IdentityModel;
 using System.Security.Claims;
 using System.Text.Json;
 using Duende.IdentityServer;

--- a/templates/src/IdentityServerInMem/IdentityServerInMem.csproj
+++ b/templates/src/IdentityServerInMem/IdentityServerInMem.csproj
@@ -7,10 +7,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Duende.IdentityServer" version="7.0.6" />
+		<PackageReference Include="Duende.IdentityServer" version="7.1.0-rc.2" />
 
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.3" />
-		<PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.11" />
+		<PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
 	</ItemGroup>
 
 

--- a/templates/src/IdentityServerInMem/Pages/Account/Logout/Index.cshtml.cs
+++ b/templates/src/IdentityServerInMem/Pages/Account/Logout/Index.cshtml.cs
@@ -4,7 +4,7 @@
 using Duende.IdentityServer.Events;
 using Duende.IdentityServer.Extensions;
 using Duende.IdentityServer.Services;
-using IdentityModel;
+using Duende.IdentityModel;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;

--- a/templates/src/IdentityServerInMem/Pages/Consent/Index.cshtml.cs
+++ b/templates/src/IdentityServerInMem/Pages/Consent/Index.cshtml.cs
@@ -6,7 +6,7 @@ using Duende.IdentityServer.Extensions;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services;
 using Duende.IdentityServer.Validation;
-using IdentityModel;
+using Duende.IdentityModel;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;

--- a/templates/src/IdentityServerInMem/Pages/Diagnostics/ViewModel.cs
+++ b/templates/src/IdentityServerInMem/Pages/Diagnostics/ViewModel.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
-using IdentityModel;
+using Duende.IdentityModel;
 using Microsoft.AspNetCore.Authentication;
 using System.Text;
 using System.Text.Json;

--- a/templates/src/IdentityServerInMem/Pages/ExternalLogin/Callback.cshtml.cs
+++ b/templates/src/IdentityServerInMem/Pages/ExternalLogin/Callback.cshtml.cs
@@ -6,7 +6,7 @@ using Duende.IdentityServer;
 using Duende.IdentityServer.Events;
 using Duende.IdentityServer.Services;
 using Duende.IdentityServer.Test;
-using IdentityModel;
+using Duende.IdentityModel;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;

--- a/templates/src/IdentityServerInMem/Pages/TestUsers.cs
+++ b/templates/src/IdentityServerInMem/Pages/TestUsers.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
-using IdentityModel;
+using Duende.IdentityModel;
 using System.Security.Claims;
 using System.Text.Json;
 using Duende.IdentityServer;

--- a/templates/src/IdentityServerInMem/Program.cs
+++ b/templates/src/IdentityServerInMem/Program.cs
@@ -1,5 +1,8 @@
-﻿using IdentityServerInMem;
+﻿using Duende.IdentityServer.Licensing;
+using IdentityServerInMem;
 using Serilog;
+using System.Globalization;
+using System.Text;
 
 Log.Logger = new LoggerConfiguration()
     .WriteTo.Console()
@@ -19,7 +22,17 @@ try
     var app = builder
         .ConfigureServices()
         .ConfigurePipeline();
-    
+
+    if (app.Environment.IsDevelopment())
+    {
+        app.Lifetime.ApplicationStopping.Register(() =>
+        {
+            var usage = app.Services.GetRequiredService<LicenseUsageSummary>();
+            Console.Write(Summary(usage));
+            Console.ReadKey();
+        });
+    }
+
     app.Run();
 }
 catch (Exception ex)
@@ -30,4 +43,17 @@ finally
 {
     Log.Information("Shut down complete");
     Log.CloseAndFlush();
+}
+
+static string Summary(LicenseUsageSummary usage)
+{
+    var sb = new StringBuilder();
+    sb.AppendLine("IdentityServer Usage Summary:");
+    sb.AppendLine(CultureInfo.InvariantCulture, $"  License: {usage.LicenseEdition}");
+    var features = usage.FeaturesUsed.Count > 0 ? string.Join(", ", usage.FeaturesUsed) : "None";
+    sb.AppendLine(CultureInfo.InvariantCulture, $"  Business and Enterprise Edition Features Used: {features}");
+    sb.AppendLine(CultureInfo.InvariantCulture, $"  {usage.ClientsUsed.Count} Client Id(s) Used");
+    sb.AppendLine(CultureInfo.InvariantCulture, $"  {usage.IssuersUsed.Count} Issuer(s) Used");
+
+    return sb.ToString();
 }


### PR DESCRIPTION
~~This PR is stacked on top of https://github.com/DuendeSoftware/products/pull/1717. Please merge it first.~~ _Done_

This PR copies the `LicenseUsageSummary` code from the main host into all the other hosts and into the templates.

I'm doing it in main rather than the release branch because
- hosts aren't released
- templates aren't synced with a release branch (at least not yet)

For this to compile in the templates, we need the latest release, so this depends on 7.1.0-rc.2. We MUST update to 7.1.0 when it hits GA before releasing the templates.

This also requires us to update the template files to refer to Duende.IdentityModel instead of IdentityModel.