### PR TITLE
Signout on refresh token expire

### DIFF
--- a/bff/hosts/Hosts.Bff.InMemory/ImpersonationAccessTokenRetriever.cs
+++ b/bff/hosts/Hosts.Bff.InMemory/ImpersonationAccessTokenRetriever.cs
@@ -34,17 +34,15 @@ public class ImpersonationAccessTokenRetriever : DefaultAccessTokenRetriever
                 SubjectToken = bearerToken.AccessToken,
                 SubjectTokenType = OidcConstants.TokenTypeIdentifiers.AccessToken
             });
-            if(exchangeResponse.IsError)
+            if(exchangeResponse.AccessToken is null)
+            {
+                return new NoAccessTokenReturnedError("Token exchanged failed. Access token is null");
+            }
+            if (exchangeResponse.IsError)
             {
                 return new AccessTokenRetrievalError($"Token exchanged failed: {exchangeResponse.ErrorDescription}");
             }
-            if(exchangeResponse.AccessToken is null)
-            {
-                return new AccessTokenRetrievalError("Token exchanged failed. Access token is null");
-            } else
-            {
-                return new BearerTokenResult(exchangeResponse.AccessToken);
-            }
+            return new BearerTokenResult(exchangeResponse.AccessToken);
         }
 
         return result;

--- a/bff/hosts/Hosts.IdentityServer/ServiceDiscoveringClientStore.cs
+++ b/bff/hosts/Hosts.IdentityServer/ServiceDiscoveringClientStore.cs
@@ -59,7 +59,9 @@ public class ServiceDiscoveringClientStore(ServiceEndpointResolver resolver) : I
                     AllowOfflineAccess = true,
                     AllowedScopes = { "openid", "profile", "api", "scope-for-isolated-api" },
 
-                    AccessTokenLifetime = 75 // Force refresh
+                    RefreshTokenExpiration = TokenExpiration.Absolute,
+                    AbsoluteRefreshTokenLifetime = 60,
+                    AccessTokenLifetime = 15 // Force refresh
                 },
                 new Client
                 {
@@ -103,6 +105,7 @@ public class ServiceDiscoveringClientStore(ServiceEndpointResolver resolver) : I
                     AllowedScopes = { "openid", "profile", "api", "scope-for-isolated-api" },
 
                     AccessTokenLifetime = 75 // Force refresh
+
                 },
 
                 new Client

--- a/bff/src/Bff.Yarp/AccessTokenRequestTransform.cs
+++ b/bff/src/Bff.Yarp/AccessTokenRequestTransform.cs
@@ -1,18 +1,17 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
-using System;
-using System.Collections.Generic;
 using System.Net.Http.Headers;
-using System.Threading.Tasks;
 using Duende.AccessTokenManagement;
 using Duende.AccessTokenManagement.OpenIdConnect;
 using Duende.Bff.Logging;
 using Duende.IdentityModel;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Yarp.ReverseProxy.Model;
 using Yarp.ReverseProxy.Transforms;
 
