### PR TITLE
Use FluentAssertions.Web to assert on Http responses

### DIFF
--- a/bff/test/Bff.Tests/Bff.Tests.csproj
+++ b/bff/test/Bff.Tests/Bff.Tests.csproj
@@ -8,6 +8,7 @@
   
     <ItemGroup>
         <PackageReference Include="Duende.IdentityServer" />
+        <PackageReference Include="FluentAssertions.Web" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
         <PackageReference Include="Microsoft.AspNetCore.TestHost" />
         <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />

--- a/bff/test/Bff.Tests/Endpoints/LocalEndpointTests.cs
+++ b/bff/test/Bff.Tests/Endpoints/LocalEndpointTests.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
+using FluentAssertions;
 
 namespace Duende.Bff.Tests.Endpoints
 {
@@ -59,7 +60,7 @@ namespace Duende.Bff.Tests.Endpoints
             var req = new HttpRequestMessage(HttpMethod.Get, BffHost.Url("/local_anon"));
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+            response.Should().Be401Unauthorized();
         }
 
 
@@ -109,7 +110,7 @@ namespace Duende.Bff.Tests.Endpoints
             req.Headers.Add("x-csrf", "1");
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            response.Should().Be302Redirect();
             response.Headers.Location
                 .ShouldNotBeNull()
                 .ToString()

--- a/bff/test/Bff.Tests/Endpoints/Management/LoginEndpointTests.cs
+++ b/bff/test/Bff.Tests/Endpoints/Management/LoginEndpointTests.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
+using FluentAssertions;
 
 namespace Duende.Bff.Tests.Endpoints.Management
 {
@@ -37,16 +38,16 @@ namespace Duende.Bff.Tests.Endpoints.Management
         public async Task login_endpoint_should_challenge_and_redirect_to_root()
         {
             var response = await BffHost.BrowserClient.GetAsync(BffHost.Url("/bff/login"));
-            response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            response.Should().Be302Redirect();
             response.Headers.Location!.ToString().ShouldStartWith(IdentityServerHost.Url("/connect/authorize"));
 
             await IdentityServerHost.IssueSessionCookieAsync("alice");
             response = await IdentityServerHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
-            response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            response.Should().Be302Redirect();
             response.Headers.Location!.ToString().ShouldStartWith(BffHost.Url("/signin-oidc"));
 
             response = await BffHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
-            response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            response.Should().Be302Redirect();
             response.Headers.Location!.ToString().ShouldBe("/");
         }
         
@@ -61,16 +62,16 @@ namespace Duende.Bff.Tests.Endpoints.Management
             await BffHost.InitializeAsync();
             
             var response = await BffHost.BrowserClient.GetAsync(BffHost.Url("/custom/bff/login"));
-            response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            response.Should().Be302Redirect();
             response.Headers.Location!.ToString().ShouldStartWith(IdentityServerHost.Url("/connect/authorize"));
 
             await IdentityServerHost.IssueSessionCookieAsync("alice");
             response = await IdentityServerHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
-            response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            response.Should().Be302Redirect();
             response.Headers.Location!.ToString().ShouldStartWith(BffHost.Url("/signin-oidc"));
 
             response = await BffHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
-            response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            response.Should().Be302Redirect();
             response.Headers.Location!.ToString().ShouldBe("/");
         }
         
@@ -85,16 +86,16 @@ namespace Duende.Bff.Tests.Endpoints.Management
             await BffHost.InitializeAsync();
             
             var response = await BffHost.BrowserClient.GetAsync(BffHost.Url("/custom/bff/login"));
-            response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            response.Should().Be302Redirect();
             response.Headers.Location!.ToString().ShouldStartWith(IdentityServerHost.Url("/connect/authorize"));
 
             await IdentityServerHost.IssueSessionCookieAsync("alice");
             response = await IdentityServerHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
-            response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            response.Should().Be302Redirect();
             response.Headers.Location!.ToString().ShouldStartWith(BffHost.Url("/signin-oidc"));
 
             response = await BffHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
-            response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            response.Should().Be302Redirect();
             response.Headers.Location!.ToString().ShouldBe("/");
         }
         
@@ -109,16 +110,16 @@ namespace Duende.Bff.Tests.Endpoints.Management
             await BffHost.InitializeAsync();
             
             var response = await BffHost.BrowserClient.GetAsync(BffHost.Url("/login"));
-            response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            response.Should().Be302Redirect();
             response.Headers.Location!.ToString().ShouldStartWith(IdentityServerHost.Url("/connect/authorize"));
 
             await IdentityServerHost.IssueSessionCookieAsync("alice");
             response = await IdentityServerHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
-            response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            response.Should().Be302Redirect();
             response.Headers.Location!.ToString().ShouldStartWith(BffHost.Url("/signin-oidc"));
 
             response = await BffHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
-            response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            response.Should().Be302Redirect();
             response.Headers.Location!.ToString().ShouldBe("/");
         }
         
@@ -128,7 +129,7 @@ namespace Duende.Bff.Tests.Endpoints.Management
             await BffHost.BffLoginAsync("alice");
 
             var response = await BffHost.BrowserClient.GetAsync(BffHost.Url("/bff/login"));
-            response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            response.Should().Be302Redirect();
             response.Headers.Location!.ToString().ShouldStartWith(IdentityServerHost.Url("/connect/authorize"));
         }
 
@@ -136,16 +137,16 @@ namespace Duende.Bff.Tests.Endpoints.Management
         public async Task login_endpoint_should_accept_returnUrl()
         {
             var response = await BffHost.BrowserClient.GetAsync(BffHost.Url("/bff/login") + "?returnUrl=/foo");
-            response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            response.Should().Be302Redirect();
             response.Headers.Location!.ToString().ShouldStartWith(IdentityServerHost.Url("/connect/authorize"));
 
             await IdentityServerHost.IssueSessionCookieAsync("alice");
             response = await IdentityServerHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
-            response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            response.Should().Be302Redirect();
             response.Headers.Location!.ToString().ShouldStartWith(BffHost.Url("/signin-oidc"));
 
             response = await BffHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
-            response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+            response.Should().Be302Redirect();
             response.Headers.Location!.ToString().ShouldBe("/foo");
         }
 

--- a/bff/test/Bff.Tests/Endpoints/Management/LogoutEndpointTests.cs
+++ b/bff/test/Bff.Tests/Endpoints/Management/LogoutEndpointTests.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
+using FluentAssertions;
 
 namespace Duende.Bff.Tests.Endpoints.Management
 {
@@ -62,7 +63,7 @@ namespace Duende.Bff.Tests.Endpoints.Management
             BffHost.BffOptions.RequireLogoutSessionId = false;
 
             var response = await BffHost.BrowserClient.GetAsync(BffHost.Url("/bff/logout"));
-            response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // endsession
+            response.Should().Be302Redirect(); // endsession
             response.Headers.Location!.ToString().ToLowerInvariant().ShouldStartWith(IdentityServerHost.Url("/connect/endsession"));
         }
 
@@ -80,7 +81,7 @@ namespace Duende.Bff.Tests.Endpoints.Management
             await BffHost.IssueSessionCookieAsync("alice");
 
             var response = await BffHost.BrowserClient.GetAsync(BffHost.Url("/bff/logout"));
-            response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // endsession
+            response.Should().Be302Redirect(); // endsession
             response.Headers.Location!.ToString().ToLowerInvariant().ShouldStartWith(IdentityServerHost.Url("/connect/endsession"));
         }
 
@@ -88,7 +89,7 @@ namespace Duende.Bff.Tests.Endpoints.Management
         public async Task logout_endpoint_for_anonymous_user_without_sid_should_succeed()
         {
             var response = await BffHost.BrowserClient.GetAsync(BffHost.Url("/bff/logout"));
-            response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // endsession
+            response.Should().Be302Redirect(); // endsession
             response.Headers.Location!.ToString().ToLowerInvariant().ShouldStartWith(IdentityServerHost.Url("/connect/endsession"));
         }
 
@@ -114,19 +115,19 @@ namespace Duende.Bff.Tests.Endpoints.Management
             await BffHost.BffLoginAsync("alice", "sid123");
 
             var response = await BffHost.BrowserClient.GetAsync(BffHost.Url("/bff/logout") + "?sid=sid123&returnUrl=/foo");
-            response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // endsession
+            response.Should().Be302Redirect(); // endsession
             response.Headers.Location!.ToString().ToLowerInvariant().ShouldStartWith(IdentityServerHost.Url("/connect/endsession"));
 
             response = await IdentityServerHost.BrowserClient.GetAsync(response.Headers.Location!.ToString());
-            response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // logout
+            response.Should().Be302Redirect(); // logout
             response.Headers.Location!.ToString().ToLowerInvariant().ShouldStartWith(IdentityServerHost.Url("/account/logout"));
 
             response = await IdentityServerHost.BrowserClient.GetAsync(response.Headers.Location!.ToString());
-            response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // post logout redirect uri
+            response.Should().Be302Redirect(); // post logout redirect uri
             response.Headers.Location!.ToString().ToLowerInvariant().ShouldStartWith(BffHost.Url("/signout-callback-oidc"));
 
             response = await BffHost.BrowserClient.GetAsync(response.Headers.Location!.ToString());
-            response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // root
+            response.Should().Be302Redirect(); // root
             response.Headers.Location!.ToString().ToLowerInvariant().ShouldBe("/foo");
         }
 

--- a/bff/test/Bff.Tests/Endpoints/Management/UserEndpointTests.cs
+++ b/bff/test/Bff.Tests/Endpoints/Management/UserEndpointTests.cs
@@ -5,6 +5,7 @@ using Duende.Bff.Tests.TestHosts;
 using System.Security.Claims;
 using System.Net;
 using Xunit.Abstractions;
