### PR TITLE
Remove IsExternalInit compatibility shim

### DIFF
--- a/bff/src/Duende.Bff/IsExternalInit.cs
+++ b/bff/src/Duende.Bff/IsExternalInit.cs
@@ -1,7 +1,0 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
-namespace System.Runtime.CompilerServices;
-
-// Allows "init" properties in .NET Core 3.1.
-internal static class IsExternalInit { }


### PR DESCRIPTION
This shim was used to support "init" properties in .NET Core 3.1. With its removal, code now assumes a more modern .NET version where this compatibility is no longer required. We live in the future.

![](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExdHUwbHRlZnQ1c3Y4cmZ2OGlxMWMxbmxyemo2em9sYW1idGo3aXo3NCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/aDcvK946SC3GwCqLk8/giphy.gif)
