### PR TITLE
Bff nullability in unit tests

### DIFF
--- a/bff/samples/Hosts.Tests/TestInfra/AppHostFixture.cs
+++ b/bff/samples/Hosts.Tests/TestInfra/AppHostFixture.cs
@@ -1,6 +1,10 @@
 using Aspire.Hosting;
 using Microsoft.Extensions.Logging;
+
+#if !DEBUG_NCRUNCH
 using Projects;
+#endif
+
 using Serilog;
 using Serilog.Core;
 using Serilog.Extensions.Logging;

--- a/bff/test/Duende.Bff.Blazor.Client.UnitTests/Duende.Bff.Blazor.Client.UnitTests.csproj
+++ b/bff/test/Duende.Bff.Blazor.Client.UnitTests/Duende.Bff.Blazor.Client.UnitTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -7,6 +7,7 @@
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/bff/test/Duende.Bff.Blazor.UnitTests/Duende.Bff.Blazor.UnitTests.csproj
+++ b/bff/test/Duende.Bff.Blazor.UnitTests/Duende.Bff.Blazor.UnitTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -7,6 +7,7 @@
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/bff/test/Duende.Bff.EntityFramework.Tests/Duende.Bff.EntityFramework.Tests.csproj
+++ b/bff/test/Duende.Bff.EntityFramework.Tests/Duende.Bff.EntityFramework.Tests.csproj
@@ -1,6 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <Nullable>enable</Nullable>
+        <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     </PropertyGroup>
 
     <ItemGroup>

--- a/bff/test/Duende.Bff.Tests/Duende.Bff.Tests.csproj
+++ b/bff/test/Duende.Bff.Tests/Duende.Bff.Tests.csproj
@@ -1,31 +1,33 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <Nullable>enable</Nullable>
+        <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Shouldly"/>
-    <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.visualstudio">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  
-    <PackageReference Include="Duende.IdentityServer" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" />
-    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Shouldly"/>
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Duende.Bff\Duende.Bff.csproj" />
-    <ProjectReference Include="..\..\src\Duende.Bff.Yarp\Duende.Bff.Yarp.csproj" />
-  </ItemGroup>
+        <PackageReference Include="Duende.IdentityServer" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
+        <PackageReference Include="Microsoft.AspNetCore.TestHost" />
+        <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Duende.Bff\Duende.Bff.csproj" />
+        <ProjectReference Include="..\..\src\Duende.Bff.Yarp\Duende.Bff.Yarp.csproj" />
+    </ItemGroup>
 
 </Project>

--- a/bff/test/Duende.Bff.Tests/Endpoints/Management/LoginEndpointTests.cs
+++ b/bff/test/Duende.Bff.Tests/Endpoints/Management/LoginEndpointTests.cs
@@ -38,16 +38,16 @@ namespace Duende.Bff.Tests.Endpoints.Management
         {
             var response = await BffHost.BrowserClient.GetAsync(BffHost.Url("/bff/login"));
             response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
-            response.Headers.Location.ToString().ShouldStartWith(IdentityServerHost.Url("/connect/authorize"));
+            response.Headers.Location!.ToString().ShouldStartWith(IdentityServerHost.Url("/connect/authorize"));
 
             await IdentityServerHost.IssueSessionCookieAsync("alice");
             response = await IdentityServerHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
             response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
-            response.Headers.Location.ToString().ShouldStartWith(BffHost.Url("/signin-oidc"));
+            response.Headers.Location!.ToString().ShouldStartWith(BffHost.Url("/signin-oidc"));
 
             response = await BffHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
             response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
-            response.Headers.Location.ToString().ShouldBe("/");
+            response.Headers.Location!.ToString().ShouldBe("/");
         }
         
         [Fact]
@@ -62,16 +62,16 @@ namespace Duende.Bff.Tests.Endpoints.Management
             
             var response = await BffHost.BrowserClient.GetAsync(BffHost.Url("/custom/bff/login"));
             response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
-            response.Headers.Location.ToString().ShouldStartWith(IdentityServerHost.Url("/connect/authorize"));
+            response.Headers.Location!.ToString().ShouldStartWith(IdentityServerHost.Url("/connect/authorize"));
 
             await IdentityServerHost.IssueSessionCookieAsync("alice");
             response = await IdentityServerHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
             response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
-            response.Headers.Location.ToString().ShouldStartWith(BffHost.Url("/signin-oidc"));
+            response.Headers.Location!.ToString().ShouldStartWith(BffHost.Url("/signin-oidc"));
 
             response = await BffHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
             response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
-            response.Headers.Location.ToString().ShouldBe("/");
+            response.Headers.Location!.ToString().ShouldBe("/");
         }
         
         [Fact]
@@ -86,16 +86,16 @@ namespace Duende.Bff.Tests.Endpoints.Management
             
             var response = await BffHost.BrowserClient.GetAsync(BffHost.Url("/custom/bff/login"));
             response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
-            response.Headers.Location.ToString().ShouldStartWith(IdentityServerHost.Url("/connect/authorize"));
+            response.Headers.Location!.ToString().ShouldStartWith(IdentityServerHost.Url("/connect/authorize"));
 
             await IdentityServerHost.IssueSessionCookieAsync("alice");
             response = await IdentityServerHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
             response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
-            response.Headers.Location.ToString().ShouldStartWith(BffHost.Url("/signin-oidc"));
+            response.Headers.Location!.ToString().ShouldStartWith(BffHost.Url("/signin-oidc"));
 
             response = await BffHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
             response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
-            response.Headers.Location.ToString().ShouldBe("/");
+            response.Headers.Location!.ToString().ShouldBe("/");
         }
         
         [Fact]
@@ -110,16 +110,16 @@ namespace Duende.Bff.Tests.Endpoints.Management
             
             var response = await BffHost.BrowserClient.GetAsync(BffHost.Url("/login"));
             response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
-            response.Headers.Location.ToString().ShouldStartWith(IdentityServerHost.Url("/connect/authorize"));
+            response.Headers.Location!.ToString().ShouldStartWith(IdentityServerHost.Url("/connect/authorize"));
 
             await IdentityServerHost.IssueSessionCookieAsync("alice");
             response = await IdentityServerHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
             response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