+using FluentAssertions;
 
 namespace Duende.Bff.Tests.Endpoints.Management
 {
@@ -56,7 +57,7 @@ namespace Duende.Bff.Tests.Endpoints.Management
             var req = new HttpRequestMessage(HttpMethod.Get, BffHost.Url("/bff/user"));
             var response = await BffHost.BrowserClient.SendAsync(req);
             
-            response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+            response.Should().Be401Unauthorized();
         }
 
         [Fact]
@@ -66,7 +67,7 @@ namespace Duende.Bff.Tests.Endpoints.Management
             req.Headers.Add("x-csrf", "1");
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+            response.Should().Be401Unauthorized();
         }
 
         [Fact]

--- a/bff/test/Bff.Tests/Endpoints/RemoteEndpointTests.cs
+++ b/bff/test/Bff.Tests/Endpoints/RemoteEndpointTests.cs
@@ -3,6 +3,7 @@
 
 using Duende.Bff.Tests.TestFramework;
 using Duende.Bff.Tests.TestHosts;
+using FluentAssertions;
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
@@ -272,7 +273,7 @@ namespace Duende.Bff.Tests.Endpoints
             var req = new HttpRequestMessage(HttpMethod.Get, BffHost.Url("/api_user_or_client/test"));
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+            response.Should().Be401Unauthorized();
         }
 
         [Fact]
@@ -300,13 +301,13 @@ namespace Duende.Bff.Tests.Endpoints
             req.Headers.Add("my-header-to-be-copied-by-yarp", "copied-value");
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.IsSuccessStatusCode.ShouldBeTrue();
-            response.Content.Headers.ContentType!.MediaType.ShouldBe("application/json");
+            response.Should().Be2XXSuccessful();
+            response.Should().HaveHeader("Content-Type", "application/json");
             var json = await response.Content.ReadAsStringAsync();
             ApiResponse apiResult = JsonSerializer.Deserialize<ApiResponse>(json).ShouldNotBeNull();
             apiResult.RequestHeaders["my-header-to-be-copied-by-yarp"].First().ShouldBe("copied-value");
 
-            response.Content.Headers.Select(x => x.Key).ShouldNotContain("added-by-custom-default-transform", 
+            response.Should().NotHaveHeader("added-by-custom-default-transform", 
                 "a custom transform doesn't run the defaults");
         }
     }

--- a/bff/test/Bff.Tests/Endpoints/YarpRemoteEndpointTests.cs
+++ b/bff/test/Bff.Tests/Endpoints/YarpRemoteEndpointTests.cs
@@ -9,6 +9,7 @@ using Duende.Bff.Tests.TestFramework;
 using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
+using FluentAssertions;
 
 namespace Duende.Bff.Tests.Endpoints
 {
@@ -29,7 +30,7 @@ namespace Duende.Bff.Tests.Endpoints
             var req = new HttpRequestMessage(HttpMethod.Get, YarpBasedBffHost.Url("/api_anon/test"));
             var response = await YarpBasedBffHost.BrowserClient.SendAsync(req);
 
-            response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+            response.Should().Be401Unauthorized();
         }
 
 

--- a/bff/test/Bff.Tests/Headers/ApiAndBffUseForwardedHeaders.cs
+++ b/bff/test/Bff.Tests/Headers/ApiAndBffUseForwardedHeaders.cs
@@ -4,7 +4,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using Duende.Bff.Tests.TestFramework;
 using Duende.Bff.Tests.TestHosts;
-using Shouldly;
+using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -25,7 +25,7 @@ namespace Duende.Bff.Tests.Headers
             req.Headers.Add("x-csrf", "1");
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.IsSuccessStatusCode.ShouldBeTrue();
+            response.Should().Be2XXSuccessful();
             var json = await response.Content.ReadAsStringAsync();
             var apiResult = JsonSerializer.Deserialize<ApiResponse>(json).ShouldNotBeNull();
 
@@ -43,7 +43,7 @@ namespace Duende.Bff.Tests.Headers
             req.Headers.Add("X-Forwarded-Host", "external");
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.IsSuccessStatusCode.ShouldBeTrue();
+            response.Should().Be2XXSuccessful();
             var json = await response.Content.ReadAsStringAsync();
             var apiResult = JsonSerializer.Deserialize<ApiResponse>(json).ShouldNotBeNull();
 
@@ -61,7 +61,7 @@ namespace Duende.Bff.Tests.Headers
             req.Headers.Add("X-Forwarded-Host", "external");
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.IsSuccessStatusCode.ShouldBeTrue();
+            response.Should().Be2XXSuccessful();
             var json = await response.Content.ReadAsStringAsync();
             var apiResult = JsonSerializer.Deserialize<ApiResponse>(json).ShouldNotBeNull();
 

--- a/bff/test/Bff.Tests/Headers/ApiUseForwardedHeaders.cs
+++ b/bff/test/Bff.Tests/Headers/ApiUseForwardedHeaders.cs
@@ -24,7 +24,7 @@ namespace Duende.Bff.Tests.Headers
             req.Headers.Add("x-csrf", "1");
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.IsSuccessStatusCode.ShouldBeTrue();
+            response.Should().Be2XXSuccessful();
             var json = await response.Content.ReadAsStringAsync();
             var apiResult = JsonSerializer.Deserialize<ApiResponse>(json).ShouldNotBeNull();
 
@@ -40,7 +40,7 @@ namespace Duende.Bff.Tests.Headers
             req.Headers.Add("X-Forwarded-Host", "external");
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.IsSuccessStatusCode.ShouldBeTrue();
+            response.Should().Be2XXSuccessful();
             var json = await response.Content.ReadAsStringAsync();
             var apiResult = JsonSerializer.Deserialize<ApiResponse>(json).ShouldNotBeNull();
 

--- a/bff/test/Bff.Tests/Headers/General.cs
+++ b/bff/test/Bff.Tests/Headers/General.cs
@@ -19,7 +19,7 @@ namespace Duende.Bff.Tests.Headers
             req.Headers.Add("x-csrf", "1");
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.IsSuccessStatusCode.ShouldBeTrue();
+            response.Should().Be2XXSuccessful();
             var json = await response.Content.ReadAsStringAsync();
             var apiResult = JsonSerializer.Deserialize<ApiResponse>(json).ShouldNotBeNull();
 
@@ -38,7 +38,7 @@ namespace Duende.Bff.Tests.Headers
             req.Headers.Add("x-custom", "custom");
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.IsSuccessStatusCode.ShouldBeTrue();
+            response.Should().Be2XXSuccessful();
             var json = await response.Content.ReadAsStringAsync();
             var apiResult = JsonSerializer.Deserialize<ApiResponse>(json).ShouldNotBeNull();
 
@@ -56,7 +56,7 @@ namespace Duende.Bff.Tests.Headers
             req.Headers.Add("x-custom", "custom");
             var response = await BffHost.BrowserClient.SendAsync(req);
 
-            response.IsSuccessStatusCode.ShouldBeTrue();
+            response.Should().Be2XXSuccessful();
             var json = await response.Content.ReadAsStringAsync();
             var apiResult = JsonSerializer.Deserialize<ApiResponse>(json).ShouldNotBeNull();
             

