### PR TITLE
Fix misplaced semicolons in lambda expressions

### DIFF
--- a/bff/hosts/Hosts.IdentityServer/Pages/Account/Login/Index.cshtml.cs
+++ b/bff/hosts/Hosts.IdentityServer/Pages/Account/Login/Index.cshtml.cs
@@ -108,7 +108,7 @@ namespace IdentityServerHost.Pages.Login
                             IsPersistent = true,
                             ExpiresUtc = DateTimeOffset.UtcNow.Add(LoginOptions.RememberMeLoginDuration)
                         };
-                    };
+                    }
 
                     // issue authentication cookie with subject ID and username
                     var isuser = new IdentityServerUser(user.SubjectId)

--- a/bff/src/Bff/EndpointServices/SilentLogin/PostConfigureOidcOptionsForSilentLogin.cs
+++ b/bff/src/Bff/EndpointServices/SilentLogin/PostConfigureOidcOptionsForSilentLogin.cs
@@ -57,7 +57,7 @@ public class PostConfigureOidcOptionsForSilentLogin : IPostConfigureOptions<Open
                     await inner.Invoke(ctx);
                 }
             }
-        };
+        }
 
         return Callback;
     }
@@ -73,7 +73,7 @@ public class PostConfigureOidcOptionsForSilentLogin : IPostConfigureOptions<Open
                     await inner.Invoke(ctx);
                 }
             }
-        };
+        }
 
         return Callback;
     }
@@ -89,7 +89,7 @@ public class PostConfigureOidcOptionsForSilentLogin : IPostConfigureOptions<Open
                     await inner.Invoke(ctx);
                 }
             }
-        };
+        }
 
         return Callback;
     }

--- a/bff/src/Bff/SessionManagement/Configuration/PostConfigureApplicationCookieRevokeRefreshToken.cs
+++ b/bff/src/Bff/SessionManagement/Configuration/PostConfigureApplicationCookieRevokeRefreshToken.cs
@@ -52,7 +52,7 @@ public class PostConfigureApplicationCookieRevokeRefreshToken : IPostConfigureOp
             {
                 await inner.Invoke(ctx);
             }
-        };
+        }
 
         return Callback;
     }

--- a/bff/src/Bff/SessionManagement/Configuration/PostConfigureApplicationValidatePrincipal.cs
+++ b/bff/src/Bff/SessionManagement/Configuration/PostConfigureApplicationValidatePrincipal.cs
@@ -62,7 +62,7 @@ public class PostConfigureApplicationValidatePrincipal : IPostConfigureOptions<C
             }
 
             return result;
-        };
+        }
 
         return Callback;
     }

--- a/bff/src/Bff/SessionManagement/Configuration/PostConfigureSlidingExpirationCheck.cs
+++ b/bff/src/Bff/SessionManagement/Configuration/PostConfigureSlidingExpirationCheck.cs
@@ -59,7 +59,7 @@ namespace Duende.Bff
                 }
 
                 return result;
-            };
+            }
 
             return Callback;
         }

--- a/templates/src/IdentityServerEntityFramework/Pages/Account/Login/Index.cshtml.cs
+++ b/templates/src/IdentityServerEntityFramework/Pages/Account/Login/Index.cshtml.cs
@@ -109,7 +109,7 @@ public class Index : PageModel
                 {
                     props.IsPersistent = true;
                     props.ExpiresUtc = DateTimeOffset.UtcNow.Add(LoginOptions.RememberMeLoginDuration);
-                };
+                }
 
                 // issue authentication cookie with subject ID and username
                 var isuser = new IdentityServerUser(user.SubjectId)

--- a/templates/src/IdentityServerInMem/Pages/Account/Login/Index.cshtml.cs
+++ b/templates/src/IdentityServerInMem/Pages/Account/Login/Index.cshtml.cs
@@ -109,7 +109,7 @@ public class Index : PageModel
                 {
                     props.IsPersistent = true;
                     props.ExpiresUtc = DateTimeOffset.UtcNow.Add(LoginOptions.RememberMeLoginDuration);
-                };
+                }
 
                 // issue authentication cookie with subject ID and username
                 var isuser = new IdentityServerUser(user.SubjectId)


### PR DESCRIPTION
This PR corrects improper semicolon usage in lambda expressions across multiple files by replacing them with closing braces. Ensures proper syntax adherence without introducing functional changes.