@@ -22,6 +21,7 @@ namespace Duende.Bff.Yarp;
 /// Adds an access token to outgoing requests
 /// </summary>
 public class AccessTokenRequestTransform(
+    IOptions<BffOptions> options,
     IDPoPProofService proofService,
     ILogger<AccessTokenRequestTransform> logger) : RequestTransform
 {
@@ -76,6 +76,16 @@ public class AccessTokenRequestTransform(
                 await ApplyDPoPToken(context, dpopToken);
                 break;
             case AccessTokenRetrievalError tokenError:
+
+                if (ShouldSignOutUser(tokenError, metadata))
+                {
+                    // see if we need to sign out
+                    var authenticationSchemeProvider = context.HttpContext.RequestServices.GetRequiredService<IAuthenticationSchemeProvider>();
+                    // get rid of local cookie first
+                    var signInScheme = await authenticationSchemeProvider.GetDefaultSignInSchemeAsync();
+                    await context.HttpContext.SignOutAsync(signInScheme?.Name);
+                }
+
                 ApplyError(context, tokenError, metadata.RequiredTokenType);
                 break;
             case NoAccessTokenResult noToken:
@@ -83,6 +93,25 @@ public class AccessTokenRequestTransform(
             default:
                 break;
         }
+    }
+
+    private bool ShouldSignOutUser(AccessTokenRetrievalError tokenError, BffRemoteApiEndpointMetadata metadata)
+    {
+        if (tokenError is NoAccessTokenReturnedError && metadata.RequiredTokenType == TokenType.User ||
+            metadata.RequiredTokenType == TokenType.UserOrClient)
+        {
+            if (!options.Value.RemoveSessionAfterTokenExpiration)
+            {
+                logger.FailedToRequestNewUserAccessToken(tokenError.Error);
+                return false;
+            }
+
+            logger.UserSessionRevoked(tokenError.Error);
+            return true;
+
+        }
+
+        return false;
     }
 
     private static BffRemoteApiEndpointMetadata? GetBffMetadataFromYarp(Endpoint endpoint)

--- a/bff/src/Bff.Yarp/AccessTokenRequestTransform.cs
+++ b/bff/src/Bff.Yarp/AccessTokenRequestTransform.cs
@@ -100,7 +100,7 @@ public class AccessTokenRequestTransform(
         if (tokenError is NoAccessTokenReturnedError && metadata.RequiredTokenType == TokenType.User ||
             metadata.RequiredTokenType == TokenType.UserOrClient)
         {
-            if (!options.Value.RemoveSessionAfterTokenExpiration)
+            if (!options.Value.RemoveSessionAfterRefreshTokenExpiration)
             {
                 logger.FailedToRequestNewUserAccessToken(tokenError.Error);
                 return false;

--- a/bff/src/Bff.Yarp/AccessTokenTransformProvider.cs
+++ b/bff/src/Bff.Yarp/AccessTokenTransformProvider.cs
@@ -110,6 +110,7 @@ public class AccessTokenTransformProvider : ITransformProvider
             transformContext.HttpContext.CheckForBffMiddleware(_options);
 
             var accessTokenTransform = new AccessTokenRequestTransform(
+                Options.Create(_options),
                 _dPoPProofService,
                 _loggerFactory.CreateLogger<AccessTokenRequestTransform>());
 

--- a/bff/src/Bff.Yarp/YarpTransformExtensions.cs
+++ b/bff/src/Bff.Yarp/YarpTransformExtensions.cs
@@ -2,10 +2,12 @@
 // See LICENSE in the project root for license information.
 
 using Duende.AccessTokenManagement;
+using Duende.Bff;
 using Duende.Bff.Yarp;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Yarp.ReverseProxy.Transforms.Builder;
 
 namespace Microsoft.AspNetCore.Builder;
@@ -22,8 +24,10 @@ public static class YarpTransformExtensions
     {
         var proofService = context.Services.GetRequiredService<IDPoPProofService>();
         var logger = context.Services.GetRequiredService<ILogger<AccessTokenRequestTransform>>();
+        var options = context.Services.GetRequiredService<IOptions<BffOptions>>();
         context.RequestTransforms.Add(
             new AccessTokenRequestTransform(
+                options,
                 proofService,
                 logger
             ));

--- a/bff/src/Bff/Configuration/BffOptions.cs
+++ b/bff/src/Bff/Configuration/BffOptions.cs
@@ -136,7 +136,7 @@ public class BffOptions
     public string? DPoPJsonWebKey { get; set; }
 
     /// <summary>
-    /// Should an user session be removed after an attempt to use a Refresh Token to acquire
+    /// Flag that specifies if a user session should be removed after an attempt to use a Refresh Token to acquire
     /// a new Access Token fails. This behavior is only triggered when proxying requests to remote
     /// APIs with TokenType.User or TokenType.UserOrClient. Defaults to True. 
     /// </summary>

--- a/bff/src/Bff/Configuration/BffOptions.cs
+++ b/bff/src/Bff/Configuration/BffOptions.cs
@@ -136,9 +136,11 @@ public class BffOptions
     public string? DPoPJsonWebKey { get; set; }
 
     /// <summary>
-    /// Should an user session be removed after we detect that user access tokens have expired. 
+    /// Should an user session be removed after an attempt to use a Refresh Token to acquire
+    /// a new Access Token fails. This behavior is only triggered when proxying requests to remote
+    /// APIs with TokenType.User or TokenType.UserOrClient. Defaults to True. 
     /// </summary>
-    public bool RemoveSessionAfterTokenExpiration { get; set; } = true;
+    public bool RemoveSessionAfterRefreshTokenExpiration { get; set; } = true;
 }
 
 /// <summary>

--- a/bff/src/Bff/Configuration/BffOptions.cs
+++ b/bff/src/Bff/Configuration/BffOptions.cs
@@ -134,6 +134,11 @@ public class BffOptions
     /// null, which is appropriate when not using DPoP.
     /// </summary>
     public string? DPoPJsonWebKey { get; set; }
+
+    /// <summary>
+    /// Should an user session be removed after we detect that user access tokens have expired. 
+    /// </summary>
+    public bool RemoveSessionAfterTokenExpiration { get; set; } = true;
 }
 
 /// <summary>

--- a/bff/src/Bff/Extensions/HttpContextExtensions.cs
+++ b/bff/src/Bff/Extensions/HttpContextExtensions.cs
@@ -50,15 +50,15 @@ internal static class HttpContextExtensions
             null or { AccessToken: null } =>
                 optional ?
                     new NoAccessTokenResult() :
-                    new AccessTokenRetrievalError("Missing access token"),
+                    new NoAccessTokenReturnedError("Missing access token"),
             { AccessTokenType: OidcConstants.TokenResponse.BearerTokenType } =>
                 new BearerTokenResult(token.AccessToken),
             { AccessTokenType: OidcConstants.TokenResponse.DPoPTokenType, DPoPJsonWebKey: not null } =>
                  new DPoPTokenResult(token.AccessToken, token.DPoPJsonWebKey),
             { AccessTokenType: OidcConstants.TokenResponse.DPoPTokenType, DPoPJsonWebKey: null } =>
-                 new AccessTokenRetrievalError("Missing DPoP Json Web Key for DPoP token"),
+                 new MissingDPopTokenError("Missing DPoP Json Web Key for DPoP token"),
             { AccessTokenType: string accessTokenType } =>
-                new AccessTokenRetrievalError($"Unexpected access token type: {accessTokenType} - should be one of 'DPoP' or 'Bearer'"),
+                new UnexpectedAccessTokenError($"Unexpected access token type: {accessTokenType} - should be one of 'DPoP' or 'Bearer'"),
             { AccessTokenType: null } => 
                 // Fall back to bearer tokens when the access token type is absent.
                 // In some edge cases, we've seen bearer tokens not have their type specified.

--- a/bff/src/Bff/General/AccessTokenRetrievalError.cs
+++ b/bff/src/Bff/General/AccessTokenRetrievalError.cs
@@ -23,4 +23,9 @@ public class AccessTokenRetrievalError : AccessTokenResult
     /// Gets or sets the error message.
     /// </summary>
     public string Error { get; set; }
+
 }
+
+public class NoAccessTokenReturnedError(string error) : AccessTokenRetrievalError(error);
+public class MissingDPopTokenError(string error) : AccessTokenRetrievalError(error);
+public class UnexpectedAccessTokenError(string error) : AccessTokenRetrievalError(error);

--- a/bff/src/Bff/General/Log.cs
+++ b/bff/src/Bff/General/Log.cs
@@ -48,6 +48,16 @@ internal static class Log
         EventIds.InvalidRouteConfiguration,
         "Invalid route configuration. Cannot combine a required access token (a call to WithAccessToken) and an optional access token (a call to WithOptionalUserAccessToken). clusterId: '{clusterId}', routeId: '{routeId}'");
 
+    private static readonly Action<ILogger, string, Exception?> FailedToRequestNewTokenMessage = LoggerMessage.Define<string>(
+        LogLevel.Warning,
+        EventIds.InvalidRouteConfiguration,
+        "Failed to request new User Access Token due to: {message}. This can mean that the refresh token is expired or revoked but the cookie session is still active. If the session was not revoked, ensure that the session cookie lifetime is smaller than the refresh token lifetime.");
+
+    private static readonly Action<ILogger, string, Exception?> UserSessionRevokedMessage = LoggerMessage.Define<string>(
+        LogLevel.Warning,
+        EventIds.InvalidRouteConfiguration,
+        "Failed to request new User Access Token due to: {message}. This likely means that the user's refresh token is expired or revoked. The user's session will be ended, which will force the user to log in.");
+
     public static void AntiForgeryValidationFailed(this ILogger logger, string localPath)
     {
         AntiForgeryValidationFailedMessage(logger, localPath, null);
@@ -71,5 +81,15 @@ internal static class Log
     public static void InvalidRouteConfiguration(this ILogger logger, string? clusterId, string routeId)
     {
         InvalidRouteConfigurationMessage(logger, clusterId ?? "no cluster id", routeId, null);
+    }
+
+    public static void FailedToRequestNewUserAccessToken(this ILogger logger, string message)
+    {
+        FailedToRequestNewTokenMessage(logger, message, null);
+    }
+
+    public static void UserSessionRevoked(this ILogger logger, string message)
+    {
+        UserSessionRevokedMessage(logger, message, null);
     }
 }

--- a/bff/test/Bff.Tests/Endpoints/RemoteEndpointTests.cs
+++ b/bff/test/Bff.Tests/Endpoints/RemoteEndpointTests.cs
@@ -40,12 +40,14 @@ namespace Duende.Bff.Tests.Endpoints
         }
 
         [Fact]
