### PR TITLE
Remove redundant comment delimiters in license header

### DIFF
--- a/bff/src/Duende.Bff/EndpointProcessing/IBffUIApiEndpoint.cs
+++ b/bff/src/Duende.Bff/EndpointProcessing/IBffUIApiEndpoint.cs
@@ -1,5 +1,5 @@
-// // Copyright (c) Duende Software. All rights reserved.
-// // See LICENSE in the project root for license information.
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
 
 namespace Duende.Bff;
 


### PR DESCRIPTION
Cleaned up the license header by removing unnecessary comment delimiters. This improves readability and maintains consistency with standard file header formatting conventions.
