### PR TITLE
Handle case-insensitive JSON claim value types.

### DIFF
--- a/identity-server/src/IdentityServer/Extensions/ClaimsExtensions.cs
+++ b/identity-server/src/IdentityServer/Extensions/ClaimsExtensions.cs
@@ -84,11 +84,12 @@ internal static class ClaimsExtensions
             }
         }
 
-        if (claim.ValueType == IdentityServerConstants.ClaimValueTypes.Json)
+        // Ignore case here so that we also match System.IdentityModel.Tokens.Jwt.JsonClaimValueTypes.Json ("JSON")
+        if (claim.ValueType.Equals(IdentityServerConstants.ClaimValueTypes.Json, StringComparison.OrdinalIgnoreCase))
         {
             try
             {
-                return System.Text.Json.JsonSerializer.Deserialize<JsonElement>(claim.Value);
+                return JsonSerializer.Deserialize<JsonElement>(claim.Value);
             }
             catch { }
         }

--- a/identity-server/src/IdentityServer/Extensions/TokenExtensions.cs
+++ b/identity-server/src/IdentityServer/Extensions/TokenExtensions.cs
@@ -153,7 +153,8 @@ public static class TokenExtensions
             return double.Parse(claim.Value);
         }
         
-        if (claim.ValueType == IdentityServerConstants.ClaimValueTypes.Json)
+        // Ignore case here so that we also match System.IdentityModel.Tokens.Jwt.JsonClaimValueTypes.Json ("JSON")
+        if (claim.ValueType.Equals(IdentityServerConstants.ClaimValueTypes.Json, StringComparison.OrdinalIgnoreCase))
         {
             return JsonSerializer.Deserialize<JsonElement>(claim.Value);
         }

--- a/identity-server/test/IdentityServer.UnitTests/Extensions/ApiResourceSigningAlgorithmSelectionTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Extensions/ApiResourceSigningAlgorithmSelectionTests.cs
@@ -2,12 +2,8 @@
 // See LICENSE in the project root for license information.
 
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using Duende.IdentityServer.Models;
 using FluentAssertions;
-using Xunit;
 
 namespace UnitTests.Extensions;
 

--- a/identity-server/test/IdentityServer.UnitTests/Extensions/ClaimsExtensionsTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Extensions/ClaimsExtensionsTests.cs
@@ -1,0 +1,29 @@
+using System.Security.Claims;
+using System.Text.Json;
+using Duende.IdentityServer;
+using Duende.IdentityServer.Extensions;
+using FluentAssertions;
+
+namespace UnitTests.Extensions;
+
+public class ClaimsExtensionsTests
+{
+
+    [Theory]
+    [InlineData(System.IdentityModel.Tokens.Jwt.JsonClaimValueTypes.Json)]
+    [InlineData(IdentityServerConstants.ClaimValueTypes.Json)]
+    public void TestName(string claimType)
+    {
+        var payload =
+        """
+        {
+            "test": "value"
+        }
+        """;
+        Claim[] claims = [new Claim("claim", payload, claimType)];
+
+        var result = claims.ToClaimsDictionary();
+
+        result["claim"].Should().BeOfType<JsonElement>();
+    }
+}

--- a/identity-server/test/IdentityServer.UnitTests/Extensions/TokenExtensionsTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Extensions/TokenExtensionsTests.cs
@@ -30,6 +30,10 @@ public class TokenExtensionsTests
         "\"test_json_array\":[\"value1\",\"value2\",\"value3\"]")]
     [InlineData("test_json_obj", " { \"value1\": \"value2\" , \"value3\": [ \"value4\", \"value5\" ] } ", "json", 
         "\"test_json_obj\":{\"value1\":\"value2\",\"value3\":[\"value4\",\"value5\"]}")]
+    [InlineData("test_json_array", " [ \"value1\" , \"value2\" , \"value3\" ] ", "JSON", 
+        "\"test_json_array\":[\"value1\",\"value2\",\"value3\"]")]
+    [InlineData("test_json_obj", " { \"value1\": \"value2\" , \"value3\": [ \"value4\", \"value5\" ] } ", "JSON", 
+        "\"test_json_obj\":{\"value1\":\"value2\",\"value3\":[\"value4\",\"value5\"]}")]
     [InlineData("test_any", "raw\"string\tspecial char", "any", "\"test_any\":\"raw\\u0022string\\tspecial char\"")]
     public void TestClaimValueTypes(string type, string value, string valueType, string expected)
     {


### PR DESCRIPTION
This updates our serialization behavior so that we treat claims with either our json value type constant or the System.IdentityModel json value type constant the same. Prior to this change, we would serialize json with the System.IdentityModel as an escaped string instead of json, while our json value type constant would become json in the claims. 

After this change, either constant will work to put JSON into your claims. For example, code like this in a profile service will now serialize the claims as JSON, instead of a string containing escaped quotes:
```
var payload = 
"""
{
  "nested": {
    "sample": "value"
  }
}
""";
context.IssuedClaims.Add(new Claim("json", payload, System.IdentityModel.Tokens.Jwt.JsonClaimValueTypes.Json))
```