--- a/bff/test/Bff.Tests/TestHosts/BffHostUsingResourceNamedTokens.cs
+++ b/bff/test/Bff.Tests/TestHosts/BffHostUsingResourceNamedTokens.cs
@@ -18,6 +18,7 @@ using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Yarp.ReverseProxy.Forwarder;
+using FluentAssertions;
 
 namespace Duende.Bff.Tests.TestHosts
 {
@@ -182,15 +183,15 @@ namespace Duende.Bff.Tests.TestHosts
         public async Task<HttpResponseMessage> BffOidcLoginAsync()
         {
             var response = await BrowserClient.GetAsync(Url("/bff/login"));
-            response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // authorize
+            response.Should().Be302Redirect(); // authorize
             response.Headers.Location!.ToString().ToLowerInvariant().ShouldStartWith(_identityServerHost.Url("/connect/authorize"));
 
             response = await _identityServerHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
-            response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // client callback
+            response.Should().Be302Redirect(); // client callback
             response.Headers.Location!.ToString().ToLowerInvariant().ShouldStartWith(Url("/signin-oidc"));
 
             response = await BrowserClient.GetAsync(response.Headers.Location.ToString());
-            response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // root
+            response.Should().Be302Redirect(); // root
             response.Headers.Location!.ToString().ToLowerInvariant().ShouldBe("/");
 
             (await GetIsUserLoggedInAsync()).ShouldBeTrue();
@@ -202,19 +203,19 @@ namespace Duende.Bff.Tests.TestHosts
         public async Task<HttpResponseMessage> BffLogoutAsync(string? sid = null)
         {
             var response = await BrowserClient.GetAsync(Url("/bff/logout") + "?sid=" + sid);
-            response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // endsession
+            response.Should().Be302Redirect(); // endsession
             response.Headers.Location!.ToString().ToLowerInvariant().ShouldStartWith(_identityServerHost.Url("/connect/endsession"));
 
             response = await _identityServerHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
-            response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // logout
+            response.Should().Be302Redirect(); // logout
             response.Headers.Location!.ToString().ToLowerInvariant().ShouldStartWith(_identityServerHost.Url("/account/logout"));
 
             response = await _identityServerHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
-            response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // post logout redirect uri
+            response.Should().Be302Redirect(); // post logout redirect uri
             response.Headers.Location!.ToString().ToLowerInvariant().ShouldStartWith(Url("/signout-callback-oidc"));
 
             response = await BrowserClient.GetAsync(response.Headers.Location.ToString());
-            response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // root
+            response.Should().Be302Redirect(); // root
             response.Headers.Location!.ToString().ToLowerInvariant().ShouldBe("/");
 
             (await GetIsUserLoggedInAsync()).ShouldBeFalse();

--- a/bff/test/Bff.Tests/TestHosts/YarpBffHost.cs
+++ b/bff/test/Bff.Tests/TestHosts/YarpBffHost.cs
@@ -10,6 +10,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using Duende.Bff.Tests.TestFramework;
 using Duende.Bff.Yarp;
+using FluentAssertions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.DependencyInjection;
@@ -274,16 +275,16 @@ public class YarpBffHost : GenericHost
     public async Task<HttpResponseMessage> BffOidcLoginAsync()
     {
         var response = await BrowserClient.GetAsync(Url("/bff/login"));
-        response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // authorize
+        response.Should().Be302Redirect(); // authorize
         response.Headers.Location!.ToString().ToLowerInvariant()
             .ShouldStartWith(_identityServerHost.Url("/connect/authorize"));
 
         response = await _identityServerHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
-        response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // client callback
+        response.Should().Be302Redirect(); // client callback
         response.Headers.Location!.ToString().ToLowerInvariant().ShouldStartWith(Url("/signin-oidc"));
 
         response = await BrowserClient.GetAsync(response.Headers.Location.ToString());
-        response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // root
+        response.Should().Be302Redirect(); // root
         response.Headers.Location!.ToString().ToLowerInvariant().ShouldBe("/");
 
         (await GetIsUserLoggedInAsync()).ShouldBeTrue();
@@ -295,21 +296,21 @@ public class YarpBffHost : GenericHost
     public async Task<HttpResponseMessage> BffLogoutAsync(string? sid = null)
     {
         var response = await BrowserClient.GetAsync(Url("/bff/logout") + "?sid=" + sid);
-        response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // endsession
+        response.Should().Be302Redirect(); // endsession
         response.Headers.Location!.ToString().ToLowerInvariant()
             .ShouldStartWith(_identityServerHost.Url("/connect/endsession"));
 
         response = await _identityServerHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
-        response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // logout
+        response.Should().Be302Redirect(); // logout
         response.Headers.Location!.ToString().ToLowerInvariant()
             .ShouldStartWith(_identityServerHost.Url("/account/logout"));
 
         response = await _identityServerHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
-        response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // post logout redirect uri
+        response.Should().Be302Redirect(); // post logout redirect uri
         response.Headers.Location!.ToString().ToLowerInvariant().ShouldStartWith(Url("/signout-callback-oidc"));
 
         response = await BrowserClient.GetAsync(response.Headers.Location.ToString());
-        response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // root
+        response.Should().Be302Redirect(); // root
         response.Headers.Location!.ToString().ToLowerInvariant().ShouldBe("/");
 
         (await GetIsUserLoggedInAsync()).ShouldBeFalse();

--- a/bff/test/Hosts.Tests/BffTests.cs
+++ b/bff/test/Hosts.Tests/BffTests.cs
@@ -1,5 +1,5 @@
 using Hosts.Tests.TestInfra;
-using Shouldly;
+using FluentAssertions;
 using Xunit.Abstractions;
 
 namespace Hosts.Tests;
@@ -19,7 +19,7 @@ public class BffTests : IntegrationTestBase
     public async Task Can_invoke_home()
     {
         var response = await _httpClient.GetAsync("/");
-        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.Should().Be200Ok();
     }
 
     [SkippableFact]

--- a/bff/test/Hosts.Tests/Hosts.Tests.csproj
+++ b/bff/test/Hosts.Tests/Hosts.Tests.csproj
@@ -14,7 +14,8 @@
 
 	<ItemGroup>
 
-		<PackageReference Include="AngleSharp" />
+        <PackageReference Include="AngleSharp" />
+        <PackageReference Include="FluentAssertions.Web" />
 		<PackageReference Include="Serilog" />
 		<PackageReference Include="Serilog.Extensions.Logging" />
 		<PackageReference Include="Serilog.Sinks.TextWriter" />

--- a/identity-server/test/Configuration.IntegrationTests/Configuration.IntegrationTests.csproj
+++ b/identity-server/test/Configuration.IntegrationTests/Configuration.IntegrationTests.csproj
@@ -15,8 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" />
     <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="FluentAssertions.Web" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />

--- a/identity-server/test/Configuration.IntegrationTests/DynamicClientRegistrationValidationTests.cs
+++ b/identity-server/test/Configuration.IntegrationTests/DynamicClientRegistrationValidationTests.cs
@@ -18,7 +18,7 @@ public class DynamicClientRegistrationValidationTests : ConfigurationIntegration
     public async Task http_get_method_should_fail()
     {
         var response = await ConfigurationHost.HttpClient!.GetAsync("/connect/dcr");
-        response.StatusCode.Should().Be(HttpStatusCode.MethodNotAllowed);
+        response.Should().Be405MethodNotAllowed();
     }
 
     [Fact]
@@ -29,7 +29,7 @@ public class DynamicClientRegistrationValidationTests : ConfigurationIntegration
             { "grant_types", "authorization_code" }
         });
         var response = await ConfigurationHost.HttpClient!.PostAsync("/connect/dcr", content);
-        response.StatusCode.Should().Be(HttpStatusCode.UnsupportedMediaType);
+        response.Should().Be415UnsupportedMediaType();
     }
 
     [Fact]
@@ -39,10 +39,8 @@ public class DynamicClientRegistrationValidationTests : ConfigurationIntegration
         {
             redirect_uris = new[] { "https://example.com/callback" }
         });
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-
-        var error = await response.Content.ReadFromJsonAsync<DynamicClientRegistrationError>();
-        error?.Error.Should().Be("invalid_client_metadata");
+        response.Should().Be400BadRequest()
+            .And.Satisfy<DynamicClientRegistrationError>(model => model?.Error.Should().Be("invalid_client_metadata"));
     }
 
     [Fact]
@@ -53,10 +51,8 @@ public class DynamicClientRegistrationValidationTests : ConfigurationIntegration
             redirect_uris = new[] { "https://example.com/callback" },
             grant_types = new[] { "password" }
         });
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-
-        var error = await response.Content.ReadFromJsonAsync<DynamicClientRegistrationError>();
-        error?.Error.Should().Be("invalid_client_metadata");
+        response.Should().Be400BadRequest()
+            .And.Satisfy<DynamicClientRegistrationError>(model => model?.Error.Should().Be("invalid_client_metadata"));
     }
 
     [Fact]
@@ -67,10 +63,8 @@ public class DynamicClientRegistrationValidationTests : ConfigurationIntegration
             redirect_uris = new[] { "https://example.com/callback" },
             grant_types = new[] { "client_credentials" }
         });
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-
-        var error = await response.Content.ReadFromJsonAsync<DynamicClientRegistrationError>();
-        error?.Error.Should().Be("invalid_redirect_uri");
+        response.Should().Be400BadRequest()
+            .And.Satisfy<DynamicClientRegistrationError>(model => model?.Error.Should().Be("invalid_redirect_uri"));
     }
 
     [Fact]
@@ -80,10 +74,8 @@ public class DynamicClientRegistrationValidationTests : ConfigurationIntegration
         {
             grant_types = new[] { "authorization_code", "client_credentials" }
         });
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-
-        var error = await response.Content.ReadFromJsonAsync<DynamicClientRegistrationError>();
-        error?.Error.Should().Be("invalid_redirect_uri");
+        response.Should().Be400BadRequest()
+            .And.Satisfy<DynamicClientRegistrationError>(model => model?.Error.Should().Be("invalid_redirect_uri"));
     }
 
     [Fact]
@@ -93,10 +85,8 @@ public class DynamicClientRegistrationValidationTests : ConfigurationIntegration
         {
             grant_types = new[] { "client_credentials", "refresh_token" }
         });
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-
-        var error = await response.Content.ReadFromJsonAsync<DynamicClientRegistrationError>();
-        error?.Error.Should().Be("invalid_client_metadata");
+        response.Should().Be400BadRequest()
+            .And.Satisfy<DynamicClientRegistrationError>(model => model?.Error.Should().Be("invalid_client_metadata"));
     }
 
     [Fact]
@@ -110,9 +100,7 @@ public class DynamicClientRegistrationValidationTests : ConfigurationIntegration
                 JwksUri = new Uri("https://example.com")
             }
         );
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-
-        var error = await response.Content.ReadFromJsonAsync<DynamicClientRegistrationError>();
-        error?.Error.Should().Be("invalid_client_metadata");
+        response.Should().Be400BadRequest()
+            .And.Satisfy<DynamicClientRegistrationError>(model => model?.Error.Should().Be("invalid_client_metadata"));
     }
 }

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Authorize/AuthorizeTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Authorize/AuthorizeTests.cs
@@ -124,7 +124,7 @@ public class AuthorizeTests
     {
         var response = await _mockPipeline.BrowserClient.GetAsync(IdentityServerPipeline.AuthorizeEndpoint);
 
-        response.StatusCode.Should().NotBe(HttpStatusCode.NotFound);
+        response.Should().NotHaveHttpStatusCode(HttpStatusCode.NotFound);
     }
 
     [Fact]
@@ -133,7 +133,7 @@ public class AuthorizeTests
     {
         var response = await _mockPipeline.BrowserClient.PostAsync(IdentityServerPipeline.AuthorizeEndpoint, new StringContent("foo"));
 
-        response.StatusCode.Should().Be(HttpStatusCode.UnsupportedMediaType);
+        response.Should().Be415UnsupportedMediaType();
     }
 
     [Fact]
