### PR TITLE
fix double quotes in release build

### DIFF
--- a/.github/workflow-gen/Program.cs
+++ b/.github/workflow-gen/Program.cs
@@ -549,7 +549,7 @@ public static class StepExtensions
         return job.Step()
             .Name("Git Config")
             .Run($"""
-                 git tag -a {component.TagPrefix}-{contexts.Event.Input.Version} -m ""Release v{contexts.Event.Input.Version}""
+                 git tag -a {component.TagPrefix}-{contexts.Event.Input.Version} -m "Release v{contexts.Event.Input.Version}"
                  git push origin {component.TagPrefix}-{contexts.Event.Input.Version}
                  """);
     }

--- a/.github/workflows/bff-release.yml
+++ b/.github/workflows/bff-release.yml
@@ -56,7 +56,7 @@ jobs:
         fi
     - name: Git Config
       run: |-
-        git tag -a bff-${{ github.event.inputs.version }} -m ""Release v${{ github.event.inputs.version }}""
+        git tag -a bff-${{ github.event.inputs.version }} -m "Release v${{ github.event.inputs.version }}"
         git push origin bff-${{ github.event.inputs.version }}
     - name: Setup Dotnet
       uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25

--- a/.github/workflows/identity-server-release.yml
+++ b/.github/workflows/identity-server-release.yml
@@ -56,7 +56,7 @@ jobs:
         fi
     - name: Git Config
       run: |-
-        git tag -a is-${{ github.event.inputs.version }} -m ""Release v${{ github.event.inputs.version }}""
+        git tag -a is-${{ github.event.inputs.version }} -m "Release v${{ github.event.inputs.version }}"
         git push origin is-${{ github.event.inputs.version }}
     - name: Setup Dotnet
       uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25

--- a/.github/workflows/templates-release.yml
+++ b/.github/workflows/templates-release.yml
@@ -53,7 +53,7 @@ jobs:
         fi
     - name: Git Config
       run: |-
-        git tag -a templates-${{ github.event.inputs.version }} -m ""Release v${{ github.event.inputs.version }}""
+        git tag -a templates-${{ github.event.inputs.version }} -m "Release v${{ github.event.inputs.version }}"
         git push origin templates-${{ github.event.inputs.version }}
     - name: build templates
       run: dotnet run --project build


### PR DESCRIPTION
**What issue does this PR address?**
Due to a copy paste error, there's a double quote in the git-tag logic of the release branch. This removes it. 


**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