-        public async Task calls_to_remote_endpoint_with_useraccesstokenparameters_having_stored_named_token_should_forward_user_to_api()
+        public async Task
+            calls_to_remote_endpoint_with_useraccesstokenparameters_having_stored_named_token_should_forward_user_to_api()
         {
             await BffHostWithNamedTokens.BffLoginAsync("alice");
 
             ApiResponse apiResult = await BffHostWithNamedTokens.BrowserClient.CallBffHostApi(
-                url: BffHostWithNamedTokens.Url("/api_user_with_useraccesstokenparameters_having_stored_named_token/test")
+                url: BffHostWithNamedTokens.Url(
+                    "/api_user_with_useraccesstokenparameters_having_stored_named_token/test")
             );
 
             apiResult.Method.ShouldBe("GET");
@@ -55,12 +57,14 @@ namespace Duende.Bff.Tests.Endpoints
         }
 
         [Fact]
-        public async Task calls_to_remote_endpoint_with_useraccesstokenparameters_having_not_stored_corresponding_named_token_finds_no_matching_token_should_fail()        
+        public async Task
+            calls_to_remote_endpoint_with_useraccesstokenparameters_having_not_stored_corresponding_named_token_finds_no_matching_token_should_fail()
         {
             await BffHostWithNamedTokens.BffLoginAsync("alice");
 
             await BffHostWithNamedTokens.BrowserClient.CallBffHostApi(
-                url: BffHostWithNamedTokens.Url("/api_user_with_useraccesstokenparameters_having_not_stored_named_token/test"),
+                url: BffHostWithNamedTokens.Url(
+                    "/api_user_with_useraccesstokenparameters_having_not_stored_named_token/test"),
                 expectedStatusCode: HttpStatusCode.Unauthorized
             );
         }