@@ -144,7 +144,7 @@ public class AuthorizeTests
             new FormUrlEncodedContent(
                 new Dictionary<string, string> { }));
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Should().Be200Ok();
     }
 
     [Fact]
@@ -153,7 +153,7 @@ public class AuthorizeTests
     {
         var response = await _mockPipeline.BrowserClient.GetAsync(IdentityServerPipeline.AuthorizeEndpoint);
 
-        ((int)response.StatusCode).Should().BeLessThan(500);
+        response.Should().Satisfy(response => ((int) response.StatusCode).Should().BeLessThan(500));
     }
 
     [Fact]

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Authorize/PushedAuthorizationTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Authorize/PushedAuthorizationTests.cs
@@ -230,10 +230,10 @@ public class PushedAuthorizationTests
         var returnUrl = new Uri(new Uri(IdentityServerPipeline.BaseUrl), returnPath);
         await _mockPipeline.LoginAsync("bob");
         var authorizeCallbackResponse = await _mockPipeline.BrowserClient.GetAsync(returnUrl);
-        
+
         // The authorize callback should continue back to the application (the prompt parameter is processed so we don't go back to the UI)
-        authorizeCallbackResponse.Should().Be302Found();
-        authorizeCallbackResponse.Headers.Location.Should().Be(expectedCallback);
+        authorizeCallbackResponse.Should().Be302Found()
+            .And.HaveHeader("Location", expectedCallback);
     }
 
     private void ConfigureScopesAndResources()

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/CheckSession/CheckSessionTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/CheckSession/CheckSessionTests.cs
@@ -27,6 +27,6 @@ public class CheckSessionTests
     {
         var response = await _mockPipeline.BackChannelClient.GetAsync(IdentityServerPipeline.CheckSessionEndpoint);
 
-        response.StatusCode.Should().NotBe(HttpStatusCode.NotFound);
+        response.Should().NotHaveHttpStatusCode(HttpStatusCode.NotFound);
     }
 }

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Ciba/CibaTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Ciba/CibaTests.cs
@@ -167,7 +167,7 @@ public class CibaTests
     {
         var response = await _mockPipeline.BackChannelClient.GetAsync(IdentityServerPipeline.BackchannelAuthenticationEndpoint);
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.Should().Be400BadRequest();
     }
 
     [Fact]
@@ -178,7 +178,7 @@ public class CibaTests
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new StringContent("invalid"));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.Should().Be400BadRequest();
     }
 
     [Fact]
@@ -202,7 +202,7 @@ public class CibaTests
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(body));
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Should().Be200Ok();
 
         _mockCibaUserValidator.UserValidatorContext.LoginHint.Should().Be("this means bob");
         _mockCibaUserValidator.UserValidatorContext.UserCode.Should().Be("xoxo");
@@ -282,11 +282,12 @@ public class CibaTests
             new FormUrlEncodedContent(body));
 
         // Custom request properties are not included automatically in the response to the client
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var responseContent = await response.Content.ReadAsStringAsync();
-        var json = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(responseContent);
-        json.Should().NotBeNull();
-        json.Should().NotContainKey("complex");
+        response.Should().Be200Ok()
+            .And.Satisfy<Dictionary<string, JsonElement>>(json => 
+            {
+                json.Should().NotBeNull();
+                json.Should().NotContainKey("complex");
+            });
 
         // Custom properties are passed to the notification service
         var notificationProperties = _mockCibaUserNotificationService.LoginRequest.Properties;
@@ -315,14 +316,13 @@ public class CibaTests
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(body));
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
-
-        var json = await response.Content.ReadAsStringAsync();
-        var values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
-
-        values.ContainsKey("auth_req_id").Should().BeTrue();
-        values.ContainsKey("expires_in").Should().BeTrue();
-        values.ContainsKey("interval").Should().BeTrue();
+        response.Should().Be200Ok()
+            .And.Satisfy<Dictionary<string, object>>(values =>
+            {
+                values.ContainsKey("auth_req_id").Should().BeTrue();
+                values.ContainsKey("expires_in").Should().BeTrue();
+                values.ContainsKey("interval").Should().BeTrue();
+            });
     }
 
     [Fact]
@@ -350,14 +350,13 @@ public class CibaTests
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(body));
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
-
-        var json = await response.Content.ReadAsStringAsync();
-        var values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
-
-        values.ContainsKey("auth_req_id").Should().BeTrue();
-        values.ContainsKey("expires_in").Should().BeTrue();
-        values.ContainsKey("interval").Should().BeTrue();
+        response.Should().Be200Ok()
+            .And.Satisfy<Dictionary<string, object>>(values =>
+            {
+                values.ContainsKey("auth_req_id").Should().BeTrue();
+                values.ContainsKey("expires_in").Should().BeTrue();
+                values.ContainsKey("interval").Should().BeTrue();
+            });
     }
 
     [Fact]
@@ -382,13 +381,11 @@ public class CibaTests
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(body));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-
-        var json = await response.Content.ReadAsStringAsync();
-        var values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
-
-        values.ContainsKey("error").Should().BeTrue();
-        values["error"].ToString().Should().Be("invalid_request");
+        response.Should().Be400BadRequest()
+            .And.BeAs(new 
+            {
+                error = "invalid_request"
+            });
     }
 
     [Fact]
@@ -416,13 +413,11 @@ public class CibaTests
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(body));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-
-        var json = await response.Content.ReadAsStringAsync();
-        var values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
-
-        values.ContainsKey("error").Should().BeTrue();
-        values["error"].ToString().Should().Be("invalid_request_object");
+        response.Should().Be400BadRequest()
+            .And.BeAs(new
+            {
+                error = "invalid_request_object"
+            });
     }
 
     [Fact]
@@ -450,13 +445,11 @@ public class CibaTests
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(body));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-
-        var json = await response.Content.ReadAsStringAsync();
-        var values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
-
-        values.ContainsKey("error").Should().BeTrue();
-        values["error"].ToString().Should().Be("invalid_request_object");
+        response.Should().Be400BadRequest()
+            .And.BeAs(new
+             {
+                 error = "invalid_request_object"
+             });
     }
 
     [Fact]
@@ -483,13 +476,11 @@ public class CibaTests
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(body));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-
-        var json = await response.Content.ReadAsStringAsync();
-        var values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
-
-        values.ContainsKey("error").Should().BeTrue();
-        values["error"].ToString().Should().Be("invalid_request_object");
+        response.Should().Be400BadRequest()
+            .And.BeAs(new
+            {
+                error = "invalid_request_object"
+            });
     }
 
     [Fact]
@@ -518,13 +509,11 @@ public class CibaTests
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(body));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-
-        var json = await response.Content.ReadAsStringAsync();
-        var values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
-
-        values.ContainsKey("error").Should().BeTrue();
-        values["error"].ToString().Should().Be("invalid_request_object");
+        response.Should().Be400BadRequest()
+            .And.BeAs(new
+            {
+                error = "invalid_request_object"
+            });
     }
 
     [Fact]
@@ -553,13 +542,11 @@ public class CibaTests
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(body));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-
-        var json = await response.Content.ReadAsStringAsync();
-        var values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
-
-        values.ContainsKey("error").Should().BeTrue();
-        values["error"].ToString().Should().Be("invalid_request_object");
+        response.Should().Be400BadRequest()
+            .And.BeAs(new
+            {
+                error = "invalid_request_object"
+            });
     }
 
     [Fact]
@@ -590,13 +577,11 @@ public class CibaTests
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(body));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-
-        var json = await response.Content.ReadAsStringAsync();
-        var values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
-
-        values.ContainsKey("error").Should().BeTrue();
-        values["error"].ToString().Should().Be("invalid_request_object");
+        response.Should().Be400BadRequest()
+            .And.BeAs(new
+            {
+                error = "invalid_request_object"
+            });
     }
 
     [Fact]
@@ -628,13 +613,11 @@ public class CibaTests
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(body));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-
-        var json = await response.Content.ReadAsStringAsync();
-        var values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
-
-        values.ContainsKey("error").Should().BeTrue();
-        values["error"].ToString().Should().Be("invalid_request_object");
+        response.Should().Be400BadRequest()
+            .And.BeAs(new
+            {
+                error = "invalid_request_object"
+            });
     }
 
     [Fact]
@@ -663,13 +646,11 @@ public class CibaTests
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(body));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-
-        var json = await response.Content.ReadAsStringAsync();
-        var values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
-
-        values.ContainsKey("error").Should().BeTrue();
-        values["error"].ToString().Should().Be("invalid_request_object");
+        response.Should().Be400BadRequest()
+            .And.BeAs(new
+            {
+                error = "invalid_request_object"
+            });
     }
 
     [Fact]
@@ -698,13 +679,11 @@ public class CibaTests
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(body));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-
-        var json = await response.Content.ReadAsStringAsync();
-        var values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
-
-        values.ContainsKey("error").Should().BeTrue();
-        values["error"].ToString().Should().Be("invalid_request_object");
+        response.Should().Be400BadRequest()
+            .And.BeAs(new
+            {
+                error = "invalid_request_object"
+            });
     }
 
     [Fact]
@@ -733,7 +712,7 @@ public class CibaTests
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(body));
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Should().Be200Ok();
     }
 
     [Fact]
@@ -758,7 +737,7 @@ public class CibaTests
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(body));
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Should().Be200Ok();
 
         _mockCibaUserNotificationService.LoginRequest.Subject.FindFirst("sub").Value.Should().Be(_user.SubjectId);
         _mockCibaUserNotificationService.LoginRequest.BindingMessage.Should().Be(bindingMessage);
