### PR TITLE
Switch to TargetFrameworks for multi-framework support

### DIFF
--- a/identity-server/migrations/AspNetIdentityDb/AspNetIdentityDb.csproj
+++ b/identity-server/migrations/AspNetIdentityDb/AspNetIdentityDb.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net8.0;</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/identity-server/migrations/IdentityServerDb/IdentityServerDb.csproj
+++ b/identity-server/migrations/IdentityServerDb/IdentityServerDb.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net8.0;</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Updated project files to use `<TargetFrameworks>` instead of `<TargetFramework>` in both `IdentityServerDb.csproj` and `AspNetIdentityDb.csproj`.
