### PR TITLE
move structured logging into aspire

### DIFF
--- a/bff/samples/Apis/Api.DPoP/Api.DPoP.csproj
+++ b/bff/samples/Apis/Api.DPoP/Api.DPoP.csproj
@@ -7,7 +7,6 @@
     <ItemGroup>
         <PackageReference Include="Duende.IdentityModel" />
         <PackageReference Include="Duende.AspNetCore.Authentication.JwtBearer" />
-        <PackageReference Include="Serilog.AspNetCore" />
     </ItemGroup>
 
 	<ItemGroup>

--- a/bff/samples/Apis/Api.DPoP/Extensions.cs
+++ b/bff/samples/Apis/Api.DPoP/Extensions.cs
@@ -5,7 +5,6 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.IdentityModel.Tokens;
-using Serilog;
 
 namespace Api.DPoP;
 
@@ -68,7 +67,7 @@ internal static class Extensions
         //     ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto | ForwardedHeaders.XForwardedHost,
         // });
 
-        app.UseSerilogRequestLogging();
+        app.UseHttpLogging();
 
         if (app.Environment.IsDevelopment())
         {

--- a/bff/samples/Apis/Api.DPoP/Program.cs
+++ b/bff/samples/Apis/Api.DPoP/Program.cs
@@ -2,44 +2,14 @@ using System;
 using Api.DPoP;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Hosting;
-using Serilog;
-using Serilog.Events;
 
 Console.Title = "DPoP Api";
 
-Log.Logger = new LoggerConfiguration()
-    .WriteTo.Console()
-    .CreateBootstrapLogger();
+var builder = WebApplication.CreateBuilder(args);
+builder.AddServiceDefaults();
 
-Log.Information("Starting up");
+var app = builder
+    .ConfigureServices()
+    .ConfigurePipeline();
 
-try
-{
-    var builder = WebApplication.CreateBuilder(args);
-    builder.AddServiceDefaults();
-
-    builder.Host.UseSerilog((ctx, lc) => lc
-        .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level}] {SourceContext}{NewLine}{Message:lj}{NewLine}{Exception}{NewLine}")
-        .Enrich.FromLogContext()
-        .MinimumLevel.Debug()
-        .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
-        .MinimumLevel.Override("Microsoft.Hosting.Lifetime", LogEventLevel.Information)
-        .MinimumLevel.Override("System", LogEventLevel.Warning)
-        .MinimumLevel.Override("Microsoft.AspNetCore.Authentication", LogEventLevel.Information)
-        .ReadFrom.Configuration(ctx.Configuration));
-
-    var app = builder
-        .ConfigureServices()
-        .ConfigurePipeline();
-
-    app.Run();
-}
-catch (Exception ex)
-{
-    Log.Fatal(ex, "Unhandled exception");
-}
-finally
-{
-    Log.Information("Shut down complete");
-    Log.CloseAndFlush();
-}
+app.Run();

--- a/bff/samples/Apis/Api.Isolated/Api.Isolated.csproj
+++ b/bff/samples/Apis/Api.Isolated/Api.Isolated.csproj
@@ -7,7 +7,6 @@
     <ItemGroup>
         <PackageReference Include="Duende.IdentityModel" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
-        <PackageReference Include="Serilog.AspNetCore" />
     </ItemGroup>
 
 	<ItemGroup>

--- a/bff/samples/Apis/Api.Isolated/Extensions.cs
+++ b/bff/samples/Apis/Api.Isolated/Extensions.cs
@@ -6,7 +6,6 @@ using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.IdentityModel.Tokens;
-using Serilog;
 
 namespace Api.Isolated
 {
@@ -56,7 +55,7 @@ namespace Api.Isolated
                 ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto | ForwardedHeaders.XForwardedHost,
             });
 