@@ -789,13 +768,11 @@ public class CibaTests
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(body));
 
-        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
-
-        var json = await response.Content.ReadAsStringAsync();
-        var values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
-
-        values.ContainsKey("error").Should().BeTrue();
-        values["error"].ToString().Should().Be("invalid_client");
+        response.Should().Be401Unauthorized()
+            .And.BeAs(new
+            {
+                error = "invalid_client"
+            });
     }
 
     [Fact]
@@ -820,13 +797,11 @@ public class CibaTests
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(body));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-
-        var json = await response.Content.ReadAsStringAsync();
-        var values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
-
-        values.ContainsKey("error").Should().BeTrue();
-        values["error"].ToString().Should().Be("unauthorized_client");
+        response.Should().Be400BadRequest()
+            .And.BeAs(new
+            {
+                error = "unauthorized_client"
+            });
     }
 
     [Theory]
@@ -855,13 +830,11 @@ public class CibaTests
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(body));
 
-        response.StatusCode.Should().Be(code);
-
-        var json = await response.Content.ReadAsStringAsync();
-        var values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
-
-        values.ContainsKey("error").Should().BeTrue();
-        values["error"].ToString().Should().Be(error);
+        response.Should().HaveHttpStatusCode(code)
+            .And.BeAs(new
+            {
+                error = error
+            });
     }
 
     [Fact]
@@ -884,13 +857,11 @@ public class CibaTests
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(body));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-
-        var json = await response.Content.ReadAsStringAsync();
-        var values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
-
-        values.ContainsKey("error").Should().BeTrue();
-        values["error"].ToString().Should().Be("unknown_user_id");
+        response.Should().Be400BadRequest()
+            .And.BeAs(new
+            {
+                error = "unknown_user_id"
+            });
     }
 
     [Fact]
@@ -915,13 +886,11 @@ public class CibaTests
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(body));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-
-        var json = await response.Content.ReadAsStringAsync();
-        var values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
-
-        values.ContainsKey("error").Should().BeTrue();
-        values["error"].ToString().Should().Be("unknown_user_id");
+        response.Should().Be400BadRequest()
+            .And.BeAs(new
+            {
+                error = "unknown_user_id"
+            });
     }
 
     [Fact]
@@ -943,13 +912,11 @@ public class CibaTests
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(body));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-
-        var json = await response.Content.ReadAsStringAsync();
-        var values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
-
-        values.ContainsKey("error").Should().BeTrue();
-        values["error"].ToString().Should().Be("invalid_request");
+        response.Should().Be400BadRequest()
+            .And.BeAs(new
+            {
+                error = "invalid_request"
+            });
     }
 
     [Fact]
@@ -973,13 +940,11 @@ public class CibaTests
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(body));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-
-        var json = await response.Content.ReadAsStringAsync();
-        var values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
-
-        values.ContainsKey("error").Should().BeTrue();
-        values["error"].ToString().Should().Be("invalid_request");
+        response.Should().Be400BadRequest()
+            .And.BeAs(new
+            {
+                error = "invalid_request"
+            });
     }
 
     [Fact]
@@ -1002,13 +967,11 @@ public class CibaTests
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(body));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-
-        var json = await response.Content.ReadAsStringAsync();
-        var values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
-
-        values.ContainsKey("error").Should().BeTrue();
-        values["error"].ToString().Should().Be("invalid_request");
+        response.Should().Be400BadRequest()
+            .And.BeAs(new
+            {
+                error = "invalid_request"
+            });
     }
 
     [Fact]
@@ -1032,13 +995,11 @@ public class CibaTests
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(body));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-
-        var json = await response.Content.ReadAsStringAsync();
-        var values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
-
-        values.ContainsKey("error").Should().BeTrue();
-        values["error"].ToString().Should().Be("invalid_target");
+        response.Should().Be400BadRequest()
+            .And.BeAs(new
+            {
+                error = "invalid_target"
+            });
     }
 
     [Fact]
@@ -1062,13 +1023,11 @@ public class CibaTests
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(body));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-
-        var json = await response.Content.ReadAsStringAsync();
-        var values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
-
-        values.ContainsKey("error").Should().BeTrue();
-        values["error"].ToString().Should().Be("invalid_target");
+        response.Should().Be400BadRequest()
+            .And.BeAs(new
+            {
+                error = "invalid_target"
+            });
     }
 
     [Fact]
@@ -1092,13 +1051,11 @@ public class CibaTests
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(body));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-
-        var json = await response.Content.ReadAsStringAsync();
-        var values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
-
-        values.ContainsKey("error").Should().BeTrue();
-        values["error"].ToString().Should().Be("invalid_target");
+        response.Should().Be400BadRequest()
+            .And.BeAs(new
+            {
+                error = "invalid_target"
+            });
     }
 
     [Fact]
@@ -1127,13 +1084,11 @@ public class CibaTests
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(body));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-
-        var json = await response.Content.ReadAsStringAsync();
-        var values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
-
-        values.ContainsKey("error").Should().BeTrue();
-        values["error"].ToString().Should().Be("invalid_scope");
+        response.Should().Be400BadRequest()
+            .And.BeAs(new
+            {
+                error = "invalid_scope"
+            });
     }
 
     [Fact]
@@ -1157,13 +1112,11 @@ public class CibaTests
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(body));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-
-        var json = await response.Content.ReadAsStringAsync();
-        var values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
-
-        values.ContainsKey("error").Should().BeTrue();
-        values["error"].ToString().Should().Be("invalid_request");
+        response.Should().Be400BadRequest()
+            .And.BeAs(new
+            {
+                error = "invalid_request"
+            });
     }
 
     [Fact]
@@ -1189,13 +1142,11 @@ public class CibaTests
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(body));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-
-        var json = await response.Content.ReadAsStringAsync();
-        var values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
-
-        values.ContainsKey("error").Should().BeTrue();
-        values["error"].ToString().Should().Be("invalid_request");
+        response.Should().Be400BadRequest()
+            .And.BeAs(new
+            {
+                error = "invalid_request"
+            });
     }
 
     [Fact]
@@ -1221,7 +1172,7 @@ public class CibaTests
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(body));
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Should().Be200Ok();
     }
 
     [Fact]
@@ -1245,13 +1196,11 @@ public class CibaTests
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(body));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-
-        var json = await response.Content.ReadAsStringAsync();
-        var values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
-
-        values.ContainsKey("error").Should().BeTrue();
-        values["error"].ToString().Should().Be("invalid_request");
+        response.Should().Be400BadRequest()
+            .And.BeAs(new
+            {
+                error = "invalid_request"
+            });
     }
 
     [Fact]
@@ -1277,7 +1226,7 @@ public class CibaTests
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(body));
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Should().Be200Ok();
 
         _mockCibaUserNotificationService.LoginRequest.IdP.Should().BeNullOrEmpty();
     }
@@ -1304,7 +1253,7 @@ public class CibaTests
                 IdentityServerPipeline.BackchannelAuthenticationEndpoint,
                 new FormUrlEncodedContent(body));
 
-            response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            response.Should().Be400BadRequest();
 
             var json = await response.Content.ReadAsStringAsync();
             var values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
@@ -1330,7 +1279,7 @@ public class CibaTests
                 IdentityServerPipeline.BackchannelAuthenticationEndpoint,
                 new FormUrlEncodedContent(body));
 
-            response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            response.Should().Be400BadRequest();
 
             var json = await response.Content.ReadAsStringAsync();
             var values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
@@ -1356,7 +1305,7 @@ public class CibaTests
                 IdentityServerPipeline.BackchannelAuthenticationEndpoint,
                 new FormUrlEncodedContent(body));
 
-            response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            response.Should().Be400BadRequest();
 
             var json = await response.Content.ReadAsStringAsync();
             var values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
@@ -1385,13 +1334,11 @@ public class CibaTests
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(body));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-
-        var json = await response.Content.ReadAsStringAsync();
-        var values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
-
-        values.ContainsKey("error").Should().BeTrue();
-        values["error"].ToString().Should().Be("invalid_request");
+        response.Should().Be400BadRequest()
+            .And.BeAs(new
+            {
+                error = "invalid_request"
+            });
     }
 
     [Fact]
@@ -1414,13 +1361,11 @@ public class CibaTests
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(body));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-
-        var json = await response.Content.ReadAsStringAsync();
-        var values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
-
-        values.ContainsKey("error").Should().BeTrue();
-        values["error"].ToString().Should().Be("invalid_request");
+        response.Should().Be400BadRequest()
+            .And.BeAs(new
+            {
+                error = "invalid_request"
+            });
     }
 
     [Fact]
@@ -1443,13 +1388,11 @@ public class CibaTests
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(body));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-
-        var json = await response.Content.ReadAsStringAsync();
-        var values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
-
-        values.ContainsKey("error").Should().BeTrue();
-        values["error"].ToString().Should().Be("invalid_request");
+        response.Should().Be400BadRequest()
+            .And.BeAs(new
+            {
+                error = "invalid_request"
+            });
     }
 
     [Fact]
@@ -1472,13 +1415,11 @@ public class CibaTests
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(body));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-
-        var json = await response.Content.ReadAsStringAsync();
-        var values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
-
-        values.ContainsKey("error").Should().BeTrue();
-        values["error"].ToString().Should().Be("invalid_request");
+        response.Should().Be400BadRequest()
+            .And.BeAs(new
+            {
+                error = "invalid_request"
+            });
     }
 
     [Fact]
