### PR TITLE
ci(is): Add workflow dispatch to build config

### DIFF
--- a/.github/workflows/identity-server-ci.yml
+++ b/.github/workflows/identity-server-ci.yml
@@ -1,6 +1,7 @@
 name: "identity-server-ci"
 
 on:
+  workflow_dispatch:  
   push:
     branches:
       - main


### PR DESCRIPTION
Add workflow dispatch to allow for manually triggering builds (needed for IdSrv 7.1, etc).