### PR TITLE
Made tracing class public to allow activity source extensions

### DIFF
--- a/identity-server/src/Telemetry/Tracing.cs
+++ b/identity-server/src/Telemetry/Tracing.cs
@@ -9,7 +9,7 @@ namespace Duende.IdentityServer;
 /// <summary>
 /// Constants for tracing
 /// </summary>
-internal static class Tracing
+public static class Tracing
 {
     private static readonly Version AssemblyVersion = typeof(Tracing).Assembly.GetName().Version;
 


### PR DESCRIPTION
**What issue does this PR address?**

Currently `Tracing` class is marked as `internal` which stops us from extending `ActivitySource` declared in that class. Why would we want to extend it?

Duende Server currently adds few predefined values to traces produced by it and does it at different stages e.g. top level span for `connect/authorize` doesn't include `clientId` label. We would like to enrich all calls by `clientId` (wherever applicable of course) and with other labels depending on scenario.

How would that work? Example below

```csharp
Tracing.DuendeActivitySource.AddActivityListener(new ActivityListener
{
    ShouldListenTo = _ => true,
    ActivityStarted = activity =>
    {
        if (activity.Parent.TryGetCorrelationId(out var correlationId))
        {
            activity.SetTag(CorrelationIdKey, correlationId);
        }
    },
    ActivityStopped = activity =>
    {
       // enrich span with all key/value in Baggage
        foreach (var (key, value) in Baggage.Current)
        {
            activity.SetTag(key, value);
        }
    },
});
```


**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