@@ -1501,13 +1442,11 @@ public class CibaTests
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(body));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-
-        var json = await response.Content.ReadAsStringAsync();
-        var values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
-
-        values.ContainsKey("error").Should().BeTrue();
-        values["error"].ToString().Should().Be("invalid_request");
+        response.Should().Be400BadRequest()
+            .And.BeAs(new
+            {
+                error = "invalid_request"
+            });
     }
 
     [Fact]
@@ -1538,7 +1477,7 @@ public class CibaTests
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(body));
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Should().Be200Ok();
 
         _mockCibaUserNotificationService.LoginRequest.Subject.HasClaim("sub", _user.SubjectId).Should().BeTrue();
         _mockCibaUserValidator.UserValidatorContext.IdTokenHint.Should().Be(id_token);
@@ -1565,7 +1504,7 @@ public class CibaTests
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(body));
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Should().Be200Ok();
 
         _mockCibaUserNotificationService.LoginRequest.Subject.HasClaim("sub", _user.SubjectId).Should().BeTrue();
         _mockCibaUserValidator.UserValidatorContext.LoginHintToken.Should().Be("xoxo");
@@ -1592,13 +1531,11 @@ public class CibaTests
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(body));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-
-        var json = await response.Content.ReadAsStringAsync();
-        var values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
-
-        values.ContainsKey("error").Should().BeTrue();
-        values["error"].ToString().Should().Be("invalid_request");
+        response.Should().Be400BadRequest()
+            .And.BeAs(new
+            {
+                error = "invalid_request"
+            });
     }
 
     [Fact]
@@ -1621,13 +1558,11 @@ public class CibaTests
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(body));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-
-        var json = await response.Content.ReadAsStringAsync();
-        var values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
-
-        values.ContainsKey("error").Should().BeTrue();
-        values["error"].ToString().Should().Be("invalid_binding_message");
+        response.Should().Be400BadRequest()
+            .And.BeAs(new
+            {
+                error = "invalid_binding_message"
+            });
     }
 
 }

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/DeviceAuthorization/DeviceAuthorizationTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/DeviceAuthorization/DeviceAuthorizationTests.cs
@@ -46,7 +46,7 @@ public class DeviceAuthorizationTests
     public async Task get_should_return_InvalidRequest()
     {
         var response = await _mockPipeline.BackChannelClient.GetAsync(IdentityServerPipeline.DeviceAuthorization);
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.Should().Be400BadRequest();
 
         var resultDto = ParseJsonBody<ErrorResultDto>(await response.Content.ReadAsStreamAsync());
 
@@ -65,7 +65,7 @@ public class DeviceAuthorizationTests
         var response = await _mockPipeline.BackChannelClient.PostAsync(IdentityServerPipeline.DeviceAuthorization,
             new StringContent(@"{""client_id"": ""client1""}", Encoding.UTF8, "application/json"));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.Should().Be400BadRequest();
 
         var resultDto = ParseJsonBody<ErrorResultDto>(await response.Content.ReadAsStreamAsync());
 
@@ -80,7 +80,7 @@ public class DeviceAuthorizationTests
         var response = await _mockPipeline.BackChannelClient.PostAsync(IdentityServerPipeline.DeviceAuthorization,
             new FormUrlEncodedContent(new Dictionary<string, string>()));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.Should().Be400BadRequest();
 
         var resultDto = ParseJsonBody<ErrorResultDto>(await response.Content.ReadAsStreamAsync());
 
@@ -98,7 +98,7 @@ public class DeviceAuthorizationTests
         };
         var response = await _mockPipeline.BackChannelClient.PostAsync(IdentityServerPipeline.DeviceAuthorization, new FormUrlEncodedContent(form));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.Should().Be400BadRequest();
 
         var resultDto = ParseJsonBody<ErrorResultDto>(await response.Content.ReadAsStreamAsync());
 
@@ -117,8 +117,8 @@ public class DeviceAuthorizationTests
         };
         var response = await _mockPipeline.BackChannelClient.PostAsync(IdentityServerPipeline.DeviceAuthorization, new FormUrlEncodedContent(form));
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
-        response.Content.Headers.ContentType.MediaType.Should().Be("application/json");
+        response.Should().Be200Ok();
+        response.Should().HaveHeader("Content-Type", "application/json");
             
         var resultDto = ParseJsonBody<ResultDto>(await response.Content.ReadAsStreamAsync());
 

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/EndSession/EndSessionTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/EndSession/EndSessionTests.cs
@@ -106,7 +106,7 @@ public class EndSessionTests
     {
         var response = await _mockPipeline.BackChannelClient.GetAsync(IdentityServerPipeline.EndSessionEndpoint);
 
-        response.StatusCode.Should().NotBe(HttpStatusCode.NotFound);
+        response.Should().NotHaveHttpStatusCode(HttpStatusCode.NotFound);
     }
 
     [Fact]
@@ -282,7 +282,7 @@ public class EndSessionTests
     {
         var response = await _mockPipeline.BackChannelClient.GetAsync(IdentityServerPipeline.EndSessionCallbackEndpoint);
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.Should().Be400BadRequest();
     }
 
     [Fact]
@@ -372,7 +372,7 @@ public class EndSessionTests
         var signoutFrameUrl = _mockPipeline.LogoutRequest.SignOutIFrameUrl;
 
         response = await _mockPipeline.BrowserClient.GetAsync(signoutFrameUrl);
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Should().Be200Ok();
         response.Content.Headers.ContentType.MediaType.Should().Be("text/html");
     }
 

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Introspection/IntrospectionTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Introspection/IntrospectionTests.cs
@@ -84,7 +84,7 @@ public class IntrospectionTests
         _client.SetBasicAuthentication("api1", "secret");
         var response = await _client.PostAsync(IntrospectionEndpoint, new FormUrlEncodedContent(form));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.Should().Be400BadRequest();
     }
 
     [Fact]
@@ -126,7 +126,7 @@ public class IntrospectionTests
 
         var client = new HttpClient(_handler);
         var response = await client.PostAsync(IntrospectionEndpoint, new StringContent(json, Encoding.UTF8, "application/json"));
-        response.StatusCode.Should().Be(HttpStatusCode.UnsupportedMediaType);
+        response.Should().Be415UnsupportedMediaType();
     }
 
     [Fact]

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Revocation/RevocationTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Revocation/RevocationTests.cs
@@ -207,7 +207,7 @@ public class RevocationTests
     {
         var response = await _mockPipeline.BackChannelClient.GetAsync(IdentityServerPipeline.RevocationEndpoint);
 
-        response.StatusCode.Should().Be(HttpStatusCode.MethodNotAllowed);
+        response.Should().Be405MethodNotAllowed();
     }
 
     [Fact]
@@ -216,7 +216,7 @@ public class RevocationTests
     {
         var response = await _mockPipeline.BackChannelClient.PostAsync(IdentityServerPipeline.RevocationEndpoint, null);
 
-        response.StatusCode.Should().Be(HttpStatusCode.UnsupportedMediaType);
+        response.Should().Be415UnsupportedMediaType();
     }
 
     [Fact]
@@ -442,7 +442,7 @@ public class RevocationTests
         };
 
         var response = await _mockPipeline.BackChannelClient.PostAsync(IdentityServerPipeline.RevocationEndpoint, new FormUrlEncodedContent(data));
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.Should().Be400BadRequest();
 
         var result = await ProtocolResponse.FromHttpResponseAsync<TokenRevocationResponse>(response);
         result.IsError.Should().BeTrue();
@@ -465,7 +465,7 @@ public class RevocationTests
         };
 
         var response = await _mockPipeline.BackChannelClient.PostAsync(IdentityServerPipeline.RevocationEndpoint, new FormUrlEncodedContent(data));
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.Should().Be400BadRequest();
 
         var result = await ProtocolResponse.FromHttpResponseAsync<TokenRevocationResponse>(response);
         result.IsError.Should().BeTrue();
@@ -487,7 +487,7 @@ public class RevocationTests
         };
 
         var response = await _mockPipeline.BackChannelClient.PostAsync(IdentityServerPipeline.RevocationEndpoint, new FormUrlEncodedContent(data));
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Should().Be200Ok();
 
         (await IsAccessTokenValidAsync(tokens)).Should().BeFalse();
     }
@@ -507,7 +507,7 @@ public class RevocationTests
         };
 
         var response = await _mockPipeline.BackChannelClient.PostAsync(IdentityServerPipeline.RevocationEndpoint, new FormUrlEncodedContent(data));
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Should().Be200Ok();
 
         (await UseRefreshTokenAsync(tokens)).Should().BeFalse();
     }
@@ -527,7 +527,7 @@ public class RevocationTests
         (await IsAccessTokenValidAsync(token)).Should().BeTrue();
 
         var response = await _mockPipeline.BackChannelClient.PostAsync(IdentityServerPipeline.RevocationEndpoint, new FormUrlEncodedContent(data));
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Should().Be200Ok();
         (await IsAccessTokenValidAsync(token)).Should().BeFalse();
     }
 
@@ -546,7 +546,7 @@ public class RevocationTests
         (await IsAccessTokenValidAsync(token)).Should().BeTrue();
 
         var response = await _mockPipeline.BackChannelClient.PostAsync(IdentityServerPipeline.RevocationEndpoint, new FormUrlEncodedContent(data));
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.Should().Be400BadRequest();
         (await IsAccessTokenValidAsync(token)).Should().BeTrue();
     }
 }

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Token/CibaTokenEndpointTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Token/CibaTokenEndpointTests.cs
@@ -146,7 +146,7 @@ public class CibaTokenEndpointTests
         var cibaResponse = await _mockPipeline.BackChannelClient.PostAsync(
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(cibaBody));
-        cibaResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        cibaResponse.Should().Be200Ok();
 
 
         // user auth/consent
