### PR TITLE
Filtering expired X.509 certificates

### DIFF
--- a/identity-server/src/IdentityServer/Services/Default/KeyManagement/KeyManager.cs
+++ b/identity-server/src/IdentityServer/Services/Default/KeyManagement/KeyManager.cs
@@ -384,6 +384,11 @@ public class KeyManager : IKeyManager
         var result = keys
             .Where(x =>
             {
+                if (x is X509KeyContainer x509Key)
+                {
+                    return x509Key.NotAfter > _clock.UtcNow;
+                }
+                
                 var age = _clock.GetAge(x.Created);
                 var isExpired = _options.KeyManagement.IsExpired(age);
                 return !isExpired;

--- a/identity-server/src/IdentityServer/Services/Default/KeyManagement/X509KeyContainer.cs
+++ b/identity-server/src/IdentityServer/Services/Default/KeyManagement/X509KeyContainer.cs
@@ -85,6 +85,11 @@ public class X509KeyContainer : KeyContainer
     /// The X509 certificate data.
     /// </summary>
     public string CertificateRawData { get; set; }
+    
+    /// <summary>
+    /// The expiration date of the certificate.
+    /// </summary>
+    public DateTime NotAfter => _cert.NotAfter;
 
     /// <inheritdoc />
     public override AsymmetricSecurityKey ToSecurityKey()

--- a/identity-server/test/IdentityServer.UnitTests/Services/Default/KeyManagement/KeyManagerTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Services/Default/KeyManagement/KeyManagerTests.cs
@@ -531,16 +531,12 @@ public class KeyManagerTests
         var key4 = CreateKey(_options.KeyManagement.PropagationTime.Add(TimeSpan.FromSeconds(1)));
         var key5 = CreateKey(_options.KeyManagement.PropagationTime);
         var key6 = CreateKey(_options.KeyManagement.PropagationTime.Subtract(TimeSpan.FromSeconds(1)));
-        var key7 = CreateKey(
-            _options.KeyManagement.RotationInterval.Subtract(TimeSpan.FromSeconds(1)),
-            x509: true);
-        var key8 = CreateKey(
-            _options.KeyManagement.KeyRetirementAge.Add(TimeSpan.FromSeconds(1)),
-            x509: true);
+        var key7 = CreateKey(_options.KeyManagement.RotationInterval.Subtract(TimeSpan.FromSeconds(1)), x509: true);
+        var key8 = CreateKey(_options.KeyManagement.KeyRetirementAge.Add(TimeSpan.FromSeconds(1)), x509: true);
 
         var result = _subject.FilterExpiredKeys(new[] { key1, key2, key3, key4, key5, key6, key7, key8 });
 
-        result.Select(x => x.Id).Should().BeEquivalentTo(new[] { key3.Id, key4.Id, key5.Id, key6.Id, key8.Id });
+        result.Select(x => x.Id).Should().BeEquivalentTo(new[] { key3.Id, key4.Id, key5.Id, key6.Id, key7.Id });
     }
 
     // CacheKeysAsync

--- a/identity-server/test/IdentityServer.UnitTests/Services/Default/KeyManagement/KeyManagerTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Services/Default/KeyManagement/KeyManagerTests.cs
@@ -540,7 +540,7 @@ public class KeyManagerTests
 
         var result = _subject.FilterExpiredKeys(new[] { key1, key2, key3, key4, key5, key6, key7, key8 });
 
-        result.Select(x => x.Id).Should().BeEquivalentTo(new[] { key3.Id, key4.Id, key5.Id, key6.Id });
+        result.Select(x => x.Id).Should().BeEquivalentTo(new[] { key3.Id, key4.Id, key5.Id, key6.Id, key8.Id });
     }
 
     // CacheKeysAsync

--- a/identity-server/test/IdentityServer.UnitTests/Services/Default/KeyManagement/KeyManagerTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Services/Default/KeyManagement/KeyManagerTests.cs
@@ -531,8 +531,14 @@ public class KeyManagerTests
         var key4 = CreateKey(_options.KeyManagement.PropagationTime.Add(TimeSpan.FromSeconds(1)));
         var key5 = CreateKey(_options.KeyManagement.PropagationTime);
         var key6 = CreateKey(_options.KeyManagement.PropagationTime.Subtract(TimeSpan.FromSeconds(1)));
+        var key7 = CreateKey(
+            _options.KeyManagement.RotationInterval.Subtract(TimeSpan.FromSeconds(1)),
+            x509: true);
+        var key8 = CreateKey(
+            _options.KeyManagement.KeyRetirementAge.Add(TimeSpan.FromSeconds(1)),
+            x509: true);
 
-        var result = _subject.FilterExpiredKeys(new[] { key1, key2, key3, key4, key5, key6 });
+        var result = _subject.FilterExpiredKeys(new[] { key1, key2, key3, key4, key5, key6, key7, key8 });
 
         result.Select(x => x.Id).Should().BeEquivalentTo(new[] { key3.Id, key4.Id, key5.Id, key6.Id });
     }


### PR DESCRIPTION
**What issue does this PR address?**
This PR addresses a potential issue where an expired X.509 certificate could remain in use if it was generated with a different configuration and landed in the database. This change provides an additional safeguard to ensure no expired certificates are used as signing keys. The `FilterExpiredKeys` method now checks the `NotAfter` date of `X509KeyContainer` keys, and unit tests have been updated to validate this scenario.