-            app.UseSerilogRequestLogging();
+            app.UseHttpLogging();
 
             if (app.Environment.IsDevelopment())
             {

--- a/bff/samples/Apis/Api.Isolated/Program.cs
+++ b/bff/samples/Apis/Api.Isolated/Program.cs
@@ -2,44 +2,14 @@ using System;
 using Api.Isolated;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Hosting;
-using Serilog;
-using Serilog.Events;
 
 Console.Title = "Isolated Api";
 
-Log.Logger = new LoggerConfiguration()
-    .WriteTo.Console()
-    .CreateBootstrapLogger();
+var builder = WebApplication.CreateBuilder(args);
+builder.AddServiceDefaults();
 
-Log.Information("Starting up");
+var app = builder
+    .ConfigureServices()
+    .ConfigurePipeline();
 
-try
-{
-    var builder = WebApplication.CreateBuilder(args);
-    builder.AddServiceDefaults();
-
-    builder.Host.UseSerilog((ctx, lc) => lc
-        .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level}] {SourceContext}{NewLine}{Message:lj}{NewLine}{Exception}{NewLine}")
-        .Enrich.FromLogContext()
-        .MinimumLevel.Debug()
-        .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
-        .MinimumLevel.Override("Microsoft.Hosting.Lifetime", LogEventLevel.Information)
-        .MinimumLevel.Override("System", LogEventLevel.Warning)
-        .MinimumLevel.Override("Microsoft.AspNetCore.Authentication", LogEventLevel.Information)
-        .ReadFrom.Configuration(ctx.Configuration));
-
-    var app = builder
-        .ConfigureServices()
-        .ConfigurePipeline();
-
-    app.Run();
-}
-catch (Exception ex)
-{
-    Log.Fatal(ex, "Unhandled exception");
-}
-finally
-{
-    Log.Information("Shut down complete");
-    Log.CloseAndFlush();
-}
+app.Run();

--- a/bff/samples/Apis/Api/Api.csproj
+++ b/bff/samples/Apis/Api/Api.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
 	    <TargetFrameworks>net9.0</TargetFrameworks>
@@ -7,7 +7,6 @@
     <ItemGroup>
         <PackageReference Include="Duende.IdentityModel" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
-        <PackageReference Include="Serilog.AspNetCore" />
     </ItemGroup>
 
 	<ItemGroup>

--- a/bff/samples/Apis/Api/Extensions.cs
+++ b/bff/samples/Apis/Api/Extensions.cs
@@ -6,7 +6,6 @@ using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.IdentityModel.Tokens;
-using Serilog;
 
 namespace Api;
 
@@ -57,7 +56,7 @@ internal static class Extensions
             ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto | ForwardedHeaders.XForwardedHost,
         });
 
-        app.UseSerilogRequestLogging();
+        app.UseHttpLogging();
 
         if (app.Environment.IsDevelopment())
         {

--- a/bff/samples/Apis/Api/Program.cs
+++ b/bff/samples/Apis/Api/Program.cs
@@ -1,45 +1,12 @@
-using System;
 using Api;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Hosting;
-using Serilog;
-using Serilog.Events;
+var builder = WebApplication.CreateBuilder(args);
 
-Console.Title = "Api";
+builder.AddServiceDefaults();
 
-Log.Logger = new LoggerConfiguration()
-    .WriteTo.Console()
-    .CreateBootstrapLogger();
+var app = builder
+    .ConfigureServices()
+    .ConfigurePipeline();
 
-Log.Information("Starting up");
-
-try
-{
-    var builder = WebApplication.CreateBuilder(args);
-    builder.AddServiceDefaults();
-
-    builder.Host.UseSerilog((ctx, lc) => lc
-        .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level}] {SourceContext}{NewLine}{Message:lj}{NewLine}{Exception}{NewLine}")
-        .Enrich.FromLogContext()
-        .MinimumLevel.Debug()
-        .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
-        .MinimumLevel.Override("Microsoft.Hosting.Lifetime", LogEventLevel.Information)
-        .MinimumLevel.Override("System", LogEventLevel.Warning)
-        .MinimumLevel.Override("Microsoft.AspNetCore.Authentication", LogEventLevel.Information)
-        .ReadFrom.Configuration(ctx.Configuration));
-
-    var app = builder
-        .ConfigureServices()
-        .ConfigurePipeline();
-
-    app.Run();
-}
-catch (Exception ex)
-{
-    Log.Fatal(ex, "Unhandled exception");
-}
-finally
-{
-    Log.Information("Shut down complete");
-    Log.CloseAndFlush();
-}
+app.Run();