@@ -180,7 +180,7 @@ public class CibaTokenEndpointTests
             IdentityServerPipeline.TokenEndpoint,
             new FormUrlEncodedContent(tokenBody));
 
-        tokenResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        tokenResponse.Should().Be200Ok();
     }
 
         
@@ -204,7 +204,7 @@ public class CibaTokenEndpointTests
         var cibaResponse = await _mockPipeline.BackChannelClient.PostAsync(
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(cibaBody));
-        cibaResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        cibaResponse.Should().Be200Ok();
 
 
 
@@ -224,7 +224,7 @@ public class CibaTokenEndpointTests
             IdentityServerPipeline.TokenEndpoint,
             new FormUrlEncodedContent(tokenBody));
 
-        tokenResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        tokenResponse.Should().Be400BadRequest();
 
         var json = await tokenResponse.Content.ReadAsStringAsync();
         values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
@@ -253,7 +253,7 @@ public class CibaTokenEndpointTests
         var cibaResponse = await _mockPipeline.BackChannelClient.PostAsync(
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(cibaBody));
-        cibaResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        cibaResponse.Should().Be200Ok();
 
 
         // user auth/consent
@@ -287,7 +287,7 @@ public class CibaTokenEndpointTests
             IdentityServerPipeline.TokenEndpoint,
             new FormUrlEncodedContent(tokenBody));
 
-        tokenResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        tokenResponse.Should().Be400BadRequest();
 
         var json = await tokenResponse.Content.ReadAsStringAsync();
         values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
@@ -316,7 +316,7 @@ public class CibaTokenEndpointTests
         var cibaResponse = await _mockPipeline.BackChannelClient.PostAsync(
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(cibaBody));
-        cibaResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        cibaResponse.Should().Be200Ok();
 
 
         // user auth/consent
@@ -350,7 +350,7 @@ public class CibaTokenEndpointTests
             IdentityServerPipeline.TokenEndpoint,
             new FormUrlEncodedContent(tokenBody));
 
-        tokenResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        tokenResponse.Should().Be400BadRequest();
 
         var json = await tokenResponse.Content.ReadAsStringAsync();
         values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
@@ -379,7 +379,7 @@ public class CibaTokenEndpointTests
         var cibaResponse = await _mockPipeline.BackChannelClient.PostAsync(
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(cibaBody));
-        cibaResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        cibaResponse.Should().Be200Ok();
 
 
         // user auth/consent
@@ -413,7 +413,7 @@ public class CibaTokenEndpointTests
             IdentityServerPipeline.TokenEndpoint,
             new FormUrlEncodedContent(tokenBody));
 
-        tokenResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        tokenResponse.Should().Be400BadRequest();
 
         var json = await tokenResponse.Content.ReadAsStringAsync();
         values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
@@ -442,7 +442,7 @@ public class CibaTokenEndpointTests
         var cibaResponse = await _mockPipeline.BackChannelClient.PostAsync(
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(cibaBody));
-        cibaResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        cibaResponse.Should().Be200Ok();
 
 
         // user auth/consent
@@ -478,7 +478,7 @@ public class CibaTokenEndpointTests
             IdentityServerPipeline.TokenEndpoint,
             new FormUrlEncodedContent(tokenBody));
 
-        tokenResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        tokenResponse.Should().Be400BadRequest();
 
         var json = await tokenResponse.Content.ReadAsStringAsync();
         values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
@@ -511,7 +511,7 @@ public class CibaTokenEndpointTests
         var cibaResponse = await _mockPipeline.BackChannelClient.PostAsync(
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(cibaBody));
-        cibaResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        cibaResponse.Should().Be200Ok();
 
 
         // user auth/consent
@@ -547,7 +547,7 @@ public class CibaTokenEndpointTests
             IdentityServerPipeline.TokenEndpoint,
             new FormUrlEncodedContent(tokenBody));
 
-        tokenResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        tokenResponse.Should().Be400BadRequest();
 
         var json = await tokenResponse.Content.ReadAsStringAsync();
         values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
@@ -580,7 +580,7 @@ public class CibaTokenEndpointTests
         var cibaResponse = await _mockPipeline.BackChannelClient.PostAsync(
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(cibaBody));
-        cibaResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        cibaResponse.Should().Be200Ok();
 
 
         // token request
@@ -600,7 +600,7 @@ public class CibaTokenEndpointTests
                 IdentityServerPipeline.TokenEndpoint,
                 new FormUrlEncodedContent(tokenBody));
 
-            tokenResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            tokenResponse.Should().Be400BadRequest();
 
             var json = await tokenResponse.Content.ReadAsStringAsync();
             values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
@@ -621,7 +621,7 @@ public class CibaTokenEndpointTests
                 IdentityServerPipeline.TokenEndpoint,
                 new FormUrlEncodedContent(tokenBody));
 
-            tokenResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            tokenResponse.Should().Be400BadRequest();
 
             var json = await tokenResponse.Content.ReadAsStringAsync();
             values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
@@ -655,7 +655,7 @@ public class CibaTokenEndpointTests
         var cibaResponse = await _mockPipeline.BackChannelClient.PostAsync(
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(cibaBody));
-        cibaResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        cibaResponse.Should().Be200Ok();
 
 
         // token request
@@ -675,7 +675,7 @@ public class CibaTokenEndpointTests
                 IdentityServerPipeline.TokenEndpoint,
                 new FormUrlEncodedContent(tokenBody));
 
-            tokenResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            tokenResponse.Should().Be400BadRequest();
 
             var json = await tokenResponse.Content.ReadAsStringAsync();
             values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
@@ -696,7 +696,7 @@ public class CibaTokenEndpointTests
                 IdentityServerPipeline.TokenEndpoint,
                 new FormUrlEncodedContent(tokenBody));
 
-            tokenResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            tokenResponse.Should().Be400BadRequest();
 
             var json = await tokenResponse.Content.ReadAsStringAsync();
             values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
@@ -720,7 +720,7 @@ public class CibaTokenEndpointTests
                 IdentityServerPipeline.TokenEndpoint,
                 new FormUrlEncodedContent(tokenBody));
 
-            tokenResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            tokenResponse.Should().Be400BadRequest();
 
             var json = await tokenResponse.Content.ReadAsStringAsync();
             values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
@@ -741,7 +741,7 @@ public class CibaTokenEndpointTests
                 IdentityServerPipeline.TokenEndpoint,
                 new FormUrlEncodedContent(tokenBody));
 
-            tokenResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            tokenResponse.Should().Be400BadRequest();
 
             var json = await tokenResponse.Content.ReadAsStringAsync();
             values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
@@ -777,7 +777,7 @@ public class CibaTokenEndpointTests
         var cibaResponse = await _mockPipeline.BackChannelClient.PostAsync(
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(cibaBody));
-        cibaResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        cibaResponse.Should().Be200Ok();
 
 
         // token request
@@ -797,7 +797,7 @@ public class CibaTokenEndpointTests
                 IdentityServerPipeline.TokenEndpoint,
                 new FormUrlEncodedContent(tokenBody));
 
-            tokenResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            tokenResponse.Should().Be400BadRequest();
 
             var json = await tokenResponse.Content.ReadAsStringAsync();
             values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
@@ -818,7 +818,7 @@ public class CibaTokenEndpointTests
                 IdentityServerPipeline.TokenEndpoint,
                 new FormUrlEncodedContent(tokenBody));
 
-            tokenResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            tokenResponse.Should().Be400BadRequest();
 
             var json = await tokenResponse.Content.ReadAsStringAsync();
             values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
@@ -842,7 +842,7 @@ public class CibaTokenEndpointTests
                 IdentityServerPipeline.TokenEndpoint,
                 new FormUrlEncodedContent(tokenBody));
 
-            tokenResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            tokenResponse.Should().Be400BadRequest();
 
             var json = await tokenResponse.Content.ReadAsStringAsync();
             values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
@@ -866,7 +866,7 @@ public class CibaTokenEndpointTests
                 IdentityServerPipeline.TokenEndpoint,
                 new FormUrlEncodedContent(tokenBody));
 
-            tokenResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            tokenResponse.Should().Be400BadRequest();
 
             var json = await tokenResponse.Content.ReadAsStringAsync();
             values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
@@ -887,7 +887,7 @@ public class CibaTokenEndpointTests
                 IdentityServerPipeline.TokenEndpoint,
                 new FormUrlEncodedContent(tokenBody));
 
-            tokenResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            tokenResponse.Should().Be400BadRequest();
 
             var json = await tokenResponse.Content.ReadAsStringAsync();
             values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
@@ -923,7 +923,7 @@ public class CibaTokenEndpointTests
         var cibaResponse = await _mockPipeline.BackChannelClient.PostAsync(
             IdentityServerPipeline.BackchannelAuthenticationEndpoint,
             new FormUrlEncodedContent(cibaBody));
-        cibaResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        cibaResponse.Should().Be200Ok();
 
 
         // token request
@@ -943,7 +943,7 @@ public class CibaTokenEndpointTests
                 IdentityServerPipeline.TokenEndpoint,
                 new FormUrlEncodedContent(tokenBody));
 
-            tokenResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            tokenResponse.Should().Be400BadRequest();
 
             var json = await tokenResponse.Content.ReadAsStringAsync();
             values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
@@ -967,7 +967,7 @@ public class CibaTokenEndpointTests
                 IdentityServerPipeline.TokenEndpoint,
                 new FormUrlEncodedContent(tokenBody));
 