-            response.Headers.Location.ToString().ShouldStartWith(BffHost.Url("/signin-oidc"));
+            response.Headers.Location!.ToString().ShouldStartWith(BffHost.Url("/signin-oidc"));
 
             response = await BffHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
             response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
-            response.Headers.Location.ToString().ShouldBe("/");
+            response.Headers.Location!.ToString().ShouldBe("/");
         }
         
         [Fact]
@@ -129,7 +129,7 @@ namespace Duende.Bff.Tests.Endpoints.Management
 
             var response = await BffHost.BrowserClient.GetAsync(BffHost.Url("/bff/login"));
             response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
-            response.Headers.Location.ToString().ShouldStartWith(IdentityServerHost.Url("/connect/authorize"));
+            response.Headers.Location!.ToString().ShouldStartWith(IdentityServerHost.Url("/connect/authorize"));
         }
 
         [Fact]
@@ -137,16 +137,16 @@ namespace Duende.Bff.Tests.Endpoints.Management
         {
             var response = await BffHost.BrowserClient.GetAsync(BffHost.Url("/bff/login") + "?returnUrl=/foo");
             response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
-            response.Headers.Location.ToString().ShouldStartWith(IdentityServerHost.Url("/connect/authorize"));
+            response.Headers.Location!.ToString().ShouldStartWith(IdentityServerHost.Url("/connect/authorize"));
 
             await IdentityServerHost.IssueSessionCookieAsync("alice");
             response = await IdentityServerHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
             response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
-            response.Headers.Location.ToString().ShouldStartWith(BffHost.Url("/signin-oidc"));
+            response.Headers.Location!.ToString().ShouldStartWith(BffHost.Url("/signin-oidc"));
 
             response = await BffHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
             response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
-            response.Headers.Location.ToString().ShouldBe("/foo");
+            response.Headers.Location!.ToString().ShouldBe("/foo");
         }
 
         [Fact]

--- a/bff/test/Duende.Bff.Tests/Endpoints/Management/LogoutEndpointTests.cs
+++ b/bff/test/Duende.Bff.Tests/Endpoints/Management/LogoutEndpointTests.cs
@@ -63,7 +63,7 @@ namespace Duende.Bff.Tests.Endpoints.Management
 
             var response = await BffHost.BrowserClient.GetAsync(BffHost.Url("/bff/logout"));
             response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // endsession
-            response.Headers.Location.ToString().ToLowerInvariant().ShouldStartWith(IdentityServerHost.Url("/connect/endsession"));
+            response.Headers.Location!.ToString().ToLowerInvariant().ShouldStartWith(IdentityServerHost.Url("/connect/endsession"));
         }
 
         [Fact]
@@ -81,7 +81,7 @@ namespace Duende.Bff.Tests.Endpoints.Management
 
             var response = await BffHost.BrowserClient.GetAsync(BffHost.Url("/bff/logout"));
             response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // endsession
-            response.Headers.Location.ToString().ToLowerInvariant().ShouldStartWith(IdentityServerHost.Url("/connect/endsession"));
+            response.Headers.Location!.ToString().ToLowerInvariant().ShouldStartWith(IdentityServerHost.Url("/connect/endsession"));
         }
 
         [Fact]
@@ -89,7 +89,7 @@ namespace Duende.Bff.Tests.Endpoints.Management
         {
             var response = await BffHost.BrowserClient.GetAsync(BffHost.Url("/bff/logout"));
             response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // endsession
-            response.Headers.Location.ToString().ToLowerInvariant().ShouldStartWith(IdentityServerHost.Url("/connect/endsession"));
+            response.Headers.Location!.ToString().ToLowerInvariant().ShouldStartWith(IdentityServerHost.Url("/connect/endsession"));
         }
 
         [Fact]
@@ -99,7 +99,12 @@ namespace Duende.Bff.Tests.Endpoints.Management
             
             await BffHost.BffLogoutAsync("sid123");
             
-            BffHost.BrowserClient.CurrentUri.ToString().ToLowerInvariant().ShouldBe(BffHost.Url("/"));
+            BffHost.BrowserClient.CurrentUri
+                .ShouldNotBeNull()
+                .ToString()
+                .ToLowerInvariant()
+                .ShouldBe(BffHost.Url("/"));
+
             (await BffHost.GetIsUserLoggedInAsync()).ShouldBeFalse();
         }
 
@@ -110,19 +115,19 @@ namespace Duende.Bff.Tests.Endpoints.Management
 
             var response = await BffHost.BrowserClient.GetAsync(BffHost.Url("/bff/logout") + "?sid=sid123&returnUrl=/foo");
             response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // endsession
-            response.Headers.Location.ToString().ToLowerInvariant().ShouldStartWith(IdentityServerHost.Url("/connect/endsession"));
+            response.Headers.Location!.ToString().ToLowerInvariant().ShouldStartWith(IdentityServerHost.Url("/connect/endsession"));
 
-            response = await IdentityServerHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
+            response = await IdentityServerHost.BrowserClient.GetAsync(response.Headers.Location!.ToString());
             response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // logout
-            response.Headers.Location.ToString().ToLowerInvariant().ShouldStartWith(IdentityServerHost.Url("/account/logout"));
+            response.Headers.Location!.ToString().ToLowerInvariant().ShouldStartWith(IdentityServerHost.Url("/account/logout"));
 
-            response = await IdentityServerHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
+            response = await IdentityServerHost.BrowserClient.GetAsync(response.Headers.Location!.ToString());
             response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // post logout redirect uri
-            response.Headers.Location.ToString().ToLowerInvariant().ShouldStartWith(BffHost.Url("/signout-callback-oidc"));
+            response.Headers.Location!.ToString().ToLowerInvariant().ShouldStartWith(BffHost.Url("/signout-callback-oidc"));
 
-            response = await BffHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
+            response = await BffHost.BrowserClient.GetAsync(response.Headers.Location!.ToString());
             response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // root
-            response.Headers.Location.ToString().ToLowerInvariant().ShouldBe("/foo");
+            response.Headers.Location!.ToString().ToLowerInvariant().ShouldBe("/foo");
         }
 
         [Fact]