--- a/bff/samples/Bff.DPoP/Bff.DPoP.csproj
+++ b/bff/samples/Bff.DPoP/Bff.DPoP.csproj
@@ -7,8 +7,7 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" />    
-        <PackageReference Include="Serilog.AspNetCore" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect"/>    
     </ItemGroup>
     
     <ItemGroup>

--- a/bff/samples/Bff.DPoP/Extensions.cs
+++ b/bff/samples/Bff.DPoP/Extensions.cs
@@ -12,9 +12,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Tokens;
-using Serilog;
 using Yarp.ReverseProxy.Configuration;
-
 
 namespace Bff.DPoP;
 
@@ -152,7 +150,7 @@ internal static class Extensions
 
     public static WebApplication ConfigurePipeline(this WebApplication app)
     {
-        app.UseSerilogRequestLogging();
+        app.UseHttpLogging();
         app.UseDeveloperExceptionPage();
 
         app.UseDefaultFiles();

--- a/bff/samples/Bff.DPoP/Program.cs
+++ b/bff/samples/Bff.DPoP/Program.cs
@@ -2,44 +2,14 @@ using System;
 using Bff.DPoP;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Hosting;
-using Serilog;
-using Serilog.Events;
 
 Console.Title = "BFF.DPoP";
 
-Log.Logger = new LoggerConfiguration()
-    .WriteTo.Console()
-    .CreateBootstrapLogger();
+var builder = WebApplication.CreateBuilder(args);
+builder.AddServiceDefaults();
 
-Log.Information("Starting up");
+var app = builder
+    .ConfigureServices()
+    .ConfigurePipeline();
 
-try
-{
-    var builder = WebApplication.CreateBuilder(args);
-    builder.AddServiceDefaults();
-
-    builder.Host.UseSerilog((ctx, lc) => lc
-        .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level}] {SourceContext}{NewLine}{Message:lj}{NewLine}{Exception}{NewLine}")
-        .Enrich.FromLogContext()
-        .MinimumLevel.Debug()
-        .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
-        .MinimumLevel.Override("Microsoft.Hosting.Lifetime", LogEventLevel.Information)
-        .MinimumLevel.Override("System", LogEventLevel.Warning)
-        .MinimumLevel.Override("Microsoft.AspNetCore.Authentication", LogEventLevel.Information)
-        .ReadFrom.Configuration(ctx.Configuration));
-
-    var app = builder
-        .ConfigureServices()
-        .ConfigurePipeline();
-
-    app.Run();
-}
-catch (Exception ex)
-{
-    Log.Fatal(ex, "Unhandled exception");
-}
-finally
-{
-    Log.Information("Shut down complete");
-    Log.CloseAndFlush();
-}
+app.Run();

