### PR TITLE
Manual CodeQL Build Commands

### DIFF
--- a/.github/workflow-gen/Program.cs
+++ b/.github/workflow-gen/Program.cs
@@ -310,7 +310,9 @@ void GenerateCodeQlWorkflow(Product system, string cronSchedule)
     
     job.StepInitializeCodeQl();
     
-    job.StepAutoBuildCodeQl();
+    job.StepSetupDotNet();
+
+    job.StepBuild(system.Solution);
     
     job.StepPerformCodeQlAnalysis();
     
@@ -619,14 +621,8 @@ public static class StepExtensions
             .Name("Initialize CodeQL")
             .Uses("github/codeql-action/init@9e8d0789d4a0fa9ceb6b1738f7e269594bdd67f0") // 3.28.9
             .With(
-                ("languages", "csharp"));
-    }
-    
-    public static void StepAutoBuildCodeQl(this Job job)
-    {
-        job.Step()
-            .Name("Auto Build")
-            .Uses("github/codeql-action/autobuild@9e8d0789d4a0fa9ceb6b1738f7e269594bdd67f0"); // 3.28.9
+                ("languages", "csharp"),
+                ("build-mode", "manual"));
     }
     
     public static void StepPerformCodeQlAnalysis(this Job job)

--- a/.github/workflows/bff-codeql-analysis.yml
+++ b/.github/workflows/bff-codeql-analysis.yml
@@ -34,8 +34,16 @@ jobs:
       uses: github/codeql-action/init@9e8d0789d4a0fa9ceb6b1738f7e269594bdd67f0
       with:
         languages: csharp
-    - name: Auto Build
-      uses: github/codeql-action/autobuild@9e8d0789d4a0fa9ceb6b1738f7e269594bdd67f0
+        build-mode: manual
+    - name: Setup Dotnet
+      uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25
+      with:
+        dotnet-version: |-
+          6.0.x
+          8.0.x
+          9.0.x
+    - name: Build
+      run: dotnet build bff.slnf -c Release
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@9e8d0789d4a0fa9ceb6b1738f7e269594bdd67f0
       with:

--- a/.github/workflows/identity-server-codeql-analysis.yml
+++ b/.github/workflows/identity-server-codeql-analysis.yml
@@ -34,8 +34,16 @@ jobs:
       uses: github/codeql-action/init@9e8d0789d4a0fa9ceb6b1738f7e269594bdd67f0
       with:
         languages: csharp
-    - name: Auto Build
-      uses: github/codeql-action/autobuild@9e8d0789d4a0fa9ceb6b1738f7e269594bdd67f0
+        build-mode: manual
+    - name: Setup Dotnet
+      uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25
+      with:
+        dotnet-version: |-
+          6.0.x
+          8.0.x
+          9.0.x
+    - name: Build
+      run: dotnet build identity-server.slnf -c Release
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@9e8d0789d4a0fa9ceb6b1738f7e269594bdd67f0
       with:


### PR DESCRIPTION
**What issue does this PR address?**
Using the CodeQL action's `autobuild` mode was resulting in both products being built in every workflow. These changes specify a product specific build in each CodeQL pipeline so each scan is only running on the appropriate product code.


**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
