### PR TITLE
remove obsolete .github folder

### DIFF
--- a/bff/.github/ISSUE_TEMPLATE/config.yml
+++ b/bff/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,0 @@
-blank_issues_enabled: false
-contact_links:
-  - name: Support Forum
-    url: https://github.com/DuendeSoftware/Support/issues/new/choose
-    about: The place for questions, bug reports, support and feature requests
-  - name: Direct Contact
-    url: https://duendesoftware.com/contact
-    about: Contact us directly

--- a/bff/.github/PULL_REQUEST_TEMPLATE.md
+++ b/bff/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,0 @@
-**What issue does this PR address?**
-
-
-
-**Important: Any code or remarks in your Pull Request are under the following terms:**
-
-If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.
-
-(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)


### PR DESCRIPTION
**What issue does this PR address?**
The .github folder under /bff is a relic from when bff was in a separate repo. It serves no purpose now, so deleting it. 


**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