--- a/bff/samples/Bff.EF/Bff.EF.csproj
+++ b/bff/samples/Bff.EF/Bff.EF.csproj
@@ -9,7 +9,6 @@
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
-		<PackageReference Include="Serilog.AspNetCore" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/bff/samples/Bff.EF/Extensions.cs
+++ b/bff/samples/Bff.EF/Extensions.cs
@@ -6,14 +6,12 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Serilog;
 using UserSessionDb.Migrations.UserSessions;
 
 namespace Bff.EF
 {
     internal static class Extensions
     {
-
         public static WebApplication ConfigureServices(this WebApplicationBuilder builder)
         {
             var services = builder.Services;
@@ -79,7 +77,7 @@ namespace Bff.EF
 
         public static WebApplication ConfigurePipeline(this WebApplication app)
         {
-            app.UseSerilogRequestLogging();
+            app.UseHttpLogging();
             app.UseDeveloperExceptionPage();
 
             app.UseDefaultFiles();

--- a/bff/samples/Bff.EF/Program.cs
+++ b/bff/samples/Bff.EF/Program.cs
@@ -2,43 +2,14 @@ using System;
 using Bff.EF;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Hosting;
-using Serilog;
-using Serilog.Events;
 
 Console.Title = "Bff.EF";
 
-Log.Logger = new LoggerConfiguration()
-    .WriteTo.Console()
-    .CreateBootstrapLogger();
+var builder = WebApplication.CreateBuilder(args);
+builder.AddServiceDefaults();
 
-Log.Information("Starting up");
+var app = builder
+    .ConfigureServices()
+    .ConfigurePipeline();
 
-try
-{
-    var builder = WebApplication.CreateBuilder(args);
-    builder.AddServiceDefaults();
-    builder.Host.UseSerilog((ctx, lc) => lc
-        .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level}] {SourceContext}{NewLine}{Message:lj}{NewLine}{Exception}{NewLine}")
-        .Enrich.FromLogContext()
-        .MinimumLevel.Debug()
-        .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
-        .MinimumLevel.Override("Microsoft.Hosting.Lifetime", LogEventLevel.Information)
-        .MinimumLevel.Override("System", LogEventLevel.Warning)
-        .MinimumLevel.Override("Microsoft.AspNetCore.Authentication", LogEventLevel.Information)
-        .ReadFrom.Configuration(ctx.Configuration));
-
-    var app = builder
-        .ConfigureServices()
-        .ConfigurePipeline();
-
-    app.Run();
-}
-catch (Exception ex)
-{
-    Log.Fatal(ex, "Unhandled exception");
-}
-finally
-{
-    Log.Information("Shut down complete");
-    Log.CloseAndFlush();
-}
+app.Run();

--- a/bff/samples/Bff/Bff.csproj
+++ b/bff/samples/Bff/Bff.csproj
@@ -1,14 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
 	    <TargetFramework>net9.0</TargetFramework>
         <RootNamespace>Bff</RootNamespace>
         <Nullable>enable</Nullable>
     </PropertyGroup>
-    
-    <ItemGroup>
-        <PackageReference Include="Serilog.AspNetCore" />
-    </ItemGroup>
     
     <ItemGroup>
       <ProjectReference Include="..\..\src\Duende.Bff.Yarp\Duende.Bff.Yarp.csproj" />

--- a/bff/samples/Bff/Extensions.cs
+++ b/bff/samples/Bff/Extensions.cs
@@ -10,7 +10,6 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.ServiceDiscovery;
-using Serilog;
 
 namespace Bff;
 
@@ -103,7 +102,7 @@ internal static class Extensions
 
     public static WebApplication ConfigurePipeline(this WebApplication app)
     {
-        app.UseSerilogRequestLogging();
+        app.UseHttpLogging();
         app.UseDeveloperExceptionPage();
 
         app.UseDefaultFiles();

--- a/bff/samples/Bff/Program.cs
+++ b/bff/samples/Bff/Program.cs
@@ -2,59 +2,18 @@ using System;
 using Bff;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Hosting;
-using Serilog;
-using Serilog.Events;
 
 Console.Title = "BFF";
 
-Log.Logger = new LoggerConfiguration()
-    .WriteTo.Console()
-    .CreateBootstrapLogger();
+var builder = WebApplication.CreateBuilder(args);
+builder.AddServiceDefaults();
 
-Log.Information("Starting up");
+var serviceProviderAccessor = new ServiceProviderAccessor();
 
-try
-{
-    var builder = WebApplication.CreateBuilder(args);
-    builder.AddServiceDefaults();
+var app = builder
+    .ConfigureServices(() => serviceProviderAccessor.ServiceProvider ?? throw new InvalidOperationException("Service Provider must be set"))
+    .ConfigurePipeline();
 
-    builder.Host.UseSerilog((ctx, lc) => lc
-        .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level}] {SourceContext}{NewLine}{Message:lj}{NewLine}{Exception}{NewLine}")
-        .Enrich.FromLogContext()
-        .MinimumLevel.Debug()
-        .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
-        .MinimumLevel.Override("Microsoft.Hosting.Lifetime", LogEventLevel.Information)
-        .MinimumLevel.Override("System", LogEventLevel.Warning)
-        .MinimumLevel.Override("Microsoft.AspNetCore.Authentication", LogEventLevel.Information)
-        .ReadFrom.Configuration(ctx.Configuration));
+serviceProviderAccessor.ServiceProvider = app.Services;
 
-    var serviceProviderAccessor = new ServiceProviderAccessor();
-
-    var app = builder
-        .ConfigureServices(() => serviceProviderAccessor.ServiceProvider ?? throw new InvalidOperationException("Service Provider must be set"))
-        .ConfigurePipeline();
-
-    serviceProviderAccessor.ServiceProvider = app.Services;
-
-    app.Run();
-
-    
-}
-catch (Exception ex)
-{
-    Log.Fatal(ex, "Unhandled exception");
-}
-finally
-{
-    Log.Information("Shut down complete");
-    Log.CloseAndFlush();
-}
-
-/// <summary>
-/// A workaround to get the service provider available in the ConfigureServices method
-/// </summary>
-class ServiceProviderAccessor
-{
-    public IServiceProvider? ServiceProvider { get; set; }
-
-}
+app.Run();

--- a/bff/samples/Bff/ServiceProviderAccessor.cs
+++ b/bff/samples/Bff/ServiceProviderAccessor.cs
@@ -1,0 +1,15 @@
+// // Copyright (c) Duende Software. All rights reserved.
+// // See LICENSE in the project root for license information.
+
+using System;
+
+namespace Bff;
+
+/// <summary>
+/// A workaround to get the service provider available in the ConfigureServices method
+/// </summary>
+internal class ServiceProviderAccessor
+{
+    public IServiceProvider? ServiceProvider { get; set; }
+
+}

--- a/bff/samples/Blazor/PerComponent/PerComponent/PerComponent.csproj
+++ b/bff/samples/Blazor/PerComponent/PerComponent/PerComponent.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
 	<TargetFrameworks>net9.0</TargetFrameworks>
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\Hosts.ServiceDefaults\Hosts.ServiceDefaults.csproj" />
     <ProjectReference Include="..\PerComponent.Client\PerComponent.Client.csproj" />
     <ProjectReference Include="..\..\..\..\src\Duende.Bff\Duende.Bff.csproj" />
     <ProjectReference Include="..\..\..\..\src\Duende.Bff.Yarp\Duende.Bff.Yarp.csproj" />

--- a/bff/samples/Blazor/PerComponent/PerComponent/Program.cs
+++ b/bff/samples/Blazor/PerComponent/PerComponent/Program.cs
@@ -7,13 +7,18 @@ using Duende.Bff.Yarp;
 
 var builder = WebApplication.CreateBuilder(args);
 
+builder.AddServiceDefaults();
+
 // BFF setup for blazor
 builder.Services.AddBff()
     .AddServerSideSessions()
     .AddBlazorServer()
     .AddRemoteApis();
+
 builder.Services.AddUserAccessTokenHttpClient("callApi", 
     configureClient: client => client.BaseAddress = new Uri("https://localhost:5010/"));
+
+
 
 // General blazor services
 builder.Services.AddRazorComponents()
@@ -61,6 +66,8 @@ builder.Services.AddAuthentication(options =>
     });
 
 var app = builder.Build();
