### PR TITLE
Some fixes to get the products mono solution compiling. 

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -71,6 +71,7 @@
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.0.0" />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="$(WilsonVersion)" />
+    <PackageVersion Include="Microsoft.IdentityModel.Logging" Version="$(WilsonVersion)" />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="$(WilsonVersion)" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="Microsoft.NETCore.Jit" Version="2.0.8" />
@@ -91,6 +92,7 @@
     <PackageVersion Include="RichardSzalay.MockHttp" Version="7.0.0" />
     <PackageVersion Include="Serilog" Version="4.2.0" />
     <PackageVersion Include="Serilog.AspNetCore" Version="8.0.3" />
+    <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageVersion Include="Serilog.Sinks.TextWriter" Version="3.0.0" />
     <PackageVersion Include="Serilog.Sinks.XUnit" Version="3.0.19" />
     <PackageVersion Include="Serilog.Extensions.Logging" Version="9.0.0" />

--- a/identity-server/clients/src/WindowsConsoleSystemBrowser/Program.cs
+++ b/identity-server/clients/src/WindowsConsoleSystemBrowser/Program.cs
@@ -1,4 +1,4 @@
-﻿using Clients;
+using Clients;
 using Duende.IdentityModel.Client;
 using Duende.IdentityModel.OidcClient;
 using Microsoft.IdentityModel.Logging;
@@ -8,10 +8,12 @@ using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using System.Threading.Tasks;
 
 namespace WindowsConsoleSystemBrowser
 {
+    [SupportedOSPlatform("Windows")]
     class Program
     {
         static async Task Main(string[] args)

--- a/identity-server/clients/src/WindowsConsoleSystemBrowser/RegistryConfig.cs
+++ b/identity-server/clients/src/WindowsConsoleSystemBrowser/RegistryConfig.cs
@@ -1,9 +1,11 @@
-﻿using System;
+using System;
 using System.Reflection;
+using System.Runtime.Versioning;
 using Microsoft.Win32;
 
 namespace WindowsConsoleSystemBrowser
 {
+    [SupportedOSPlatform("Windows")]
     class RegistryConfig
     {
         public RegistryConfig(string uriScheme)

--- a/identity-server/clients/src/WindowsConsoleSystemBrowser/WindowsConsoleSystemBrowser.csproj
+++ b/identity-server/clients/src/WindowsConsoleSystemBrowser/WindowsConsoleSystemBrowser.csproj
@@ -1,13 +1,14 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net472</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Duende.IdentityModel.OidcClient" />
-    
+    <PackageReference Include="Microsoft.IdentityModel.Logging"/>
     <PackageReference Include="Serilog.Extensions.Logging" />
     <PackageReference Include="Serilog.Sinks.Console" />
   </ItemGroup>

--- a/identity-server/perf/IdentityServer.PerfTests/IdentityServer.PerfTests.csproj
+++ b/identity-server/perf/IdentityServer.PerfTests/IdentityServer.PerfTests.csproj
@@ -2,12 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-      <TargetFramework>net6.0</TargetFramework>
+      <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.9" />
+        <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.12" />
+        <PackageReference Include="Microsoft.IdentityModel.Logging" Version="8.4.0" />
     </ItemGroup>
 
   <ItemGroup>

--- a/identity-server/test/IdentityServer.IntegrationTests/Hosting/ServerSideSessionTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Hosting/ServerSideSessionTests.cs
@@ -2,22 +2,21 @@
 // See LICENSE in the project root for license information.
 
 
+using Duende.IdentityModel.Client;
+using Duende.IdentityServer;
+using Duende.IdentityServer.Extensions;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services;
 using Duende.IdentityServer.Stores;
 using Duende.IdentityServer.Test;
-using Shouldly;
 using IntegrationTests.Common;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.Extensions.DependencyInjection;
-using Duende.IdentityModel.Client;
-using Microsoft.IdentityModel.JsonWebTokens;
-using Microsoft.AspNetCore.Authentication.Cookies;
-using Duende.IdentityServer;
-using Microsoft.AspNetCore.DataProtection;
-using Duende.IdentityServer.Extensions;
-using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.JsonWebTokens;
+using System.Security.Claims;
 
 namespace IntegrationTests.Hosting;
 
@@ -503,10 +502,10 @@ public class ServerSideSessionTests
             var jwt = form.Substring("login_token=".Length + 1);
             var handler = new JsonWebTokenHandler();
             var token = handler.ReadJsonWebToken(jwt);
-            token.Issuer.Should().Be(IdentityServerPipeline.BaseUrl);
-            token.GetClaim("sub").Value.Should().Be("alice");
+            token.Issuer.ShouldBe(IdentityServerPipeline.BaseUrl);
+            token.GetClaim("sub").Value.ShouldBe("alice");
         };
-        _pipeline.BackChannelMessageHandler.InvokeWasCalled.Should().BeFalse();
+        _pipeline.BackChannelMessageHandler.InvokeWasCalled.ShouldBeFalse();
 
         var session = (await _sessionStore.GetSessionsAsync(new SessionFilter { SubjectId = "alice" })).Single();
         session.Expires = System.DateTime.UtcNow.AddMinutes(-1);
@@ -514,7 +513,7 @@ public class ServerSideSessionTests
 
         await _pipeline.RequestAuthorizationEndpointAsync("client", "code", "openid api offline_access", "https://client/callback");
 
-        _pipeline.BackChannelMessageHandler.InvokeWasCalled.Should().BeTrue();
+        _pipeline.BackChannelMessageHandler.InvokeWasCalled.ShouldBeTrue();
     }
 
     [Fact]


### PR DESCRIPTION
**What issue does this PR address?**

- `WindowsConsoleSystemBrowser` targets net8.0 (instead of net472) and some adjustments to get compiling
- `IdentityServer.PerfTests` targets net8.0 (instead of net6.0) and update package refs to get compiling again

This PR is stacked on #1768 and will be rebased when that is merged.

**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
