### PR TITLE
Ensure Client Secret is Required for Clients with ClientCredentials Grant

### DIFF
--- a/identity-server/src/IdentityServer/Validation/Default/DefaultClientConfigurationValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/Default/DefaultClientConfigurationValidator.cs
@@ -242,6 +242,12 @@ public class DefaultClientConfigurationValidator : IClientConfigurationValidator
                         return Task.CompletedTask;
                     }
                 }
+                
+                if (string.Equals(grantType, GrantType.ClientCredentials) && !context.Client.RequireClientSecret)
+                {
+                    context.SetError("RequireClientSecret is false, but client is using client credentials grant type.");
+                    return Task.CompletedTask;
+                }
             }
         }
 

--- a/identity-server/test/IdentityServer.IntegrationTests/Clients/ClientCredentialsClient.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Clients/ClientCredentialsClient.cs
@@ -2,20 +2,14 @@
 // See LICENSE in the project root for license information.
 
 
-using System.Collections.Generic;
-using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Text;
 using System.Text.Json;
-using System.Threading.Tasks;
-using Shouldly;
 using Duende.IdentityModel;
 using Duende.IdentityModel.Client;
 using IntegrationTests.Clients.Setup;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
-using Xunit;
 
 namespace IntegrationTests.Clients;
 
@@ -265,7 +259,7 @@ public class ClientCredentialsClient
 
 
     [Fact]
-    public async Task Request_For_client_with_no_secret_and_basic_authentication_should_succeed()
+    public async Task Request_For_client_with_no_secret_and_basic_authentication_should_fail()
     {
         var response = await _client.RequestClientCredentialsTokenAsync(new ClientCredentialsTokenRequest
         {
@@ -274,20 +268,8 @@ public class ClientCredentialsClient
             Scope = "api1"
         });
 
-        response.IsError.ShouldBe(false);
-        response.ExpiresIn.ShouldBe(3600);
-        response.TokenType.ShouldBe("Bearer");
-        response.IdentityToken.ShouldBeNull();
-        response.RefreshToken.ShouldBeNull();
-
-        var payload = GetPayload(response);
-            
-        payload["iss"].GetString().ShouldBe("https://idsvr4");
-        payload["aud"].GetString().ShouldBe("api");
-        payload["client_id"].GetString().ShouldBe("client.no_secret");
-
-        var scopes = payload["scope"].EnumerateArray();
-        scopes.First().ToString().ShouldBe("api1");
+        response.IsError.ShouldBeTrue();
+        response.Error.ShouldBe("invalid_client");
     }
 
     [Fact]


### PR DESCRIPTION
**What issue does this PR address?**
Currently it's possible to configure a client to allow the `ClientCredentials` grant type and set `RequireClientSecret` on the client to `false` which creates a bad scenario. These changes update the `DefaultClientConfigurationValidator` to consider that scenario invalid.


**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