+
+app.UseHttpLogging();
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())

--- a/bff/samples/Blazor/WebAssembly/WebAssembly/Program.cs
+++ b/bff/samples/Blazor/WebAssembly/WebAssembly/Program.cs
@@ -5,6 +5,8 @@ using Microsoft.AspNetCore.Components.Server;
 
 var builder = WebApplication.CreateBuilder(args);
 
+builder.AddServiceDefaults();
+
 builder.Services.AddRazorComponents()
     .AddInteractiveWebAssemblyComponents();
 
@@ -60,6 +62,8 @@ else
     // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
     app.UseHsts();
 }
+
+app.UseHttpLogging();
 
 app.UseHttpsRedirection();
 

--- a/bff/samples/Blazor/WebAssembly/WebAssembly/WebAssembly.csproj
+++ b/bff/samples/Blazor/WebAssembly/WebAssembly/WebAssembly.csproj
@@ -8,9 +8,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\src\Duende.Bff\Duende.Bff.csproj" />
+    <ProjectReference Include="..\..\..\Hosts.ServiceDefaults\Hosts.ServiceDefaults.csproj" />
     <ProjectReference Include="..\WebAssembly.Client\WebAssembly.Client.csproj" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect"/>
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server"/>
   </ItemGroup>
 
 </Project>

--- a/bff/samples/Hosts.AppHost/Hosts.AppHost.csproj
+++ b/bff/samples/Hosts.AppHost/Hosts.AppHost.csproj
@@ -12,8 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" />
-    <PackageReference Include="System.Text.Json" />
+    <PackageReference Include="Aspire.Hosting.AppHost"/>
   </ItemGroup>
 
     <ItemGroup>

