### PR TITLE
Ensure session lifetime coordination is invoked when a session expires

### DIFF
--- a/identity-server/src/IdentityServer/Constants.cs
+++ b/identity-server/src/IdentityServer/Constants.cs
@@ -223,6 +223,7 @@ internal static class Constants
     {
         public const string IdentityServerBasePath = "idsvr:IdentityServerBasePath";
         public const string SignOutCalled = "idsvr:IdentityServerSignOutCalled";
+        public const string DetectedExpiredUserSession = "idsvr:IdentityServerDetectedExpiredUserSession";
     }
 
     public static class TokenTypeHints

--- a/identity-server/src/IdentityServer/Extensions/HttpContextExtensions.cs
+++ b/identity-server/src/IdentityServer/Extensions/HttpContextExtensions.cs
@@ -29,6 +29,23 @@ public static class HttpContextExtensions
         return context.Items.ContainsKey(Constants.EnvironmentKeys.SignOutCalled);
     }
 
+    internal static void SetExpiredUserSession(this HttpContext context, UserSession userSession)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        context.Items[Constants.EnvironmentKeys.DetectedExpiredUserSession] = userSession;
+    }
+
+    internal static bool TryGetExpiredUserSession(this HttpContext context, out UserSession expiredUserSession)
+    {
+        expiredUserSession = null;
+        if (context.Items.TryGetValue(Constants.EnvironmentKeys.DetectedExpiredUserSession, out var userSession))
+        {
+            expiredUserSession = userSession as UserSession;
+        }
+
+        return expiredUserSession != null;
+    }
+
     internal static async Task<string> GetIdentityServerSignoutFrameCallbackUrlAsync(this HttpContext context, LogoutMessage logoutMessage = null)
     {
         var userSession = context.RequestServices.GetRequiredService<IUserSession>();

--- a/identity-server/src/IdentityServer/Hosting/IdentityServerMiddleware.cs
+++ b/identity-server/src/IdentityServer/Hosting/IdentityServerMiddleware.cs
@@ -83,6 +83,13 @@ public class IdentityServerMiddleware
                     await sessionCoordinationService.ProcessLogoutAsync(session);
                 }
             }
+
+            if (context.TryGetExpiredUserSession(out var expiredUserSession))
+            {
+                _logger.LogDebug("Detected expired session removed; processing post-expiration cleanup.");
+                
+                await sessionCoordinationService.ProcessExpirationAsync(expiredUserSession);
+            }
         });
 
         try


### PR DESCRIPTION
**What issue does this PR address?**
Scenarios can exist where session lifetime coordination is enabled but a session is expired and removed prior to the cleanup job running and processing that expiration. These changes account for that scenario and implement a workaround to detect when the dotnet cookie handler removes a session and triggers the session coordination service's processing of an expired session to ensure things such as backchannel logout and removal of grants.


**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