-            tokenResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            tokenResponse.Should().Be400BadRequest();
 
             var json = await tokenResponse.Content.ReadAsStringAsync();
             values = JsonSerializer.Deserialize<Dictionary<string, object>>(json);

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Token/TokenEndpointTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Token/TokenEndpointTests.cs
@@ -91,7 +91,7 @@ public class TokenEndpointTests
         _mockPipeline.BackChannelClient.DefaultRequestHeaders.Add("Referer", "http://127.0.0.1:33086/appservice/appservice?t=1564165664142?load");
         var response = await _mockPipeline.BackChannelClient.PostAsync(IdentityServerPipeline.TokenEndpoint, form);
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Should().Be200Ok();
         var json = await response.Content.ReadAsStringAsync();
         var result = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json);
         result.ContainsKey("error").Should().BeFalse();
@@ -114,7 +114,7 @@ public class TokenEndpointTests
         _mockPipeline.BackChannelClient.DefaultRequestHeaders.Add("Referer", "http://127.0.0.1:33086/appservice/appservice?t=1564165664142?load");
         var response = await _mockPipeline.BackChannelClient.PostAsync(IdentityServerPipeline.TokenEndpoint, form);
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Should().Be200Ok();
         var json = await response.Content.ReadAsStringAsync();
         var result = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json);
         result.ContainsKey("error").Should().BeFalse();
@@ -129,7 +129,7 @@ public class TokenEndpointTests
         
         var response = await _mockPipeline.BackChannelClient.PostAsync(IdentityServerPipeline.TokenEndpoint, content);
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.Should().Be400BadRequest();
         var json = await response.Content.ReadAsStringAsync();
         var result = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json);
         var error = result["error"].GetString();

--- a/identity-server/test/IdentityServer.IntegrationTests/Hosting/DynamicProvidersTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Hosting/DynamicProvidersTests.cs
@@ -281,7 +281,7 @@ public class DynamicProvidersTests
         response.Headers.Location.ToString().Should().StartWith("/callback");
 
         response = await _host.BrowserClient.GetAsync(_host.Url("/callback"));
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Should().Be200Ok();
         var body = await response.Content.ReadAsStringAsync();
         body.Should().Be("1"); // sub
     }
@@ -299,7 +299,7 @@ public class DynamicProvidersTests
 
         response = await _host.BrowserClient.GetAsync(redirectUri);
         response = await _host.BrowserClient.GetAsync(_host.Url(response.Headers.Location.ToString())); // ~/callback
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Should().Be200Ok();
         var body = await response.Content.ReadAsStringAsync();
         body.Should().Be("2"); // sub
     }
@@ -321,7 +321,7 @@ public class DynamicProvidersTests
         response = await _host.BrowserClient.GetAsync(redirectUri);
             
         response = await _host.BrowserClient.GetAsync(_host.Url(response.Headers.Location.ToString()));
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Should().Be200Ok();
         var body = await response.Content.ReadAsStringAsync();
         body.Should().Be("1"); // sub
     }
@@ -340,7 +340,7 @@ public class DynamicProvidersTests
         response = await _host.BrowserClient.GetAsync(_host.Url("/callback")); // signs the user in
 
         response = await _host.BrowserClient.GetAsync(_host.Url("/user"));
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Should().Be200Ok();
 
 
         response = await _host.BrowserClient.GetAsync(_host.Url("/logout?scheme=idp1"));
@@ -353,11 +353,11 @@ public class DynamicProvidersTests
         var iframeUrl = await _idp1.BrowserClient.ReadElementAttributeAsync("iframe", "src");
 
         response = await _host.BrowserClient.GetAsync(_host.Url("/user"));
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Should().Be200Ok();
 
         iframeUrl.Should().StartWith(_host.Url("/federation/idp1/signout"));
         response = await _host.BrowserClient.GetAsync(iframeUrl); // ~/federation/idp1/signout
-        response.IsSuccessStatusCode.Should().BeTrue();
+        response.Should().Be2XXSuccessful();
 
         response = await _host.BrowserClient.GetAsync(_host.Url("/user"));
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);

--- a/identity-server/test/IdentityServer.IntegrationTests/Hosting/FederatedSignoutTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Hosting/FederatedSignoutTests.cs
@@ -81,7 +81,7 @@ public class FederatedSignoutTests
 
         var response = await _pipeline.BrowserClient.GetAsync(IdentityServerPipeline.FederatedSignOutUrl + "?sid=123");
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Should().Be200Ok();
         response.Content.Headers.ContentType.MediaType.Should().Be("text/html");
         var html = await response.Content.ReadAsStringAsync();
         html.Should().Contain("https://server/connect/endsession/callback?endSessionId=");
@@ -102,7 +102,7 @@ public class FederatedSignoutTests
 
         var response = await _pipeline.BrowserClient.PostAsync(IdentityServerPipeline.FederatedSignOutUrl, new FormUrlEncodedContent(new Dictionary<string, string> { { "sid", "123" } }));
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Should().Be200Ok();
         response.Content.Headers.ContentType.MediaType.Should().Be("text/html");
         var html = await response.Content.ReadAsStringAsync();
         html.Should().Contain("https://server/connect/endsession/callback?endSessionId=");
@@ -115,7 +115,7 @@ public class FederatedSignoutTests
 
         var response = await _pipeline.BrowserClient.GetAsync(IdentityServerPipeline.FederatedSignOutUrl + "?sid=123");
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Should().Be200Ok();
         response.Content.Headers.ContentType.Should().BeNull();
         var html = await response.Content.ReadAsStringAsync();
         html.Should().Be(String.Empty);
@@ -126,7 +126,7 @@ public class FederatedSignoutTests
     {
         var response = await _pipeline.BrowserClient.GetAsync(IdentityServerPipeline.FederatedSignOutUrl + "?sid=123");
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Should().Be200Ok();
         response.Content.Headers.ContentType.Should().BeNull();
         var html = await response.Content.ReadAsStringAsync();
         html.Should().Be(String.Empty);
@@ -152,7 +152,7 @@ public class FederatedSignoutTests
 
         var response = await _pipeline.BrowserClient.GetAsync(IdentityServerPipeline.FederatedSignOutUrl + "?sid=123");
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Should().Be200Ok();
         response.Content.Headers.ContentType.Should().BeNull();
         var html = await response.Content.ReadAsStringAsync();
         html.Should().Be(String.Empty);

--- a/identity-server/test/IdentityServer.IntegrationTests/Hosting/LocalApiAuthentication/LocalApiAuthenticationTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Hosting/LocalApiAuthentication/LocalApiAuthenticationTests.cs
@@ -244,7 +244,7 @@ public class LocalApiAuthenticationTests
 
         var response = await _pipeline.BackChannelClient.SendAsync(req);
 
-        response.IsSuccessStatusCode.Should().BeTrue();
+        response.Should().Be2XXSuccessful();
         ApiWasCalled.Should().BeTrue();
         ApiPrincipal.Identity.IsAuthenticated.Should().BeTrue();
     }
@@ -261,7 +261,7 @@ public class LocalApiAuthenticationTests
 
         var response = await _pipeline.BackChannelClient.SendAsync(req);
 
-        response.IsSuccessStatusCode.Should().BeTrue();
+        response.Should().Be2XXSuccessful();
         ApiWasCalled.Should().BeTrue();
         ApiPrincipal.Identity.IsAuthenticated.Should().BeTrue();
     }
@@ -277,7 +277,7 @@ public class LocalApiAuthenticationTests
 
         var response = await _pipeline.BackChannelClient.SendAsync(req);
 
-        response.IsSuccessStatusCode.Should().BeTrue();
+        response.Should().Be2XXSuccessful();
         ApiWasCalled.Should().BeTrue();
         ApiPrincipal.Identity.IsAuthenticated.Should().BeTrue();
     }

--- a/identity-server/test/IdentityServer.IntegrationTests/TestFramework/TestBrowserClient.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/TestFramework/TestBrowserClient.cs
@@ -110,7 +110,7 @@ public class TestBrowserClient : HttpClient
     }
     public async Task<HtmlForm> ReadFormAsync(HttpResponseMessage response, string selector = null)
     {
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Should().Be200Ok();
 
         var htmlForm = new HtmlForm();
 
@@ -194,7 +194,7 @@ public class TestBrowserClient : HttpClient
 
     public async Task AssertExistsAsync(HttpResponseMessage response, string selector)
     {
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Should().Be200Ok();
 
         var html = await response.Content.ReadAsStringAsync();
 
@@ -210,7 +210,7 @@ public class TestBrowserClient : HttpClient
     }
     public async Task AssertNotExistsAsync(HttpResponseMessage response, string selector)
     {
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Should().Be200Ok();
 
         var html = await response.Content.ReadAsStringAsync();
 
@@ -226,7 +226,7 @@ public class TestBrowserClient : HttpClient
     }
     public async Task AssertErrorPageAsync(HttpResponseMessage response, string error = null)
     {
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Should().Be200Ok();
         await AssertExistsAsync(response, ".error-page");
 
         if (!String.IsNullOrWhiteSpace(error))
@@ -242,7 +242,7 @@ public class TestBrowserClient : HttpClient
     }
     public async Task AssertValidationErrorAsync(HttpResponseMessage response, string error = null)
     {
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Should().Be200Ok();
         await AssertExistsAsync(response, ".validation-summary-errors");
 
         if (!String.IsNullOrWhiteSpace(error))


### PR DESCRIPTION
- ehanced output when a test failes (request/response are logged)
- response deserialization on the fly
- HTTP domain like assertions

**What issue does this PR address?**



**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