--- a/bff/samples/Hosts.ServiceDefaults/Extensions.cs
+++ b/bff/samples/Hosts.ServiceDefaults/Extensions.cs
@@ -23,6 +23,8 @@ public static class Extensions
 
         builder.AddDefaultHealthChecks();
 
+        builder.Services.AddHttpLogging();
+
         builder.Services.AddServiceDiscovery();
 
         builder.Services.ConfigureHttpClientDefaults(http =>

--- a/bff/samples/Hosts.Tests/Hosts.Tests.csproj
+++ b/bff/samples/Hosts.Tests/Hosts.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>net9.0</TargetFramework>
@@ -21,7 +21,10 @@
 		<PackageReference Include="Serilog.Extensions.Logging" />
 		<PackageReference Include="Serilog.Sinks.TextWriter" />
 		<PackageReference Include="Serilog.Sinks.XUnit" />
-		<PackageReference Include="Shouldly" />
+        <PackageReference Include="Serilog.AspNetCore" />
+        <PackageReference Include="Shouldly" />
+		<PackageReference Include="xunit.core" />
+		<PackageReference Include="xunit.runner.visualstudio" />
 		<PackageReference Include="Aspire.Hosting.Testing" />
 		<PackageReference Include="Xunit.SkippableFact" />
 

--- a/bff/samples/Hosts.Tests/TestInfra/AppHostFixture.cs
+++ b/bff/samples/Hosts.Tests/TestInfra/AppHostFixture.cs
@@ -92,7 +92,8 @@ public class AppHostFixture : IAsyncLifetime
                 .WaitAsync(TimeSpan.FromSeconds(30));
         }
 
-
+#else
+        _app = null!;
 #endif //#DEBUG_NCRUNCH
     }
 

--- a/bff/samples/IdentityServer/Extensions.cs
+++ b/bff/samples/IdentityServer/Extensions.cs
@@ -2,8 +2,6 @@
 // // See LICENSE in the project root for license information.
 
 using IdentityServerHost;
-using Serilog;
-
 namespace IdentityServer;
 
 internal static class Extensions
@@ -34,8 +32,8 @@ internal static class Extensions
     }
     
     public static WebApplication ConfigurePipeline(this WebApplication app)
-    { 
-        app.UseSerilogRequestLogging();
+    {
+        app.UseHttpLogging();
         app.UseDeveloperExceptionPage();
         app.UseStaticFiles();
 

--- a/bff/samples/IdentityServer/IdentityServer.csproj
+++ b/bff/samples/IdentityServer/IdentityServer.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFrameworks>net9.0</TargetFrameworks>
@@ -8,7 +8,6 @@
   <ItemGroup>
     <PackageReference Include="Duende.IdentityServer" />
     <PackageReference Include="Duende.IdentityModel" />
-    <PackageReference Include="Serilog.AspNetCore" />
   </ItemGroup>
 
   <ItemGroup>

--- a/bff/samples/IdentityServer/Program.cs
+++ b/bff/samples/IdentityServer/Program.cs
@@ -1,42 +1,11 @@
-﻿using IdentityServer;
-using Serilog;
-using Serilog.Events;
+using IdentityServer;
 
 Console.Title = "IdentityServer";
+var builder = WebApplication.CreateBuilder(args);
+builder.AddServiceDefaults();
 
-Log.Logger = new LoggerConfiguration()
-    .WriteTo.Console()
-    .CreateBootstrapLogger();
+var app = builder
+    .ConfigureServices()
+    .ConfigurePipeline();
 
-Log.Information("Starting up");
-
-try
-{
-    var builder = WebApplication.CreateBuilder(args);
-    builder.AddServiceDefaults();
-
-    builder.Host.UseSerilog((ctx, lc) => lc
-        .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level}] {SourceContext}{NewLine}{Message:lj}{NewLine}{Exception}{NewLine}")
-        .Enrich.FromLogContext()
-        .MinimumLevel.Debug()
-        .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
-        .MinimumLevel.Override("Microsoft.Hosting.Lifetime", LogEventLevel.Information)
-        .MinimumLevel.Override("System", LogEventLevel.Warning)
-        .MinimumLevel.Override("Microsoft.AspNetCore.Authentication", LogEventLevel.Information)
-        .ReadFrom.Configuration(ctx.Configuration));
-
-    var app = builder
-        .ConfigureServices()
-        .ConfigurePipeline();
-    
-    app.Run();
-}
-catch (Exception ex)
-{
-    Log.Fatal(ex, "Unhandled exception");
-}
-finally
-{
-    Log.Information("Shut down complete");
-    Log.CloseAndFlush();
-}
+app.Run();

