### PR TITLE
Add cancellation token support for ticket retrieval

### DIFF
--- a/bff/src/Duende.Bff/SessionManagement/Revocation/SessionRevocationService.cs
+++ b/bff/src/Duende.Bff/SessionManagement/Revocation/SessionRevocationService.cs
@@ -52,7 +52,7 @@ public class SessionRevocationService : ISessionRevocationService
 
         if (_options.RevokeRefreshTokenOnLogout)
         {
-            var tickets = await _ticketStore.GetUserTicketsAsync(filter);
+            var tickets = await _ticketStore.GetUserTicketsAsync(filter, cancellationToken);
             if (tickets?.Any() == true)
             {
                 foreach (var ticket in tickets)


### PR DESCRIPTION
Updated the `GetUserTicketsAsync` method to include a cancellation token parameter. This ensures proper cancellation handling during user ticket retrieval.