--- a/bff/test/Duende.Bff.Tests/Endpoints/Management/UserEndpointTests.cs
+++ b/bff/test/Duende.Bff.Tests/Endpoints/Management/UserEndpointTests.cs
@@ -74,12 +74,12 @@ namespace Duende.Bff.Tests.Endpoints.Management
         }
 
         [Fact]
-        public async Task when_configured_user_endpoint_for_unauthenticated_user_should_return_200_and_null()
+        public async Task when_configured_user_endpoint_for_unauthenticated_user_should_return_200_and_empty()
         {
             BffHost.BffOptions.AnonymousSessionResponse = AnonymousSessionResponse.Response200;
 
             var data = await BffHost.CallUserEndpointAsync();
-            data.ShouldBeNull();
+            data.ShouldBeEmpty();
         }
     }
 }

--- a/bff/test/Duende.Bff.Tests/Endpoints/YarpRemoteEndpointTests.cs
+++ b/bff/test/Duende.Bff.Tests/Endpoints/YarpRemoteEndpointTests.cs
@@ -4,9 +4,7 @@
 using Duende.Bff.Tests.TestHosts;
 using System.Net;
 using System.Net.Http;
-using System.Text.Json;
 using System.Threading.Tasks;
-using Duende.Bff.Tests.TestFramework;
 using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
@@ -18,12 +16,12 @@ namespace Duende.Bff.Tests.Endpoints
         [Fact]
         public async Task anonymous_call_with_no_csrf_header_to_no_token_requirement_no_csrf_route_should_succeed()
         {
-            var req = new HttpRequestMessage(HttpMethod.Get, BffHost.Url("/api_anon_no_csrf/test"));
-            var response = await BffHost.BrowserClient.SendAsync(req);
-
-            response.StatusCode.ShouldBe(HttpStatusCode.OK);
+            await BffHost.BrowserClient.CallBffHostApi(
+                url: BffHost.Url("/api_anon_no_csrf/test"),
+                expectedStatusCode: HttpStatusCode.OK
+            );
         }
-        
+
         [Fact]
         public async Task anonymous_call_with_no_csrf_header_to_csrf_route_should_fail()
         {
@@ -32,38 +30,33 @@ namespace Duende.Bff.Tests.Endpoints
 
             response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
         }
-        
+
+
         [Fact]
         public async Task anonymous_call_to_no_token_requirement_route_should_succeed()
         {
-            var req = new HttpRequestMessage(HttpMethod.Get, BffHost.Url("/api_anon/test"));
-            req.Headers.Add("x-csrf", "1");
-            var response = await BffHost.BrowserClient.SendAsync(req);
-
-            response.StatusCode.ShouldBe(HttpStatusCode.OK);
+            await BffHost.BrowserClient.CallBffHostApi(
+                url: BffHost.Url("/api_anon/test"),
+                expectedStatusCode: HttpStatusCode.OK
+            );
         }