--- a/bff/src/Duende.Bff.Blazor.Client/Duende.Bff.Blazor.Client.csproj
+++ b/bff/src/Duende.Bff.Blazor.Client/Duende.Bff.Blazor.Client.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>

--- a/bff/test/Duende.Bff.Tests/TestFramework/TestLoggerProvider.cs
+++ b/bff/test/Duende.Bff.Tests/TestFramework/TestLoggerProvider.cs
@@ -2,8 +2,6 @@
 // See LICENSE in the project root for license information.
 
 using Microsoft.Extensions.Logging;
-using System;
-using System.Collections.Generic;
 
 namespace Duende.Bff.Tests.TestFramework
 {

--- a/bff/test/Duende.Bff.Tests/TestFramework/TestLoggerProvider.cs
+++ b/bff/test/Duende.Bff.Tests/TestFramework/TestLoggerProvider.cs
@@ -48,7 +48,14 @@ namespace Duende.Bff.Tests.TestFramework
 
         private void Log(string msg)
         {
-            _writeOutput?.Invoke(_name + msg);
+            try
+            {
+                _writeOutput?.Invoke(_name + msg);
+            }
+            catch (Exception)
+            {
+                Console.WriteLine("Logging Failed: " + msg);
+            }
             LogEntries.Add(msg);
         }
 

--- a/bff/test/Duende.Bff.Tests/TestHosts/BffIntegrationTestBase.cs
+++ b/bff/test/Duende.Bff.Tests/TestHosts/BffIntegrationTestBase.cs
@@ -1,33 +1,28 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
-using System;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System.Security.Claims;
-using System.Threading.Tasks;
-using Xunit;
 using Xunit.Abstractions;
 
 namespace Duende.Bff.Tests.TestHosts
 {
-    public class BffIntegrationTestBase : IAsyncLifetime
+    public class BffIntegrationTestBase : OutputWritingTestBase
     {
-        private readonly ITestOutputHelper _output;
         protected readonly IdentityServerHost IdentityServerHost;
         protected ApiHost ApiHost;
         protected BffHost BffHost;
         protected BffHostUsingResourceNamedTokens BffHostWithNamedTokens;
 
-        public BffIntegrationTestBase(ITestOutputHelper output)
+        public BffIntegrationTestBase(ITestOutputHelper output) : base(output)
         {
-            _output = output;
-            IdentityServerHost = new IdentityServerHost(output.WriteLine);
-            ApiHost = new ApiHost(_output.WriteLine, IdentityServerHost, "scope1");
-            BffHost = new BffHost(_output.WriteLine, IdentityServerHost, ApiHost, "spa");
-            BffHostWithNamedTokens = new BffHostUsingResourceNamedTokens(_output.WriteLine, IdentityServerHost, ApiHost, "spa");
+            IdentityServerHost = new IdentityServerHost(WriteLine);
+            ApiHost = new ApiHost(WriteLine, IdentityServerHost, "scope1");
+            BffHost = new BffHost(WriteLine, IdentityServerHost, ApiHost, "spa");
+            BffHostWithNamedTokens = new BffHostUsingResourceNamedTokens(WriteLine, IdentityServerHost, ApiHost, "spa");
 
             IdentityServerHost.Clients.Add(new Client
             {
@@ -59,21 +54,23 @@ namespace Duende.Bff.Tests.TestHosts
             await IdentityServerHost.IssueSessionCookieAsync(new Claim("sub", sub));
         }
 
-        public async Task InitializeAsync()
+        public override async Task InitializeAsync()
         {
             await IdentityServerHost.InitializeAsync();
             await ApiHost.InitializeAsync();
             await BffHost.InitializeAsync();
             await BffHostWithNamedTokens.InitializeAsync();
-
+            await base.InitializeAsync();
         }
 
-        public async Task DisposeAsync()
+        public override async Task DisposeAsync()
         {
             await ApiHost.DisposeAsync();
             await BffHost.DisposeAsync();
             await BffHostWithNamedTokens.DisposeAsync();
             await IdentityServerHost.DisposeAsync();
+            await base.DisposeAsync();
+
         }
     }
 }

--- a/bff/test/Duende.Bff.Tests/TestHosts/OutputWritingTestBase.cs
+++ b/bff/test/Duende.Bff.Tests/TestHosts/OutputWritingTestBase.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using System.Text;
+using Xunit.Abstractions;
+
+namespace Duende.Bff.Tests.TestHosts;
+
+public class OutputWritingTestBase(ITestOutputHelper testOutputHelper) : IAsyncLifetime
+{
+    private readonly StringBuilder _output = new StringBuilder();
+
+    public void WriteLine(string message)
+    {
+        _output.AppendLine(message);
+    }
+
+    public virtual Task InitializeAsync()
+    {
+        return Task.CompletedTask;
+    }
+
+    public virtual Task DisposeAsync()
+    {
+        testOutputHelper.WriteLine(_output.ToString());
+        return Task.CompletedTask;
+    }
+}

--- a/bff/test/Duende.Bff.Tests/TestHosts/YarpBffIntegrationTestBase.cs
+++ b/bff/test/Duende.Bff.Tests/TestHosts/YarpBffIntegrationTestBase.cs
@@ -13,16 +13,16 @@ using Xunit.Abstractions;
 
 namespace Duende.Bff.Tests.TestHosts
 {
-    public class YarpBffIntegrationTestBase : IAsyncLifetime
+    public class YarpBffIntegrationTestBase : OutputWritingTestBase
     {
         private readonly IdentityServerHost _identityServerHost;
         protected readonly ApiHost ApiHost;
         protected readonly YarpBffHost BffHost;
         private BffHostUsingResourceNamedTokens _bffHostWithNamedTokens;
 
-        protected YarpBffIntegrationTestBase(ITestOutputHelper output)
+        protected YarpBffIntegrationTestBase(ITestOutputHelper output) : base(output)
         {
-            _identityServerHost = new IdentityServerHost(output.WriteLine);
+            _identityServerHost = new IdentityServerHost(WriteLine);
             
             _identityServerHost.Clients.Add(new Client
             {
@@ -45,11 +45,11 @@ namespace Duende.Bff.Tests.TestHosts
                         provider.GetRequiredService<ICancellationTokenProvider>()));
             };
             
-            ApiHost = new ApiHost(output.WriteLine, _identityServerHost, "scope1");
+            ApiHost = new ApiHost(WriteLine, _identityServerHost, "scope1");
 
-            BffHost = new YarpBffHost(output.WriteLine, _identityServerHost, ApiHost, "spa");
+            BffHost = new YarpBffHost(WriteLine, _identityServerHost, ApiHost, "spa");
 
-            _bffHostWithNamedTokens = new BffHostUsingResourceNamedTokens(output.WriteLine, _identityServerHost, ApiHost, "spa");
+            _bffHostWithNamedTokens = new BffHostUsingResourceNamedTokens(WriteLine, _identityServerHost, ApiHost, "spa");
         }
 
         public async Task Login(string sub)
@@ -57,21 +57,22 @@ namespace Duende.Bff.Tests.TestHosts
             await _identityServerHost.IssueSessionCookieAsync(new Claim("sub", sub));
         }
 
-        public async Task InitializeAsync()
+        public override async Task InitializeAsync()
         {
             await _identityServerHost.InitializeAsync();
             await ApiHost.InitializeAsync();
             await BffHost.InitializeAsync();
             await _bffHostWithNamedTokens.InitializeAsync();
-
+            await base.InitializeAsync();
         }
 
-        public async Task DisposeAsync()
+        public override async Task DisposeAsync()
         {
             await _identityServerHost.DisposeAsync();
             await ApiHost.DisposeAsync();
             await BffHost.DisposeAsync();
             await _bffHostWithNamedTokens.DisposeAsync();
+            await base.DisposeAsync();
         }
     }
 }


### PR DESCRIPTION
**What issue does this PR address?**
Using serilog in the samples means the logs don't go into aspire's structured logging, which kind of defeats the purpose. 
So, I'm reverting the use of serilog in the samples. 


**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
