### PR TITLE
ci(is): add 7.1 workflow dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
-name: "CI"
+name: "IdentityServer 7.1"
 
 on:
+  workflow_dispatch:
   push:
     branches:
     - main


### PR DESCRIPTION
Config to facilitate IdentityServer releases pre-move to mono-repo.