### PR TITLE
tests write output via ITestOutputHelper

### DIFF
--- a/bff/test/Duende.Bff.Tests/Endpoints/LocalEndpointTests.cs
+++ b/bff/test/Duende.Bff.Tests/Endpoints/LocalEndpointTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Duende.Bff.Tests.TestFramework;
@@ -11,10 +11,11 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using Shouldly;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Duende.Bff.Tests.Endpoints
 {
-    public class LocalEndpointTests : BffIntegrationTestBase
+    public class LocalEndpointTests(ITestOutputHelper output) : BffIntegrationTestBase(output)
     {
         [Fact]
         public async Task calls_to_authorized_local_endpoint_should_succeed()

--- a/bff/test/Duende.Bff.Tests/Endpoints/Management/BackchannelLogoutEndpointTests.cs
+++ b/bff/test/Duende.Bff.Tests/Endpoints/Management/BackchannelLogoutEndpointTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Duende.Bff.Tests.TestHosts;
@@ -8,10 +8,11 @@ using System.Net;
 using System.Threading.Tasks;
 using Shouldly;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Duende.Bff.Tests.Endpoints.Management
 {
-    public class BackchannelLogoutEndpointTests : BffIntegrationTestBase
+    public class BackchannelLogoutEndpointTests(ITestOutputHelper output) : BffIntegrationTestBase(output)
     {
         [Fact]
         public async Task backchannel_logout_should_allow_anonymous()

--- a/bff/test/Duende.Bff.Tests/Endpoints/Management/LoginEndpointTests.cs
+++ b/bff/test/Duende.Bff.Tests/Endpoints/Management/LoginEndpointTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Duende.Bff.Tests.TestHosts;
@@ -8,10 +8,11 @@ using System.Net;
 using System.Threading.Tasks;
 using Shouldly;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Duende.Bff.Tests.Endpoints.Management
 {
-    public class LoginEndpointTests : BffIntegrationTestBase
+    public class LoginEndpointTests(ITestOutputHelper output) : BffIntegrationTestBase(output)
     {
         [Fact]
         public async Task login_should_allow_anonymous()

--- a/bff/test/Duende.Bff.Tests/Endpoints/Management/LogoutEndpointTests.cs
+++ b/bff/test/Duende.Bff.Tests/Endpoints/Management/LogoutEndpointTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Duende.Bff.Tests.TestHosts;
@@ -8,10 +8,11 @@ using System.Net;
 using System.Threading.Tasks;
 using Shouldly;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Duende.Bff.Tests.Endpoints.Management
 {
-    public class LogoutEndpointTests : BffIntegrationTestBase
+    public class LogoutEndpointTests(ITestOutputHelper output) : BffIntegrationTestBase(output)
     {
         [Fact]
         public async Task logout_endpoint_should_allow_anonymous()

--- a/bff/test/Duende.Bff.Tests/Endpoints/Management/ManagementBasePathTests.cs
+++ b/bff/test/Duende.Bff.Tests/Endpoints/Management/ManagementBasePathTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Duende.Bff.Tests.TestHosts;
@@ -9,10 +9,11 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using System.Net;
 using Shouldly;
+using Xunit.Abstractions;
 
 namespace Duende.Bff.Tests.Endpoints.Management
 {
-    public class ManagementBasePathTests : BffIntegrationTestBase
+    public class ManagementBasePathTests(ITestOutputHelper output) : BffIntegrationTestBase(output)
     {
         [Theory]
         [InlineData(Constants.ManagementEndpoints.Login)]

--- a/bff/test/Duende.Bff.Tests/Endpoints/Management/UserEndpointTests.cs
+++ b/bff/test/Duende.Bff.Tests/Endpoints/Management/UserEndpointTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using System.Linq;
@@ -9,10 +9,11 @@ using System.Threading.Tasks;
 using Xunit;
 using System.Net;
 using Shouldly;
+using Xunit.Abstractions;
 
 namespace Duende.Bff.Tests.Endpoints.Management
 {
-    public class UserEndpointTests : BffIntegrationTestBase
+    public class UserEndpointTests(ITestOutputHelper output) : BffIntegrationTestBase(output)
     {
         [Fact]
         public async Task user_endpoint_for_authenticated_user_should_return_claims()

--- a/bff/test/Duende.Bff.Tests/Endpoints/RemoteEndpointTests.cs
+++ b/bff/test/Duende.Bff.Tests/Endpoints/RemoteEndpointTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Duende.Bff.Tests.TestFramework;
@@ -15,10 +15,11 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using Shouldly;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Duende.Bff.Tests.Endpoints
 {
-    public class RemoteEndpointTests : BffIntegrationTestBase
+    public class RemoteEndpointTests(ITestOutputHelper output) : BffIntegrationTestBase(output)
     {
         [Fact]
         public async Task unauthenticated_calls_to_remote_endpoint_should_return_401()

--- a/bff/test/Duende.Bff.Tests/Endpoints/YarpRemoteEndpointTests.cs
+++ b/bff/test/Duende.Bff.Tests/Endpoints/YarpRemoteEndpointTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Duende.Bff.Tests.TestHosts;
@@ -9,10 +9,11 @@ using System.Threading.Tasks;
 using Duende.Bff.Tests.TestFramework;
 using Shouldly;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Duende.Bff.Tests.Endpoints
 {
-    public class YarpRemoteEndpointTests : YarpBffIntegrationTestBase
+    public class YarpRemoteEndpointTests(ITestOutputHelper output) : YarpBffIntegrationTestBase(output)
     {
         [Fact]
         public async Task anonymous_call_with_no_csrf_header_to_no_token_requirement_no_csrf_route_should_succeed()

--- a/bff/test/Duende.Bff.Tests/GenericHostTests.cs
+++ b/bff/test/Duende.Bff.Tests/GenericHostTests.cs
@@ -7,15 +7,16 @@ using System.Net;
 using System.Threading.Tasks;
 using Shouldly;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Duende.Bff.Tests
 {
-    public class GenericHostTests
+    public class GenericHostTests(ITestOutputHelper output)
     {
         [Fact]
         public async Task Test1()
         {
-            var host = new GenericHost();
+            var host = new GenericHost(output.WriteLine);
             host.OnConfigure += app => app.Run(ctx => {
                 ctx.Response.StatusCode = 204;
                 return Task.CompletedTask;

--- a/bff/test/Duende.Bff.Tests/Headers/ApiAndBffUseForwardedHeaders.cs
+++ b/bff/test/Duende.Bff.Tests/Headers/ApiAndBffUseForwardedHeaders.cs
@@ -6,17 +6,18 @@ using Duende.Bff.Tests.TestFramework;
 using Duende.Bff.Tests.TestHosts;
 using Shouldly;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Duende.Bff.Tests.Headers
 {
     public class ApiAndBffUseForwardedHeaders : BffIntegrationTestBase
     {
-        public ApiAndBffUseForwardedHeaders()
+        public ApiAndBffUseForwardedHeaders(ITestOutputHelper output) : base(output)
         {
-            ApiHost = new ApiHost(IdentityServerHost, "scope1", useForwardedHeaders: true);
+            ApiHost = new ApiHost(output.WriteLine, IdentityServerHost, "scope1", useForwardedHeaders: true);
             ApiHost.InitializeAsync().Wait();
 
-            BffHost = new BffHost(IdentityServerHost, ApiHost, "spa", useForwardedHeaders: true);
+            BffHost = new BffHost(output.WriteLine, IdentityServerHost, ApiHost, "spa", useForwardedHeaders: true);
             BffHost.InitializeAsync().Wait();
         }
         

--- a/bff/test/Duende.Bff.Tests/Headers/ApiUseForwardedHeaders.cs
+++ b/bff/test/Duende.Bff.Tests/Headers/ApiUseForwardedHeaders.cs
@@ -6,17 +6,18 @@ using Duende.Bff.Tests.TestFramework;
 using Duende.Bff.Tests.TestHosts;
 using Shouldly;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Duende.Bff.Tests.Headers
 {
     public class ApiUseForwardedHeaders : BffIntegrationTestBase
     {
-        public ApiUseForwardedHeaders()
+        public ApiUseForwardedHeaders(ITestOutputHelper output) : base(output)
         {
-            ApiHost = new ApiHost(IdentityServerHost, "scope1", useForwardedHeaders: true);
+            ApiHost = new ApiHost(output.WriteLine, IdentityServerHost, "scope1", useForwardedHeaders: true);
             ApiHost.InitializeAsync().Wait();
 
-            BffHost = new BffHost(IdentityServerHost, ApiHost, "spa", useForwardedHeaders: false);
+            BffHost = new BffHost(output.WriteLine, IdentityServerHost, ApiHost, "spa", useForwardedHeaders: false);
             BffHost.InitializeAsync().Wait();
         }
         

--- a/bff/test/Duende.Bff.Tests/Headers/General.cs
+++ b/bff/test/Duende.Bff.Tests/Headers/General.cs
@@ -6,10 +6,11 @@ using Duende.Bff.Tests.TestFramework;
 using Duende.Bff.Tests.TestHosts;
 using Shouldly;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Duende.Bff.Tests.Headers
 {
-    public class General : BffIntegrationTestBase
+    public class General(ITestOutputHelper output) : BffIntegrationTestBase(output)
     {
         [Fact]
         public async Task local_endpoint_should_receive_standard_headers()

--- a/bff/test/Duende.Bff.Tests/SessionManagement/CookieSlidingTests.cs
+++ b/bff/test/Duende.Bff.Tests/SessionManagement/CookieSlidingTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Duende.Bff.Tests.TestHosts;
@@ -10,6 +10,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.Abstractions;
 
 
 namespace Duende.Bff.Tests.SessionManagement
@@ -19,7 +20,7 @@ namespace Duende.Bff.Tests.SessionManagement
         InMemoryUserSessionStore _sessionStore = new InMemoryUserSessionStore();
         FakeTimeProvider _clock = new(DateTime.UtcNow);
 
-        public CookieSlidingTests()
+        public CookieSlidingTests(ITestOutputHelper output) : base(output)
         {
             BffHost.OnConfigureServices += services => 
             {

--- a/bff/test/Duende.Bff.Tests/SessionManagement/RevokeRefreshTokenTests.cs
+++ b/bff/test/Duende.Bff.Tests/SessionManagement/RevokeRefreshTokenTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Duende.Bff.Tests.TestHosts;
@@ -8,10 +8,11 @@ using Microsoft.Extensions.DependencyInjection;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Duende.Bff.Tests.SessionManagement
 {
-    public class RevokeRefreshTokenTests : BffIntegrationTestBase
+    public class RevokeRefreshTokenTests(ITestOutputHelper output) : BffIntegrationTestBase(output)
     {
         [Fact]
         public async Task logout_should_revoke_refreshtoken()

--- a/bff/test/Duende.Bff.Tests/SessionManagement/ServerSideTicketStoreTests.cs
+++ b/bff/test/Duende.Bff.Tests/SessionManagement/ServerSideTicketStoreTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Duende.Bff.Tests.TestHosts;
@@ -7,6 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Duende.Bff.Tests.SessionManagement
 {
@@ -14,7 +15,7 @@ namespace Duende.Bff.Tests.SessionManagement
     {
         InMemoryUserSessionStore _sessionStore = new InMemoryUserSessionStore();
 
-        public ServerSideTicketStoreTests()
+        public ServerSideTicketStoreTests(ITestOutputHelper output) : base(output)
         {
             BffHost.OnConfigureServices += services =>
             {

--- a/bff/test/Duende.Bff.Tests/TestFramework/GenericHost.cs
+++ b/bff/test/Duende.Bff.Tests/TestFramework/GenericHost.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Shouldly;
@@ -19,15 +19,12 @@ using System.Threading.Tasks;
 
 namespace Duende.Bff.Tests.TestFramework
 {
-    public class GenericHost
+    public class GenericHost(WriteTestOutput writeOutput, string baseAddress = "https://server")
     {
-        public GenericHost(string baseAddress = "https://server")
-        {
-            if (baseAddress.EndsWith("/")) baseAddress = baseAddress.Substring(0, baseAddress.Length - 1);
-            _baseAddress = baseAddress;
-        }
+        private readonly string _baseAddress = baseAddress.EndsWith("/")
+            ? baseAddress.Substring(0, baseAddress.Length - 1)
+            : baseAddress;
 
-        private readonly string _baseAddress;
         IServiceProvider _appServices;
 
         public Assembly HostAssembly { get; set; }
@@ -37,7 +34,7 @@ namespace Duende.Bff.Tests.TestFramework
         public TestBrowserClient BrowserClient { get; set; }
         public HttpClient HttpClient { get; set; }
 
-        public TestLoggerProvider Logger { get; set; } = new TestLoggerProvider();
+        public TestLoggerProvider Logger { get; set; } = new TestLoggerProvider(writeOutput, baseAddress + " - ");
 
 
         public T Resolve<T>()

--- a/bff/test/Duende.Bff.Tests/TestFramework/TestLoggerProvider.cs
+++ b/bff/test/Duende.Bff.Tests/TestFramework/TestLoggerProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Microsoft.Extensions.Logging;
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 
 namespace Duende.Bff.Tests.TestFramework
 {
-    public class TestLoggerProvider : ILoggerProvider
+    public class TestLoggerProvider(WriteTestOutput? writeOutput = null, string? name = null) : ILoggerProvider
     {
         public class DebugLogger : ILogger, IDisposable
         {
@@ -45,6 +45,7 @@ namespace Duende.Bff.Tests.TestFramework
 
         private void Log(string msg)
         {
+            writeOutput?.Invoke(name + msg);
             LogEntries.Add(msg);
         }
 
@@ -57,4 +58,6 @@ namespace Duende.Bff.Tests.TestFramework
         {
         }
     }
+
+    public delegate void WriteTestOutput(string message);
 }

--- a/bff/test/Duende.Bff.Tests/TestHosts/ApiHost.cs
+++ b/bff/test/Duende.Bff.Tests/TestHosts/ApiHost.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using System.Collections.Generic;
@@ -10,6 +10,7 @@ using Microsoft.Extensions.DependencyInjection;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using Duende.IdentityServer.Extensions;
 using Microsoft.AspNetCore.HttpOverrides;
 
 namespace Duende.Bff.Tests.TestHosts
@@ -21,8 +22,13 @@ namespace Duende.Bff.Tests.TestHosts
         private readonly IdentityServerHost _identityServerHost;
         private readonly bool _useForwardedHeaders;
 
-        public ApiHost(IdentityServerHost identityServerHost, string scope, string baseAddress = "https://api", bool useForwardedHeaders = false) 
-            : base(baseAddress)
+        public ApiHost(
+            WriteTestOutput output,
+            IdentityServerHost identityServerHost, 
+            string scope, 
+            string baseAddress = "https://api", 
+            bool useForwardedHeaders = false) 
+            : base(output, baseAddress)
         {
             _identityServerHost = identityServerHost;
             _useForwardedHeaders = useForwardedHeaders;

--- a/bff/test/Duende.Bff.Tests/TestHosts/BffHost.cs
+++ b/bff/test/Duende.Bff.Tests/TestHosts/BffHost.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Duende.Bff.Tests.TestFramework;
@@ -35,9 +35,14 @@ public class BffHost : GenericHost
 
     public BffOptions BffOptions { get; private set; }
 
-    public BffHost(IdentityServerHost identityServerHost, ApiHost apiHost, string clientId,
-        string baseAddress = "https://app", bool useForwardedHeaders = false)
-        : base(baseAddress)
+    public BffHost(
+        WriteTestOutput output,
+        IdentityServerHost identityServerHost, 
+        ApiHost apiHost, 
+        string clientId,
+        string baseAddress = "https://app", 
+        bool useForwardedHeaders = false)
+        : base(output, baseAddress)
     {
         _identityServerHost = identityServerHost;
         _apiHost = apiHost;

--- a/bff/test/Duende.Bff.Tests/TestHosts/BffHostUsingResourceNamedTokens.cs
+++ b/bff/test/Duende.Bff.Tests/TestHosts/BffHostUsingResourceNamedTokens.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Duende.Bff.Tests.TestFramework;
@@ -16,6 +16,7 @@ using Duende.Bff.Yarp;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Xunit.Abstractions;
 
 namespace Duende.Bff.Tests.TestHosts
 {
@@ -30,9 +31,14 @@ namespace Duende.Bff.Tests.TestHosts
 
         public BffOptions BffOptions { get; private set; }
 
-        public BffHostUsingResourceNamedTokens(IdentityServerHost identityServerHost, ApiHost apiHost, string clientId,
-            string baseAddress = "https://app", bool useForwardedHeaders = false)
-            : base(baseAddress)
+        public BffHostUsingResourceNamedTokens(
+            WriteTestOutput output,
+            IdentityServerHost identityServerHost, 
+            ApiHost apiHost, 
+            string clientId,
+            string baseAddress = "https://app", 
+            bool useForwardedHeaders = false)
+            : base(output, baseAddress)
         {
             _identityServerHost = identityServerHost;
             _apiHost = apiHost;

--- a/bff/test/Duende.Bff.Tests/TestHosts/BffIntegrationTestBase.cs
+++ b/bff/test/Duende.Bff.Tests/TestHosts/BffIntegrationTestBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Duende.IdentityServer.Models;
@@ -7,6 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using Xunit.Abstractions;
 
 namespace Duende.Bff.Tests.TestHosts
 {
@@ -17,9 +18,9 @@ namespace Duende.Bff.Tests.TestHosts
         protected BffHost BffHost;
         protected BffHostUsingResourceNamedTokens BffHostWithNamedTokens;
 
-        public BffIntegrationTestBase()
+        public BffIntegrationTestBase(ITestOutputHelper output)
         {
-            IdentityServerHost = new IdentityServerHost();
+            IdentityServerHost = new IdentityServerHost(output.WriteLine);
             
             IdentityServerHost.Clients.Add(new Client
             {
@@ -46,13 +47,13 @@ namespace Duende.Bff.Tests.TestHosts
             
             IdentityServerHost.InitializeAsync().Wait();
 
-            ApiHost = new ApiHost(IdentityServerHost, "scope1");
+            ApiHost = new ApiHost(output.WriteLine, IdentityServerHost, "scope1");
             ApiHost.InitializeAsync().Wait();
 
-            BffHost = new BffHost(IdentityServerHost, ApiHost, "spa");
+            BffHost = new BffHost(output.WriteLine, IdentityServerHost, ApiHost, "spa");
             BffHost.InitializeAsync().Wait();
 
-            BffHostWithNamedTokens = new BffHostUsingResourceNamedTokens(IdentityServerHost, ApiHost, "spa");
+            BffHostWithNamedTokens = new BffHostUsingResourceNamedTokens(output.WriteLine, IdentityServerHost, ApiHost, "spa");
             BffHostWithNamedTokens.InitializeAsync().Wait();
         }
 

--- a/bff/test/Duende.Bff.Tests/TestHosts/IdentityServerHost.cs
+++ b/bff/test/Duende.Bff.Tests/TestHosts/IdentityServerHost.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Duende.Bff.Tests.TestFramework;
@@ -18,8 +18,8 @@ namespace Duende.Bff.Tests.TestHosts;
 
 public class IdentityServerHost : GenericHost
 {
-    public IdentityServerHost(string baseAddress = "https://identityserver")
-        : base(baseAddress)
+    public IdentityServerHost(WriteTestOutput output, string baseAddress = "https://identityserver")
+        : base(output, baseAddress)
     {
         OnConfigureServices += ConfigureServices;
         OnConfigure += Configure;

--- a/bff/test/Duende.Bff.Tests/TestHosts/YarpBffHost.cs
+++ b/bff/test/Duende.Bff.Tests/TestHosts/YarpBffHost.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Duende.Bff.Tests.TestFramework;
@@ -34,9 +34,14 @@ namespace Duende.Bff.Tests.TestHosts
 
         public BffOptions BffOptions { get; private set; }
 
-        public YarpBffHost(IdentityServerHost identityServerHost, ApiHost apiHost, string clientId,
-            string baseAddress = "https://app", bool useForwardedHeaders = false)
-            : base(baseAddress)
+        public YarpBffHost(
+            WriteTestOutput output, 
+            IdentityServerHost identityServerHost, 
+            ApiHost apiHost, 
+            string clientId,
+            string baseAddress = "https://app", 
+            bool useForwardedHeaders = false)
+            : base(output, baseAddress)
         {
             _identityServerHost = identityServerHost;
             _apiHost = apiHost;

--- a/bff/test/Duende.Bff.Tests/TestHosts/YarpBffIntegrationTestBase.cs
+++ b/bff/test/Duende.Bff.Tests/TestHosts/YarpBffIntegrationTestBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Duende.IdentityServer.Models;
@@ -7,6 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using Xunit.Abstractions;
 
 namespace Duende.Bff.Tests.TestHosts
 {
@@ -17,9 +18,9 @@ namespace Duende.Bff.Tests.TestHosts
         protected readonly YarpBffHost BffHost;
         private BffHostUsingResourceNamedTokens _bffHostWithNamedTokens;
 
-        protected YarpBffIntegrationTestBase()
+        protected YarpBffIntegrationTestBase(ITestOutputHelper output)
         {
-            _identityServerHost = new IdentityServerHost();
+            _identityServerHost = new IdentityServerHost(output.WriteLine);
             
             _identityServerHost.Clients.Add(new Client
             {
@@ -44,13 +45,13 @@ namespace Duende.Bff.Tests.TestHosts
             
             _identityServerHost.InitializeAsync().Wait();
 
-            ApiHost = new ApiHost(_identityServerHost, "scope1");
+            ApiHost = new ApiHost(output.WriteLine, _identityServerHost, "scope1");
             ApiHost.InitializeAsync().Wait();
 
-            BffHost = new YarpBffHost(_identityServerHost, ApiHost, "spa");
+            BffHost = new YarpBffHost(output.WriteLine, _identityServerHost, ApiHost, "spa");
             BffHost.InitializeAsync().Wait();
 
-            _bffHostWithNamedTokens = new BffHostUsingResourceNamedTokens(_identityServerHost, ApiHost, "spa");
+            _bffHostWithNamedTokens = new BffHostUsingResourceNamedTokens(output.WriteLine, _identityServerHost, ApiHost, "spa");
             _bffHostWithNamedTokens.InitializeAsync().Wait();
         }
 


### PR DESCRIPTION
This PR ensures that all tests now write the HTTP logs to the output. 