### PR TITLE
Remove duplicate 'add' in AddEntityFrameworkServerSideSessionsServices

### DIFF
--- a/.github/workflows/bff-ci.yml
+++ b/.github/workflows/bff-ci.yml
@@ -53,7 +53,7 @@ jobs:
       run: 'ls '
       working-directory: test
     - name: Test report
-      if: success() || failure()
+      if: github.event == 'push' && (success() || failure())
       uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5
       with:
         name: Test Report

--- a/.github/workflows/identity-server-ci.yml
+++ b/.github/workflows/identity-server-ci.yml
@@ -51,7 +51,7 @@ jobs:
       run: 'ls '
       working-directory: test
     - name: Test report
-      if: success() || failure()
+      if: github.event == 'push' && (success() || failure())
       uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5
       with:
         name: Test Report

--- a/bff/docs/upgrade-guide.md
+++ b/bff/docs/upgrade-guide.md
@@ -99,3 +99,7 @@ a custom IAccessTokenRetriever, then you should adjust their usage accordingly.
     /// The remote address of the API.
     /// </summary>
     public required Uri ApiAddress { get; set; }
+
+### AddAddEntityFrameworkServerSideSessionsServices has been renamed to AddEntityFrameworkServerSideSessionsServices
+
+If you used the method AddAddEntityFrameworkServerSideSessionsServices() in your code, please replace it with the corrected AddEntityFrameworkServerSideSessionsServices()

--- a/bff/src/Bff.EntityFramework/Configuration/BffBuilderExtensions.cs
+++ b/bff/src/Bff.EntityFramework/Configuration/BffBuilderExtensions.cs
@@ -46,7 +46,7 @@ public static class BffBuilderExtensions
         where TContext : DbContext, ISessionDbContext
     {
         bffBuilder.Services.AddDbContext<TContext>(action);
-        return bffBuilder.AddAddEntityFrameworkServerSideSessionsServices<TContext>();
+        return bffBuilder.AddEntityFrameworkServerSideSessionsServices<TContext>();
     }
 
     /// <summary>
@@ -59,7 +59,7 @@ public static class BffBuilderExtensions
         where TContext : DbContext, ISessionDbContext
     {
         bffBuilder.Services.AddDbContext<TContext>(action);
-        return bffBuilder.AddAddEntityFrameworkServerSideSessionsServices<TContext>();
+        return bffBuilder.AddEntityFrameworkServerSideSessionsServices<TContext>();
     }
 
 
@@ -69,7 +69,7 @@ public static class BffBuilderExtensions
     /// </summary>
     /// <param name="bffBuilder"></param>
     /// <returns></returns>
-    public static BffBuilder AddAddEntityFrameworkServerSideSessionsServices<TContext>(this BffBuilder bffBuilder)
+    public static BffBuilder AddEntityFrameworkServerSideSessionsServices<TContext>(this BffBuilder bffBuilder)
         where TContext : ISessionDbContext
     {
         bffBuilder.Services.AddTransient<IUserSessionStoreCleanup, UserSessionStore>();


### PR DESCRIPTION
Fixes #1695

**What issue does this PR address?**
The method BffBuilderExtensions.AddAddEntityFrameworkServerSideSessionsServices() now is called AddEntityFrameworkServerSideSessionsServices(), without the duplicate 'add'. 

## Breaking Changes:

The name AddAddEntityFrameworkServerSideSessionsServices() has been renamed to AddEntityFrameworkServerSideSessionsServices.

If you used this method in your code, please rename it to .AddEntityFrameworkServerSideSessionsServices();

**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