-        
+
         [Fact]
         public async Task anonymous_call_to_user_token_requirement_route_should_fail()
         {
-            var req = new HttpRequestMessage(HttpMethod.Get, BffHost.Url("/api_user/test"));
-            req.Headers.Add("x-csrf", "1");
-            var response = await BffHost.BrowserClient.SendAsync(req);
-
-            response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+            await BffHost.BrowserClient.CallBffHostApi(
+                url: BffHost.Url("/api_user/test"),
+                expectedStatusCode: HttpStatusCode.Unauthorized
+            );
         }
 
         [Fact]
         public async Task anonymous_call_to_optional_user_token_route_should_succeed()
         {
-            var req = new HttpRequestMessage(HttpMethod.Get, BffHost.Url("/api_optional_user/test"));
-            req.Headers.Add("x-csrf", "1");
-            var response = await BffHost.BrowserClient.SendAsync(req);
+            var apiResult = await BffHost.BrowserClient.CallBffHostApi(
+                url: BffHost.Url("/api_optional_user/test")
+            );
 
-            response.IsSuccessStatusCode.ShouldBeTrue();
-            response.Content.Headers.ContentType.MediaType.ShouldBe("application/json");
-            var json = await response.Content.ReadAsStringAsync();
-            var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
             apiResult.Method.ShouldBe("GET");
             apiResult.Path.ShouldBe("/api_optional_user/test");
             apiResult.Sub.ShouldBeNull();
@@ -76,36 +69,29 @@ namespace Duende.Bff.Tests.Endpoints
         public async Task authenticated_GET_should_forward_user_to_api(string route)
         {
             await BffHost.BffLoginAsync("alice");
-        
-            var req = new HttpRequestMessage(HttpMethod.Get, BffHost.Url(route));
-            req.Headers.Add("x-csrf", "1");
-            var response = await BffHost.BrowserClient.SendAsync(req);
-        
-            response.IsSuccessStatusCode.ShouldBeTrue();
-            response.Content.Headers.ContentType.MediaType.ShouldBe("application/json");
-            var json = await response.Content.ReadAsStringAsync();
-            var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
+
+            var apiResult = await BffHost.BrowserClient.CallBffHostApi(
+                url: BffHost.Url(route)
+            );
+
             apiResult.Method.ShouldBe("GET");
             apiResult.Path.ShouldBe(route);
             apiResult.Sub.ShouldBe("alice");
             apiResult.ClientId.ShouldBe("spa");
         }
-        
+
         [Theory]
         [InlineData("/api_user/test")]
         [InlineData("/api_optional_user/test")]
         public async Task authenticated_PUT_should_forward_user_to_api(string route)
         {
             await BffHost.BffLoginAsync("alice");
-        
-            var req = new HttpRequestMessage(HttpMethod.Put, BffHost.Url(route));
-            req.Headers.Add("x-csrf", "1");
-            var response = await BffHost.BrowserClient.SendAsync(req);
-        
-            response.IsSuccessStatusCode.ShouldBeTrue();
-            response.Content.Headers.ContentType.MediaType.ShouldBe("application/json");
-            var json = await response.Content.ReadAsStringAsync();
-            var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
+
+            var apiResult = await BffHost.BrowserClient.CallBffHostApi(
+                url: BffHost.Url(route),
+                method: HttpMethod.Put
+            );
+
             apiResult.Method.ShouldBe("PUT");
             apiResult.Path.ShouldBe(route);
             apiResult.Sub.ShouldBe("alice");
@@ -118,109 +104,92 @@ namespace Duende.Bff.Tests.Endpoints
         public async Task authenticated_POST_should_forward_user_to_api(string route)
         {
             await BffHost.BffLoginAsync("alice");
-        
-            var req = new HttpRequestMessage(HttpMethod.Post, BffHost.Url(route));
-            req.Headers.Add("x-csrf", "1");
-            var response = await BffHost.BrowserClient.SendAsync(req);
-        
-            response.IsSuccessStatusCode.ShouldBeTrue();
-            response.Content.Headers.ContentType.MediaType.ShouldBe("application/json");
-            var json = await response.Content.ReadAsStringAsync();
-            var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
+
+            var apiResult = await BffHost.BrowserClient.CallBffHostApi(
+                url: BffHost.Url(route),
+                method: HttpMethod.Post
+            );
+
             apiResult.Method.ShouldBe("POST");
             apiResult.Path.ShouldBe(route);
             apiResult.Sub.ShouldBe("alice");
             apiResult.ClientId.ShouldBe("spa");
         }
-        
+
         [Fact]
         public async Task call_to_client_token_route_should_forward_client_token_to_api()
         {
             await BffHost.BffLoginAsync("alice");
-        
-            var req = new HttpRequestMessage(HttpMethod.Get, BffHost.Url("/api_client/test"));
-            req.Headers.Add("x-csrf", "1");
-            var response = await BffHost.BrowserClient.SendAsync(req);
-        
-            response.IsSuccessStatusCode.ShouldBeTrue();
-            response.Content.Headers.ContentType.MediaType.ShouldBe("application/json");
-            var json = await response.Content.ReadAsStringAsync();
-            var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
+
+            var apiResult = await BffHost.BrowserClient.CallBffHostApi(
+                url: BffHost.Url("/api_client/test")
+            );
+
             apiResult.Method.ShouldBe("GET");
             apiResult.Path.ShouldBe("/api_client/test");
             apiResult.Sub.ShouldBeNull();
             apiResult.ClientId.ShouldBe("spa");
         }
-        
+
         [Fact]
         public async Task call_to_user_or_client_token_route_should_forward_user_or_client_token_to_api()
         {
             {
-                var req = new HttpRequestMessage(HttpMethod.Get, BffHost.Url("/api_user_or_client/test"));
-                req.Headers.Add("x-csrf", "1");
-                var response = await BffHost.BrowserClient.SendAsync(req);
-        
-                response.IsSuccessStatusCode.ShouldBeTrue();
-                response.Content.Headers.ContentType.MediaType.ShouldBe("application/json");
-                var json = await response.Content.ReadAsStringAsync();
-                var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
+                var apiResult = await BffHost.BrowserClient.CallBffHostApi(
+                    url: BffHost.Url("/api_user_or_client/test")
+                );
+
                 apiResult.Method.ShouldBe("GET");
                 apiResult.Path.ShouldBe("/api_user_or_client/test");
                 apiResult.Sub.ShouldBeNull();
                 apiResult.ClientId.ShouldBe("spa");
             }
-        
+
             {
                 await BffHost.BffLoginAsync("alice");
-        
-                var req = new HttpRequestMessage(HttpMethod.Get, BffHost.Url("/api_user_or_client/test"));
-                req.Headers.Add("x-csrf", "1");
-                var response = await BffHost.BrowserClient.SendAsync(req);
-        
-                response.IsSuccessStatusCode.ShouldBeTrue();
-                response.Content.Headers.ContentType.MediaType.ShouldBe("application/json");
-                var json = await response.Content.ReadAsStringAsync();
-                var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
+
+                var apiResult = await BffHost.BrowserClient.CallBffHostApi(
+                    url: BffHost.Url("/api_user_or_client/test")
+                );
+
                 apiResult.Method.ShouldBe("GET");
                 apiResult.Path.ShouldBe("/api_user_or_client/test");
                 apiResult.Sub.ShouldBe("alice");
                 apiResult.ClientId.ShouldBe("spa");
             }
         }
-        
+
         [Fact]
         public async Task response_status_401_from_remote_endpoint_should_return_401_from_bff()
         {
             await BffHost.BffLoginAsync("alice");
             ApiHost.ApiStatusCodeToReturn = 401;
-        
-            var req = new HttpRequestMessage(HttpMethod.Get, BffHost.Url("/api_user/test"));
-            req.Headers.Add("x-csrf", "1");
-            var response = await BffHost.BrowserClient.SendAsync(req);
-        
-            response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+
+            var response = await BffHost.BrowserClient.CallBffHostApi(
+                url: BffHost.Url("/api_user/test"),
+                expectedStatusCode: HttpStatusCode.Unauthorized
+            );
         }
-        
+
         [Fact]
         public async Task response_status_403_from_remote_endpoint_should_return_403_from_bff()
         {
             await BffHost.BffLoginAsync("alice");
             ApiHost.ApiStatusCodeToReturn = 403;
-        
-            var req = new HttpRequestMessage(HttpMethod.Get, BffHost.Url("/api_user/test"));
-            req.Headers.Add("x-csrf", "1");
-            var response = await BffHost.BrowserClient.SendAsync(req);
-        
-            response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+
+            var response = await BffHost.BrowserClient.CallBffHostApi(
+                url: BffHost.Url("/api_user/test"),
+                expectedStatusCode: HttpStatusCode.Forbidden
+            );
         }
 
         [Fact]
         public async Task invalid_configuration_of_routes_should_return_500()
         {
-            var req = new HttpRequestMessage(HttpMethod.Get, BffHost.Url("/api_invalid/test"));
-            var response = await BffHost.BrowserClient.SendAsync(req);
-        
-            response.StatusCode.ShouldBe(HttpStatusCode.InternalServerError);
+            var response = await BffHost.BrowserClient.CallBffHostApi(
+                url: BffHost.Url("/api_invalid/test"),
+                expectedStatusCode: HttpStatusCode.InternalServerError
+            );
         }
     }
 }