@@ -153,6 +157,32 @@ namespace Duende.Bff.Tests.Endpoints
 
             await BffHost.BrowserClient.CallBffHostApi(
                 url: BffHost.Url("/api_with_access_token_retrieval_that_fails"),
+                expectedStatusCode: HttpStatusCode.Unauthorized
+            );
+
+            // user should be signed out
+            var result = await BffHost.GetIsUserLoggedInAsync();
+            result.ShouldBeFalse();
+        }
+
+        [Fact]
+        public async Task calls_to_remote_api_that_returns_forbidden_will_return_forbidden()
+        {
+            await BffHost.BffLoginAsync("alice");
+
+            await BffHost.BrowserClient.CallBffHostApi(
+                url: BffHost.Url("/api_forbidden"),
+                expectedStatusCode: HttpStatusCode.Forbidden
+            );
+        }
+
+        [Fact]
+        public async Task calls_to_remote_api_that_returns_unauthorized_will_return_unauthorized()
+        {
+            await BffHost.BffLoginAsync("alice");
+
+            await BffHost.BrowserClient.CallBffHostApi(
+                url: BffHost.Url("/api_unauthenticated"),
                 expectedStatusCode: HttpStatusCode.Unauthorized
             );
         }

--- a/bff/test/Bff.Tests/TestHosts/ApiHost.cs
+++ b/bff/test/Bff.Tests/TestHosts/ApiHost.cs
@@ -61,6 +61,20 @@ namespace Duende.Bff.Tests.TestHosts
 
             app.UseEndpoints(endpoints =>
             {
+                endpoints.Map("/return_unauthenticated",
+                    context =>
+                    {
+                        context.Response.StatusCode = (int) System.Net.HttpStatusCode.Unauthorized;
+                        return Task.CompletedTask;
+                    });
+
+                endpoints.Map("/return_forbidden",
+                    context =>
+                    {
+                        context.Response.StatusCode = (int) System.Net.HttpStatusCode.Forbidden;
+                        return Task.CompletedTask;
+                    });
+
                 endpoints.Map("/{**catch-all}", async context =>
                 {
                     // capture body if present

--- a/bff/test/Bff.Tests/TestHosts/BffHost.cs
+++ b/bff/test/Bff.Tests/TestHosts/BffHost.cs
@@ -428,6 +428,16 @@ public class BffHost : GenericHost
                 .RequireAccessToken(TokenType.UserOrClient);
 
             endpoints.MapRemoteBffApiEndpoint(
+                    "/api_unauthenticated", _apiHost.Url() + "return_unauthenticated")
+                .RequireAccessToken(TokenType.UserOrClient);
+
+
+            endpoints.MapRemoteBffApiEndpoint(
+                    "/api_forbidden", _apiHost.Url() + "return_forbidden")
+                .RequireAccessToken(TokenType.UserOrClient);
+
+
+            endpoints.MapRemoteBffApiEndpoint(
                     "/api_user_or_anon", _apiHost.Url())
                 .WithOptionalUserAccessToken();
 

--- a/bff/test/Bff.Tests/TestHosts/FailureAccessTokenRetriever.cs
+++ b/bff/test/Bff.Tests/TestHosts/FailureAccessTokenRetriever.cs
@@ -9,6 +9,6 @@ public class FailureAccessTokenRetriever : IAccessTokenRetriever
 {
     public Task<AccessTokenResult> GetAccessToken(AccessTokenRetrievalContext context)
     {
-        return Task.FromResult<AccessTokenResult>(new AccessTokenRetrievalError("Test"));
+        return Task.FromResult<AccessTokenResult>(new NoAccessTokenReturnedError("Test"));
     }
 }

--- a/bff/test/Hosts.Tests/BffBlazorWebAssemblyTests.cs
+++ b/bff/test/Hosts.Tests/BffBlazorWebAssemblyTests.cs
@@ -2,6 +2,7 @@
 using Hosts.Tests.PageModels;
 using Hosts.Tests.TestInfra;
 using Microsoft.Playwright;
+using System.Net.Http;
 using Xunit.Abstractions;
 
 namespace Hosts.Tests;
@@ -21,6 +22,9 @@ public class BffBlazorWebAssemblyTests(ITestOutputHelper output, AppHostFixture 
     [SkippableFact]
     public async Task Can_login_and_load_local_api()
     {
+        await Warmup();
+
+
         var homePage = await GoToHome();
 
         await homePage.VerifyNotLoggedIn();
@@ -37,6 +41,11 @@ public class BffBlazorWebAssemblyTests(ITestOutputHelper output, AppHostFixture 
 
     }
 
-
-
+    private async Task Warmup()
+    {
+        // there have been issues where playwright hangs on the first test run.
+        // maybe warming up the app will help?
+        var httpClient = CreateHttpClient(AppHostServices.BffBlazorWebassembly);
+        (await httpClient.GetAsync("/")).StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
 }

--- a/bff/test/Hosts.Tests/BffTests.cs
+++ b/bff/test/Hosts.Tests/BffTests.cs
@@ -1,3 +1,4 @@
+using Hosts.ServiceDefaults;
 using Hosts.Tests.TestInfra;
 using Shouldly;
 using Xunit.Abstractions;
@@ -11,8 +12,8 @@ public class BffTests : IntegrationTestBase
 
     public BffTests(ITestOutputHelper output, AppHostFixture fixture) : base(output: output, fixture: fixture)
     {
-        _httpClient = CreateHttpClient("bff");
-        _bffClient = new BffClient(CreateHttpClient("bff"));
+        _httpClient = CreateHttpClient(AppHostServices.Bff);
+        _bffClient = new BffClient(CreateHttpClient(AppHostServices.Bff));
     }
 
     [SkippableFact]
@@ -25,6 +26,10 @@ public class BffTests : IntegrationTestBase
     [SkippableFact]
     public async Task Can_initiate_login()
     {
+
+        var response = await _httpClient.GetAsync("/");
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
         await _bffClient.TriggerLogin();
 
         // Verify that there are user claims

--- a/bff/test/Hosts.Tests/BlazorPerComponentTests.cs
+++ b/bff/test/Hosts.Tests/BlazorPerComponentTests.cs
@@ -21,6 +21,8 @@ public class BlazorPerComponentTests(ITestOutputHelper output, AppHostFixture fi
     [SkippableFact]
     public async Task Can_load_blazor_webassembly_app()
     {
+        await Warmup();
+
         var homePage = await GoToHome();
         await homePage.Login();
         var callApiPage = await homePage.GoToCallApiPage();
@@ -31,6 +33,12 @@ public class BlazorPerComponentTests(ITestOutputHelper output, AppHostFixture fi
         await callApiPage.InvokeCallApi("InteractiveAuto");
 
     }
-
+    private async Task Warmup()
+    {
+        // there have been issues where playwright hangs on the first test run.
+        // maybe warming up the app will help?
+        var httpClient = CreateHttpClient(AppHostServices.BffBlazorPerComponent);
+        (await httpClient.GetAsync("/")).StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
 
 }


### PR DESCRIPTION
**What issue does this PR address?**
The BFF now detects, when it tries to request an access token to access **external services** that there was a failure to request an access token. Should this happen, then by default, the session will be terminated. This behavior can be disabled with a setting. 

The BCP for Browser Based Applications states:

> 6.1.2.2. [Refresh Tokens](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-browser-based-apps#name-refresh-tokens)

> When the refresh token expires, there is no way to obtain a valid access token without running an entirely new Authorization Code flow. Therefore, it makes sense to configure the lifetime of the cookie-based session managed by the BFF to be equal to the maximum lifetime of the refresh token. **Additionally, when the BFF learns that a refresh token for an active session is no longer valid, it also makes sense to invalidate the session**.[¶](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-browser-based-apps#section-6.1.2.2-3)

That last line is implemented here. 

## Why sign out a user's session?

As mentioned in the BCP, if the session is still valid but the refresh token has expired, there is a weird situation going on for the user. Local api's, external (client credential) api's AND the BFF's user management api's continue to work, but the external api's with user tokens stop working and get a 401 error. Refreshing the browser doesn't help, because the app still thinks the user is logged in. Only starting a new login flow will solve the error. 

Now the browser can (and should) trigger a new login flow if a 401 error is received, but now by default, when the user hits this refresh token expiration error, the user will be signed out of the session, so reloading the browser will indicate that the session has expired and the user needs to log in again. 





**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
