### PR TITLE
Filter client credentials in ToOptimizedFullDictionary method

### DIFF
--- a/identity-server/src/IdentityServer/Extensions/ValidatedAuthorizeRequestExtensions.cs
+++ b/identity-server/src/IdentityServer/Extensions/ValidatedAuthorizeRequestExtensions.cs
@@ -195,6 +195,16 @@ public static class ValidatedAuthorizeRequestExtensions
     [Obsolete("This method is obsolete and will be removed in a future version.")]
     public static IDictionary<string, string[]> ToOptimizedFullDictionary(this ValidatedAuthorizeRequest request)
     {
-        return request.ToOptimizedRawValues().ToFullDictionary();
+        var collection = request.ToOptimizedRawValues();
+        
+        // Filter client authentication out of the dictionary that we're building
+        // It's possible for a PAR request to include client auth and we don't want
+        // that to cause these values to get passed into the (obsolete) authorization
+        // parameters message store, where they might get logged or otherwise stored
+        // insecurely.
+        collection.Remove(OidcConstants.TokenRequest.ClientAssertion);
+        collection.Remove(OidcConstants.TokenRequest.ClientSecret);
+        
+        return collection.ToFullDictionary();
     }
 }

--- a/identity-server/test/IdentityServer.UnitTests/Extensions/ValidatedAuthorizeRequestExtensionsTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Extensions/ValidatedAuthorizeRequestExtensionsTests.cs
@@ -47,4 +47,23 @@ public class ValidatedAuthorizeRequestExtensionsTests
 
         Assert.Equal(2, res[OidcConstants.AuthorizeRequest.Resource].Length);
     }
+
+    [Theory]
+    [Obsolete]
+    [InlineData(OidcConstants.TokenRequest.ClientAssertion)]
+    [InlineData(OidcConstants.TokenRequest.ClientSecret)]
+    public void ToOptimizedFullDictionary_should_filter_client_credentials(string filteredClaimType)
+    {
+        var request = new ValidatedAuthorizeRequest()
+        {
+            Raw = new System.Collections.Specialized.NameValueCollection
+            {
+                { filteredClaimType, "" },
+            }
+        };
+
+        var result = request.ToOptimizedFullDictionary();
+
+        Assert.Empty(result);
+    }
 }


### PR DESCRIPTION
Filter client authentication because it's possible for a PAR request to include client auth, and we don't want that to cause client auth parameters to get passed into the authorization parameters message store, where they might get logged or otherwise stored insecurely.