### PR TITLE
build - build with the correct security context

### DIFF
--- a/.github/workflow-gen/Program.cs
+++ b/.github/workflow-gen/Program.cs
@@ -77,9 +77,7 @@ void GenerateCiWorkflow(Component component)
         job.StepPack(project);
     }
 
-    job.StepSign()
-        .OnlyIfOnBranch()
-        ;
+    job.StepSign();
 
     job.StepPush("MyGet", "https://www.myget.org/F/duende_identityserver/api/v2/package", "MYGET");
 
@@ -193,7 +191,7 @@ public static class StepExtensions
     /// Only run this if the build is triggered on a branch IN the same repo
     /// this means it's from a trusted contributor.
     /// </summary>
-    public static Step OnlyIfOnBranch(this Step step)
+    public static Step IfGithubEventIsPush(this Step step)
         => step.If("github.event == 'push'");
 
     public static void StepTestAndReport(this Job job, string componentName, string testProject)
@@ -243,7 +241,7 @@ public static class StepExtensions
                     "--azure-key-vault-certificate NuGetPackageSigning";
         return job.Step()
             .Name("Sign packages")
-            .OnlyIfOnBranch()
+            .IfGithubEventIsPush()
             .Run($"""
                  for file in artifacts/*.nupkg; do
                     dotnet NuGetKeyVaultSignTool sign "$file" {flags}

--- a/.github/workflow-gen/Program.cs
+++ b/.github/workflow-gen/Program.cs
@@ -39,13 +39,14 @@ void GenerateCiWorkflow(Component component)
         .Push()
         .Paths(paths);
     workflow.On
-        .PullRequestTarget()
+        .PullRequest()
         .Paths(paths);
 
     workflow.EnvDefaults();
 
     var job = workflow
         .Job("build")
+        .RunEitherOnBranchOrAsPR()
         .Name("Build")
         .RunsOn(GitHubHostedRunners.UbuntuLatest)
         .Defaults().Run("bash", component.Name)
@@ -76,7 +77,9 @@ void GenerateCiWorkflow(Component component)
         job.StepPack(project);
     }
 
-    job.StepSign();
+    job.StepSign()
+        .OnlyIfOnBranch()
+        ;
 
     job.StepPush("MyGet", "https://www.myget.org/F/duende_identityserver/api/v2/package", "MYGET");
 
@@ -180,8 +183,18 @@ public static class StepExtensions
             .Name("Setup .NET")
             .ActionsSetupDotNet("3e891b0cb619bf60e2c25674b222b8940e2c1c25", ["6.0.x", "8.0.x", "9.0.x"]); // v4.1.0
 
+    /// <summary>
+    /// Only run this for a main build
+    /// </summary>
     public static Step IfRefMain(this Step step) 
         => step.If("github.ref == 'refs/heads/main'");
+
+    /// <summary>
+    /// Only run this if the build is triggered on a branch IN the same repo
+    /// this means it's from a trusted contributor.
+    /// </summary>
+    public static Step OnlyIfOnBranch(this Step step)
+        => step.If("github.event == 'push'");
 
     public static void StepTestAndReport(this Job job, string componentName, string testProject)
     {
@@ -219,7 +232,7 @@ public static class StepExtensions
             .Run($"dotnet pack -c Release {path} -o artifacts");
     }
 
-    public static void StepSign(this Job job)
+    public static Step StepSign(this Job job)
     {
         var flags = "--file-digest sha256 "                                                +
                     "--timestamp-rfc3161 http://timestamp.digicert.com "                   +
@@ -228,8 +241,9 @@ public static class StepExtensions
                     "--azure-key-vault-tenant-id ed3089f0-5401-4758-90eb-066124e2d907 "    +
                     "--azure-key-vault-client-secret ${{ secrets.SignClientSecret }} "     +
                     "--azure-key-vault-certificate NuGetPackageSigning";
-        job.Step()
+        return job.Step()
             .Name("Sign packages")
+            .OnlyIfOnBranch()
             .Run($"""
                  for file in artifacts/*.nupkg; do
                     dotnet NuGetKeyVaultSignTool sign "$file" {flags}
@@ -246,10 +260,10 @@ public static class StepExtensions
             .Run($"dotnet nuget push artifacts/*.nupkg --source {sourceUrl} --api-key {apiKey} --skip-duplicate");
     }
 
-    public static void StepUploadArtifacts(this Job job, string componentName)
+    public static Step StepUploadArtifacts(this Job job, string componentName)
     {
         var path = $"{componentName}/artifacts/*.nupkg";
-        job.Step()
+        return job.Step()
             .Name("Upload Artifacts")
             .IfRefMain()
             .Uses("actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882") // 4.4.3
@@ -259,6 +273,25 @@ public static class StepExtensions
                 ("overwrite", "true"),
                 ("retention-days", "15"));
     }
+
+    /// <summary>
+    /// The build triggers both on branch AND on pull_request.
+    ///
+    /// Only (trusted) contributors can open branches in the main repo, so these builds can run with a higher trust level.
+    /// So, they are running with trigger 'push'. These builds have access to the secrets and thus they can do things like
+    /// sign, push the packages, etc..
+    /// 
+    /// External contributors can only create branches on external repo's. These builds run with a lower trust level.
+    /// So, they are running with trigger 'pull_request'. These builds do not have access to the secrets and thus they can't
+    /// sign, push the packages, etc..
+    ///
+    /// Now, if a trusted contributor creates a branch in the main repo, then creates a PR, we don't want to run the build twice.
+    /// This prevents that. The build will only run once, on the branch with the higher trust level.
+    /// 
+    /// </summary>
+    public static Job RunEitherOnBranchOrAsPR(this Job job)
+        => job.If(
+            "(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) || (github.event_name == 'push')");
 }
 
 public class GitHubContexts

--- a/.github/workflows/bff-ci.yml
+++ b/.github/workflows/bff-ci.yml
@@ -8,7 +8,7 @@ on:
     - .github/workflows/bff-**
     - bff/**
     - Directory.Packages.props
-  pull_request_target:
+  pull_request:
     paths:
     - .github/workflows/bff-**
     - bff/**
@@ -19,6 +19,7 @@ env:
 jobs:
   build:
     name: Build
+    if: (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) || (github.event_name == 'push')
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -99,6 +100,7 @@ jobs:
     - name: Pack Duende.Bff.Yarp
       run: dotnet pack -c Release src/Duende.Bff.Yarp -o artifacts
     - name: Sign packages
+      if: github.event == 'push'
       run: |-
         for file in artifacts/*.nupkg; do
            dotnet NuGetKeyVaultSignTool sign "$file" --file-digest sha256 --timestamp-rfc3161 http://timestamp.digicert.com --azure-key-vault-url https://duendecodesigninghsm.vault.azure.net/ --azure-key-vault-client-id 18e3de68-2556-4345-8076-a46fad79e474 --azure-key-vault-tenant-id ed3089f0-5401-4758-90eb-066124e2d907 --azure-key-vault-client-secret ${{ secrets.SignClientSecret }} --azure-key-vault-certificate NuGetPackageSigning

--- a/.github/workflows/bff-release.yml
+++ b/.github/workflows/bff-release.yml
@@ -54,6 +54,7 @@ jobs:
     - name: Tool restore
       run: dotnet tool restore
     - name: Sign packages
+      if: github.event == 'push'
       run: |-
         for file in artifacts/*.nupkg; do
            dotnet NuGetKeyVaultSignTool sign "$file" --file-digest sha256 --timestamp-rfc3161 http://timestamp.digicert.com --azure-key-vault-url https://duendecodesigninghsm.vault.azure.net/ --azure-key-vault-client-id 18e3de68-2556-4345-8076-a46fad79e474 --azure-key-vault-tenant-id ed3089f0-5401-4758-90eb-066124e2d907 --azure-key-vault-client-secret ${{ secrets.SignClientSecret }} --azure-key-vault-certificate NuGetPackageSigning

--- a/.github/workflows/identity-server-ci.yml
+++ b/.github/workflows/identity-server-ci.yml
@@ -8,7 +8,7 @@ on:
     - .github/workflows/identity-server-**
     - identity-server/**
     - Directory.Packages.props
-  pull_request_target:
+  pull_request:
     paths:
     - .github/workflows/identity-server-**
     - identity-server/**
@@ -19,6 +19,7 @@ env:
 jobs:
   build:
     name: Build
+    if: (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) || (github.event_name == 'push')
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -125,6 +126,7 @@ jobs:
     - name: Pack Storage
       run: dotnet pack -c Release src/Storage -o artifacts
     - name: Sign packages
+      if: github.event == 'push'
       run: |-
         for file in artifacts/*.nupkg; do
            dotnet NuGetKeyVaultSignTool sign "$file" --file-digest sha256 --timestamp-rfc3161 http://timestamp.digicert.com --azure-key-vault-url https://duendecodesigninghsm.vault.azure.net/ --azure-key-vault-client-id 18e3de68-2556-4345-8076-a46fad79e474 --azure-key-vault-tenant-id ed3089f0-5401-4758-90eb-066124e2d907 --azure-key-vault-client-secret ${{ secrets.SignClientSecret }} --azure-key-vault-certificate NuGetPackageSigning

--- a/.github/workflows/identity-server-release.yml
+++ b/.github/workflows/identity-server-release.yml
@@ -58,6 +58,7 @@ jobs:
     - name: Tool restore
       run: dotnet tool restore
     - name: Sign packages
+      if: github.event == 'push'
       run: |-
         for file in artifacts/*.nupkg; do
            dotnet NuGetKeyVaultSignTool sign "$file" --file-digest sha256 --timestamp-rfc3161 http://timestamp.digicert.com --azure-key-vault-url https://duendecodesigninghsm.vault.azure.net/ --azure-key-vault-client-id 18e3de68-2556-4345-8076-a46fad79e474 --azure-key-vault-tenant-id ed3089f0-5401-4758-90eb-066124e2d907 --azure-key-vault-client-secret ${{ secrets.SignClientSecret }} --azure-key-vault-certificate NuGetPackageSigning


### PR DESCRIPTION
**What issue does this PR address?**
This PR changes the build so that a build runs only once, and in the right security context, depending on their origins. 

_Previously, the build used pull_request_target. Effectively, this means that the entire context (including which code to build) was pointing to the target of the PR (likely main). This means it wasn't building anything in the PR, but actually building main (not very useful in a PR workflow)_ 

### How does it work?
1. Builds / pr's from contributors are run trusted and can access security tokens needed for signing. If you create a branch in the DuendeSoftware repo, then you'll automatically get a CI build for this. You can (must) create a PR for this to get it merged. When you create a PR, the build script will detect that there is still a branch for it and will built it normally (skip the PR build).

2. Builds from PR's created from external contributors (which have to originate from a different fork) will NOT run with security tokens, so artifacts will not be signed / pushed. 

### Publishing artifacts somewhere from external contributors. 
/
If we ever want to to anything with the output of external pr's other than merge them into main (IE: deploy them somewhere), then we should:
a. let the build publish the artifacts to github. 
b. setup a different workflow that will run only if the after the previous build is complete AND if pr is labelled (which only contributors can do) This workflow can then publish the changes. 






**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