--- a/bff/test/Duende.Bff.Tests/Headers/ApiAndBffUseForwardedHeaders.cs
+++ b/bff/test/Duende.Bff.Tests/Headers/ApiAndBffUseForwardedHeaders.cs
@@ -14,13 +14,10 @@ namespace Duende.Bff.Tests.Headers
     {
         public ApiAndBffUseForwardedHeaders(ITestOutputHelper output) : base(output)
         {
-            ApiHost = new ApiHost(output.WriteLine, IdentityServerHost, "scope1", useForwardedHeaders: true);
-            ApiHost.InitializeAsync().Wait();
-
-            BffHost = new BffHost(output.WriteLine, IdentityServerHost, ApiHost, "spa", useForwardedHeaders: true);
-            BffHost.InitializeAsync().Wait();
+            BffHost.UseForwardedHeaders = true;
+            ApiHost.UseForwardedHeaders = true;
         }
-        
+
         [Fact]
         public async Task bff_host_name_should_propagate_to_api()
         {
@@ -30,7 +27,7 @@ namespace Duende.Bff.Tests.Headers
 
             response.IsSuccessStatusCode.ShouldBeTrue();
             var json = await response.Content.ReadAsStringAsync();
-            var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
+            var apiResult = JsonSerializer.Deserialize<ApiResponse>(json).ShouldNotBeNull();
 
             var host = apiResult.RequestHeaders["Host"].Single();
             host.ShouldBe("app");
@@ -48,7 +45,7 @@ namespace Duende.Bff.Tests.Headers
 
             response.IsSuccessStatusCode.ShouldBeTrue();
             var json = await response.Content.ReadAsStringAsync();
-            var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
+            var apiResult = JsonSerializer.Deserialize<ApiResponse>(json).ShouldNotBeNull();
 
             var host = apiResult.RequestHeaders["Host"].Single();
             host.ShouldBe("external");
@@ -66,7 +63,7 @@ namespace Duende.Bff.Tests.Headers
 
             response.IsSuccessStatusCode.ShouldBeTrue();
             var json = await response.Content.ReadAsStringAsync();
-            var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
+            var apiResult = JsonSerializer.Deserialize<ApiResponse>(json).ShouldNotBeNull();
 
             var host = apiResult.RequestHeaders["Host"].Single();
             host.ShouldBe("external");

--- a/bff/test/Duende.Bff.Tests/Headers/ApiUseForwardedHeaders.cs
+++ b/bff/test/Duende.Bff.Tests/Headers/ApiUseForwardedHeaders.cs
@@ -14,13 +14,9 @@ namespace Duende.Bff.Tests.Headers
     {
         public ApiUseForwardedHeaders(ITestOutputHelper output) : base(output)
         {
-            ApiHost = new ApiHost(output.WriteLine, IdentityServerHost, "scope1", useForwardedHeaders: true);
-            ApiHost.InitializeAsync().Wait();
-
-            BffHost = new BffHost(output.WriteLine, IdentityServerHost, ApiHost, "spa", useForwardedHeaders: false);
-            BffHost.InitializeAsync().Wait();
+            ApiHost.UseForwardedHeaders = true;
         }
-        
+
         [Fact]
         public async Task bff_host_name_should_propagate_to_api()
         {
@@ -30,7 +26,7 @@ namespace Duende.Bff.Tests.Headers
 
             response.IsSuccessStatusCode.ShouldBeTrue();
             var json = await response.Content.ReadAsStringAsync();
-            var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
+            var apiResult = JsonSerializer.Deserialize<ApiResponse>(json).ShouldNotBeNull();
 
             var host = apiResult.RequestHeaders["Host"].Single();
             host.ShouldBe("app");
@@ -46,7 +42,7 @@ namespace Duende.Bff.Tests.Headers
 
             response.IsSuccessStatusCode.ShouldBeTrue();
             var json = await response.Content.ReadAsStringAsync();
-            var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
+            var apiResult = JsonSerializer.Deserialize<ApiResponse>(json).ShouldNotBeNull();
 
             var host = apiResult.RequestHeaders["Host"].Single();
             host.ShouldBe("app");

--- a/bff/test/Duende.Bff.Tests/Headers/General.cs
+++ b/bff/test/Duende.Bff.Tests/Headers/General.cs
@@ -21,7 +21,7 @@ namespace Duende.Bff.Tests.Headers
 
             response.IsSuccessStatusCode.ShouldBeTrue();
             var json = await response.Content.ReadAsStringAsync();
-            var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
+            var apiResult = JsonSerializer.Deserialize<ApiResponse>(json).ShouldNotBeNull();
 
             apiResult.RequestHeaders.Count.ShouldBe(2);
             apiResult.RequestHeaders["Host"].Single().ShouldBe("app");
@@ -40,7 +40,7 @@ namespace Duende.Bff.Tests.Headers
 
             response.IsSuccessStatusCode.ShouldBeTrue();
             var json = await response.Content.ReadAsStringAsync();
-            var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
+            var apiResult = JsonSerializer.Deserialize<ApiResponse>(json).ShouldNotBeNull();
 
             apiResult.RequestHeaders["Host"].Single().ShouldBe("api");
             apiResult.RequestHeaders["x-custom"].Single().ShouldBe("custom");
@@ -58,7 +58,7 @@ namespace Duende.Bff.Tests.Headers
 
             response.IsSuccessStatusCode.ShouldBeTrue();
             var json = await response.Content.ReadAsStringAsync();
-            var apiResult = JsonSerializer.Deserialize<ApiResponse>(json);
+            var apiResult = JsonSerializer.Deserialize<ApiResponse>(json).ShouldNotBeNull();
             
             apiResult.RequestHeaders["X-Forwarded-Host"].Single().ShouldBe("app");
             apiResult.RequestHeaders["X-Forwarded-Proto"].Single().ShouldBe("https");

--- a/bff/test/Duende.Bff.Tests/SessionManagement/CookieSlidingTests.cs
+++ b/bff/test/Duende.Bff.Tests/SessionManagement/CookieSlidingTests.cs
@@ -17,8 +17,8 @@ namespace Duende.Bff.Tests.SessionManagement
 {
     public class CookieSlidingTests : BffIntegrationTestBase
     {
-        InMemoryUserSessionStore _sessionStore = new InMemoryUserSessionStore();
-        FakeTimeProvider _clock = new(DateTime.UtcNow);
+        readonly InMemoryUserSessionStore _sessionStore = new();
+        readonly FakeTimeProvider _clock = new(DateTime.UtcNow);
 
         public CookieSlidingTests(ITestOutputHelper output) : base(output)
         {
@@ -32,7 +32,6 @@ namespace Duende.Bff.Tests.SessionManagement
                 });
                 services.AddSingleton<TimeProvider>(_clock);
             };
-            BffHost.InitializeAsync().Wait();
         }
 
         private void SetClock(TimeSpan t)

--- a/bff/test/Duende.Bff.Tests/SessionManagement/ServerSideTicketStoreTests.cs
+++ b/bff/test/Duende.Bff.Tests/SessionManagement/ServerSideTicketStoreTests.cs
@@ -13,7 +13,7 @@ namespace Duende.Bff.Tests.SessionManagement
 {
     public class ServerSideTicketStoreTests : BffIntegrationTestBase
     {
-        InMemoryUserSessionStore _sessionStore = new InMemoryUserSessionStore();
+        readonly InMemoryUserSessionStore _sessionStore = new();
 
         public ServerSideTicketStoreTests(ITestOutputHelper output) : base(output)
         {
@@ -21,7 +21,6 @@ namespace Duende.Bff.Tests.SessionManagement
             {
                 services.AddSingleton<IUserSessionStore>(_sessionStore);
             };
-            BffHost.InitializeAsync().Wait();
         }
 
         [Fact]

--- a/bff/test/Duende.Bff.Tests/TestFramework/ApiResponse.cs
+++ b/bff/test/Duende.Bff.Tests/TestFramework/ApiResponse.cs
@@ -1,14 +1,23 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
+using System;
 using System.Collections.Generic;
+using System.Text.Json;
+using Shouldly;
 
 namespace Duende.Bff.Tests.TestFramework
 {
-    public record ApiResponse(string Method, string Path, string Sub, string ClientId, IEnumerable<ClaimRecord> Claims)
+    public record ApiResponse(string Method, string Path, string? Sub, string? ClientId, IEnumerable<ClaimRecord> Claims)
     {
-        public string Body { get; init; }
+        public required string? Body { get; init; }
 
-        public Dictionary<string, List<string>> RequestHeaders { get; init; }
+        public Dictionary<string, List<string>> RequestHeaders { get; init; } = new();
+
+        public T BodyAs<T>()
+        {
+            Body.ShouldNotBeNull();
+            return JsonSerializer.Deserialize<T>(Body, TestSerializerOptions.Default) ?? throw new NullReferenceException($"result {Body} could not be deserialized to {typeof(T).Name}");
+        }
     }
 }

--- a/bff/test/Duende.Bff.Tests/TestFramework/MockExternalAuthenticationHandler.cs
+++ b/bff/test/Duende.Bff.Tests/TestFramework/MockExternalAuthenticationHandler.cs
@@ -1,70 +1,56 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
-using Duende.Bff.Tests.TestFramework;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using System;
-using System.Text.Encodings.Web;
-using System.Threading.Tasks;
 
-namespace Duende.Bff.Tests.TestFramework
+namespace Duende.Bff.Tests.TestFramework;
+
+public class MockExternalAuthenticationHandler : RemoteAuthenticationHandler<MockExternalAuthenticationOptions>,
+    IAuthenticationSignOutHandler
 {
-    public class MockExternalAuthenticationHandler : RemoteAuthenticationHandler<MockExternalAuthenticationOptions>, IAuthenticationSignOutHandler
+    public MockExternalAuthenticationHandler(
+        IOptionsMonitor<MockExternalAuthenticationOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
-        public MockExternalAuthenticationHandler(
-            IOptionsMonitor<MockExternalAuthenticationOptions> options, 
-            ILoggerFactory logger, 
-            UrlEncoder encoder) 
-            : base(options, logger, encoder)
-        {
-        }
-
-        public bool ChallengeWasCalled { get; set; }
-        public AuthenticationProperties ChallengeAuthenticationProperties { get; set; }
-        protected override Task HandleChallengeAsync(AuthenticationProperties properties)
-        {
-            ChallengeWasCalled = true;
-            ChallengeAuthenticationProperties = properties;
-            return Task.CompletedTask;
-        }
-
-        protected override Task<HandleRequestResult> HandleRemoteAuthenticateAsync()
-        {
-            var result = HandleRequestResult.NoResult();
-            return Task.FromResult(result);
-        }
-
-        public bool SignOutWasCalled { get; set; }
-        public AuthenticationProperties SignOutAuthenticationProperties { get; set; }
-        public Task SignOutAsync(AuthenticationProperties properties)
-        {
-            SignOutWasCalled = true;
-            SignOutAuthenticationProperties = properties;
-            return Task.CompletedTask;
-        }
     }
 
-    public class MockExternalAuthenticationOptions : RemoteAuthenticationOptions
+    public bool ChallengeWasCalled { get; set; } = false;
+    public AuthenticationProperties? ChallengeAuthenticationProperties { get; set; }
+
+    protected override Task HandleChallengeAsync(AuthenticationProperties properties)
     {
-        public MockExternalAuthenticationOptions()
-        {
-            CallbackPath = "/external-callback";
-        }
+        ChallengeWasCalled = true;
+        ChallengeAuthenticationProperties = properties;
+        return Task.CompletedTask;
+    }
+
+    protected override Task<HandleRequestResult> HandleRemoteAuthenticateAsync()
+    {
+        var result = HandleRequestResult.NoResult();
+        return Task.FromResult(result);
+    }
+
+    public bool SignOutWasCalled { get; set; }
+    public AuthenticationProperties? SignOutAuthenticationProperties { get; set; }
+
+    public Task SignOutAsync(AuthenticationProperties? properties)
+    {
+        SignOutWasCalled = true;
+        SignOutAuthenticationProperties = properties;
+        return Task.CompletedTask;
     }
 }
 
-namespace Microsoft.Extensions.DependencyInjection
+public class MockExternalAuthenticationOptions : RemoteAuthenticationOptions
 {
-    public static class MockExternalAuthenticationExtensions
+    public MockExternalAuthenticationOptions()
     {
-        public static AuthenticationBuilder AddMockExternalAuthentication(this AuthenticationBuilder builder,
-            string authenticationScheme = "external",
-            string displayName = "external",
-            Action<MockExternalAuthenticationOptions> configureOptions = null)
-        {
-            return builder.AddRemoteScheme<MockExternalAuthenticationOptions, MockExternalAuthenticationHandler>(authenticationScheme, displayName, configureOptions);
-        }
+        CallbackPath = "/external-callback";
     }
 }

--- a/bff/test/Duende.Bff.Tests/TestFramework/MockSessionRevocationService.cs
+++ b/bff/test/Duende.Bff.Tests/TestFramework/MockSessionRevocationService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using System.Threading;
@@ -9,7 +9,7 @@ namespace Duende.Bff.Tests.TestFramework
     public class MockSessionRevocationService : ISessionRevocationService
     {
         public bool DeleteUserSessionsWasCalled { get; set; }
-        public UserSessionsFilter DeleteUserSessionsFilter { get; set; }
+        public UserSessionsFilter? DeleteUserSessionsFilter { get; set; }
         public Task RevokeSessionsAsync(UserSessionsFilter filter, CancellationToken cancellationToken)
         {
             DeleteUserSessionsWasCalled = true;

--- a/bff/test/Duende.Bff.Tests/TestFramework/Records.cs
+++ b/bff/test/Duende.Bff.Tests/TestFramework/Records.cs
@@ -9,18 +9,18 @@ namespace Duende.Bff.Tests.TestFramework
     public record JsonRecord(string Type, JsonElement Value)
     {
         [JsonPropertyName("type")]
-        public string Type { get; init; } = Type;
+        public string Type { get; } = Type;
 
         [JsonPropertyName("value")]
-        public JsonElement Value { get; init; } = Value;
+        public JsonElement Value { get; } = Value;
     }
 
     public record ClaimRecord(string Type, string Value)
     {
         [JsonPropertyName("type")]
-        public string Type { get; init; } = Type;
+        public string Type { get; } = Type;
 
         [JsonPropertyName("value")]
-        public string Value { get; init; } = Value;
+        public string Value { get; } = Value;
     }
 }

--- a/bff/test/Duende.Bff.Tests/TestFramework/TestBrowserClient.cs
+++ b/bff/test/Duende.Bff.Tests/TestFramework/TestBrowserClient.cs
@@ -1,79 +1,150 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using System;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Shouldly;
 
-namespace Duende.Bff.Tests.TestFramework
+namespace Duende.Bff.Tests.TestFramework;
+
+public class TestBrowserClient : HttpClient
 {
-    public class TestBrowserClient : HttpClient
+    private class CookieHandler(HttpMessageHandler next) : DelegatingHandler(next)
     {
-        class CookieHandler : DelegatingHandler
-        {
-            public CookieContainer CookieContainer { get; } = new CookieContainer();
-            public Uri CurrentUri { get; private set; }
-            public HttpResponseMessage LastResponse { get; private set; }
+        public CookieContainer CookieContainer { get; } = new();
+        public Uri? CurrentUri { get; private set; }
+        public HttpResponseMessage? LastResponse { get; private set; }
 
-            public CookieHandler(HttpMessageHandler next)
-                : base(next)
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            CurrentUri = request.RequestUri ?? throw new NullReferenceException("RequestUri is not set");
+            var cookieHeader = CookieContainer.GetCookieHeader(request.RequestUri);
+            if (!string.IsNullOrEmpty(cookieHeader))
             {
+                request.Headers.Add("Cookie", cookieHeader);
             }
 
-            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            var response = await base.SendAsync(request, cancellationToken);
+
+            if (response.Headers.Contains("Set-Cookie"))
             {
-                CurrentUri = request.RequestUri;
-                string cookieHeader = CookieContainer.GetCookieHeader(request.RequestUri);
-                if (!string.IsNullOrEmpty(cookieHeader))
-                {
-                    request.Headers.Add("Cookie", cookieHeader);
-                }
-
-                var response = await base.SendAsync(request, cancellationToken);
-
-                if (response.Headers.Contains("Set-Cookie"))
-                {
-                    var responseCookieHeader = string.Join(",", response.Headers.GetValues("Set-Cookie"));
-                    CookieContainer.SetCookies(request.RequestUri, responseCookieHeader);
-                }
-
-                LastResponse = response;
-
-                return response;
+                var responseCookieHeader = string.Join(",", response.Headers.GetValues("Set-Cookie"));
+                CookieContainer.SetCookies(request.RequestUri, responseCookieHeader);
             }
-        }
 
-        private CookieHandler _handler;
-        
-        public CookieContainer CookieContainer => _handler.CookieContainer;
-        public Uri CurrentUri => _handler.CurrentUri;
-        public HttpResponseMessage LastResponse => _handler.LastResponse;
+            LastResponse = response;
 
-        public TestBrowserClient(HttpMessageHandler handler)
-            : this(new CookieHandler(handler))
-        {
-        }
-
-        private TestBrowserClient(CookieHandler handler)
-            : base(handler)
-        {
-            _handler = handler;
-        }
-
-        public void RemoveCookie(string name)
-        {
-            RemoveCookie(CurrentUri.ToString(), name);
-        }
-        public void RemoveCookie(string uri, string name)
-        {
-            var cookie = CookieContainer.GetCookies(new Uri(uri)).FirstOrDefault(x => x.Name == name);
-            if (cookie != null)
-            {
-                cookie.Expired = true;
-            }
+            return response;
         }
     }
+
+    private readonly CookieHandler _handler;
+
+    private CookieContainer CookieContainer => _handler.CookieContainer;
+    public Uri? CurrentUri => _handler.CurrentUri;
+    public HttpResponseMessage? LastResponse => _handler.LastResponse;
+
+    public TestBrowserClient(HttpMessageHandler handler)
+        : this(new CookieHandler(handler))
+    {
+    }
+
+    private TestBrowserClient(CookieHandler handler)
+        : base(handler)
+    {
+        _handler = handler;
+    }
+
+    public void RemoveCookie(string name)
+    {
+        if (CurrentUri == null) throw new NullReferenceException("CurrentUri is null");
+
+        RemoveCookie(CurrentUri.ToString(), name);
+    }
+
+    private void RemoveCookie(string uri, string name)
+    {
+        var cookie = CookieContainer.GetCookies(new Uri(uri)).FirstOrDefault(x => x.Name == name);
+        if (cookie != null)
+        {
+            cookie.Expired = true;
+        }
+    }
+
+
+    /// <summary>
+    /// Calls the specified BFF api and verifies that the response is successful
+    /// and returns the ApiResponse object.
+    /// </summary>
+    /// <param name="url">The url to call</param>
+    /// <param name="expectedStatusCode">If specified, the system will verify that this reponse code was given</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>The specified api response</returns>
+    public async Task<ApiResponse> CallBffHostApi(
+        string url, 
+        HttpStatusCode? expectedStatusCode = null, 
+        CancellationToken ct = default)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get, url);
+        req.Headers.Add("x-csrf", "1");
+        var response = await SendAsync(req, ct);
+
+        if (expectedStatusCode == null)
+        {
+            response.IsSuccessStatusCode.ShouldBeTrue();
+            response.Content.Headers.ContentType?.MediaType.ShouldBe("application/json");
+            var json = await response.Content.ReadAsStringAsync(ct);
+            var apiResult = JsonSerializer.Deserialize<ApiResponse>(json).ShouldNotBeNull();
+
+            apiResult.Method.ShouldBe("GET", StringCompareShould.IgnoreCase);
+
+            return apiResult;
+        }
+        else
+        {
+            response.StatusCode.ToString().ShouldBe(expectedStatusCode.ToString());
+            return null!;
+        }
+
+    }
+
+    public async Task<ApiResponse> CallBffHostApi(
+        string url, 
+        HttpMethod method, 
+        HttpContent? content = null,
+        HttpStatusCode? expectedStatusCode = null,
+        CancellationToken ct = default)
+    {
+        var req = new HttpRequestMessage(method, url);
+        if (req.Content == null)
+        {
+            req.Content = content;
+        }
+        req.Headers.Add("x-csrf", "1");
+        var response = await SendAsync(req, ct);
+        if (expectedStatusCode == null)
+        {
+            response.IsSuccessStatusCode.ShouldBeTrue();
+            response.Content.Headers.ContentType?.MediaType.ShouldBe("application/json");
+            var json = await response.Content.ReadAsStringAsync(ct);
+            var apiResult = JsonSerializer.Deserialize<ApiResponse>(json).ShouldNotBeNull();
+
+            apiResult.Method.ShouldBe(method.ToString(), StringCompareShould.IgnoreCase);
+            return apiResult;
+        }
+        else
+        {
+            response.StatusCode.ToString().ShouldBe(expectedStatusCode.ToString());
+            return null!;
+        }
+    }
+
+
+
 }

--- a/bff/test/Duende.Bff.Tests/TestFramework/TestLoggerProvider.cs
+++ b/bff/test/Duende.Bff.Tests/TestFramework/TestLoggerProvider.cs
@@ -12,7 +12,7 @@ namespace Duende.Bff.Tests.TestFramework
         private readonly WriteTestOutput _writeOutput = writeOutput ?? throw new ArgumentNullException(nameof(writeOutput));
         private readonly string _name = name ?? throw new ArgumentNullException(nameof(name));
 
-        public class DebugLogger : ILogger, IDisposable
+        private class DebugLogger : ILogger, IDisposable
         {
             private readonly TestLoggerProvider _parent;
             private readonly string _category;
@@ -27,7 +27,7 @@ namespace Duende.Bff.Tests.TestFramework
             {
             }
 
-            public IDisposable BeginScope<TState>(TState state)
+            public IDisposable BeginScope<TState>(TState state) where TState : notnull
             {
                 return this;
             }
@@ -37,7 +37,7 @@ namespace Duende.Bff.Tests.TestFramework
                 return true;
             }
 
-            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
             {
                 var msg = $"[{logLevel}] {_category} : {formatter(state, exception)}";
                 _parent.Log(msg);

--- a/bff/test/Duende.Bff.Tests/TestFramework/TestSerializerOptions.cs
+++ b/bff/test/Duende.Bff.Tests/TestFramework/TestSerializerOptions.cs
@@ -1,0 +1,15 @@
+// // Copyright (c) Duende Software. All rights reserved.
+// // See LICENSE in the project root for license information.
+
+using System.Text.Json;
+
+namespace Duende.Bff.Tests.TestFramework;
+
+public static class TestSerializerOptions
+{
+    public static JsonSerializerOptions Default => new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true
+    };
+}

--- a/bff/test/Duende.Bff.Tests/TestHosts/IdentityServerHost.cs
+++ b/bff/test/Duende.Bff.Tests/TestHosts/IdentityServerHost.cs
@@ -25,14 +25,14 @@ public class IdentityServerHost : GenericHost
         OnConfigure += Configure;
     }
 
-    public List<Client> Clients { get; set; } = new List<Client>();
-    public List<IdentityResource> IdentityResources { get; set; } = new List<IdentityResource>()
+    public List<Client> Clients { get; set; } = new();
+    public List<IdentityResource> IdentityResources { get; set; } = new()
         {
             new IdentityResources.OpenId(),
             new IdentityResources.Profile(),
             new IdentityResources.Email(),
         };
-    public List<ApiScope> ApiScopes { get; set; } = new List<ApiScope>();
+    public List<ApiScope> ApiScopes { get; set; } = new();
 
     private void ConfigureServices(IServiceCollection services)
     {
@@ -76,7 +76,7 @@ public class IdentityServerHost : GenericHost
 
                 var signOutContext = await interaction.GetLogoutContextAsync(logoutId);
 
-                context.Response.Redirect(signOutContext.PostLogoutRedirectUri);
+                context.Response.Redirect(signOutContext.PostLogoutRedirectUri ?? "/");
             });
             endpoints.MapGet("/__token", async (ITokenService tokens) =>
             {
@@ -103,7 +103,7 @@ public class IdentityServerHost : GenericHost
         });
     }
 
-    public async Task CreateIdentityServerSessionCookieAsync(string sub, string sid = null)
+    public async Task CreateIdentityServerSessionCookieAsync(string sub, string? sid = null)
     {
         var props = new AuthenticationProperties();
 


### PR DESCRIPTION
Changes the nullability setting in the unit tests. 

To make the tests more maintainable, some of the tests have been rewritten to use a helper method. 

Lastly, the tests weren't disposing of the hosts, and they were calling .Wait on startups. This is now fully async. 

**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
