### PR TITLE
Fixing issue when refresh token times out

### DIFF
--- a/bff/hosts/Blazor/PerComponent/Hosts.Bff.Blazor.PerComponent.Client/Components/CallApi.razor
+++ b/bff/hosts/Blazor/PerComponent/Hosts.Bff.Blazor.PerComponent.Client/Components/CallApi.razor
@@ -1,5 +1,11 @@
+@using System.Net
+@using Duende.Bff.Blazor.Client
+@using Microsoft.Extensions.Options
 @inject IRenderModeContext RenderModeContext
 @inject IHttpClientFactory Factory
+@inject IOptions<BffBlazorOptions> Options
+@inject NavigationManager Navigation
+@inject AuthenticationStateProvider GetAuthenticationStateAsync
 
 <div class="card">
     <h3 class="card-header">@Header</h3>
@@ -13,10 +19,10 @@
 
                 @if(_apiResult != null)
                 {
-                        <p class="card-text">
-                            Token ID: @_apiResult.Jti
-                            <br />Retrieved at @_apiResult.Time
-                        </p>
+                    <p class="card-text">
+                        Token ID: @_apiResult.Jti
+                        <br />Retrieved at @_apiResult.Time
+                    </p>
                 } else
                 {
                     <p class="card-text">API Result: not called yet</p>
@@ -45,8 +51,28 @@
     protected async Task CallApiAsync()
     {
         DisableUi = true;
-        _apiResult = await _http.GetFromJsonAsync<ApiResult>("user-token");
+        try
+        {
+            _apiResult = await _http.GetFromJsonAsync<ApiResult>("user-token");
+        }
+        catch (HttpRequestException e) when (e.StatusCode == HttpStatusCode.Unauthorized)
+        {
+            // The user is not authenticated. This can happen if the authentication cookie
+            // is valid longer than the refresh token. The server already logs the user
+            // out. In theory, we could just 'refresh' the page, but this might cause 
+            // an endless auth loop. 
+            Navigation.NavigateTo(await BffLogoutUrl(), forceLoad: true);
+        }
+
         DisableUi = false;
+    }
+
+    async Task<string> BffLogoutUrl()
+    {
+        var context = await GetAuthenticationStateAsync.GetAuthenticationStateAsync();
+        var logoutUrl =  context.User.FindFirst(Constants.ClaimTypes.LogoutUrl);
+        if (logoutUrl == null) throw new InvalidOperationException("The logout url is missing");
+        return $"{Options.Value.StateProviderBaseAddress}{logoutUrl.Value}";
     }
 
     protected override void OnAfterRender(bool firstRender)

--- a/bff/hosts/Hosts.IdentityServer/ServiceDiscoveringClientStore.cs
+++ b/bff/hosts/Hosts.IdentityServer/ServiceDiscoveringClientStore.cs
@@ -83,7 +83,10 @@ public class ServiceDiscoveringClientStore(ServiceEndpointResolver resolver) : I
                     AllowOfflineAccess = true,
                     AllowedScopes = { "openid", "profile", "api", "scope-for-isolated-api" },
 
-                    AccessTokenLifetime = 75 // Force refresh
+                    // Intentionally set lifetime short to see what happens when access and refresh tokens expire
+                    AccessTokenLifetime = 15,
+                    RefreshTokenExpiration = TokenExpiration.Absolute,
+                    AbsoluteRefreshTokenLifetime = 60
                 },
                 new Client
                 {
@@ -104,7 +107,10 @@ public class ServiceDiscoveringClientStore(ServiceEndpointResolver resolver) : I
                     AllowOfflineAccess = true,
                     AllowedScopes = { "openid", "profile", "api", "scope-for-isolated-api" },
 
-                    AccessTokenLifetime = 75 // Force refresh
+                    // Intentionally set lifetime short to see what happens when access and refresh tokens expire
+                    AccessTokenLifetime = 15,
+                    RefreshTokenExpiration = TokenExpiration.Absolute,
+                    AbsoluteRefreshTokenLifetime = 60
 
                 },
 
@@ -129,7 +135,10 @@ public class ServiceDiscoveringClientStore(ServiceEndpointResolver resolver) : I
                     AllowOfflineAccess = true,
                     AllowedScopes = { "openid", "profile", "api", "scope-for-isolated-api" },
 
-                    AccessTokenLifetime = 75
+                    // Intentionally set lifetime short to see what happens when access and refresh tokens expire
+                    AccessTokenLifetime = 15,
+                    RefreshTokenExpiration = TokenExpiration.Absolute,
+                    AbsoluteRefreshTokenLifetime = 60
                 }
             ];
         }

--- a/bff/src/Bff.Blazor/ServerSideTokenStore.cs
+++ b/bff/src/Bff.Blazor/ServerSideTokenStore.cs
@@ -45,6 +45,10 @@ public class ServerSideTokenStore(
 
     private async Task<UserSession?> GetSession(ClaimsPrincipal user)
     {
+        if (user.Identity?.IsAuthenticated == false)
+        {
+            return null;
+        }
         var sub = user.FindFirst("sub")?.Value ?? throw new InvalidOperationException("no sub claim");
         var sid = user.FindFirst("sid")?.Value ?? throw new InvalidOperationException("no sid claim");
 

--- a/bff/src/Bff/EndpointServices/Logout/DefaultLogoutService.cs
+++ b/bff/src/Bff/EndpointServices/Logout/DefaultLogoutService.cs
@@ -78,7 +78,7 @@ public class DefaultLogoutService : ILogoutService
                 }
             }
         }
-            
+
         var returnUrl = context.Request.Query[Constants.RequestParameters.ReturnUrl].FirstOrDefault();
         if (!string.IsNullOrWhiteSpace(returnUrl))
         {

--- a/bff/test/Bff.Tests/Endpoints/Management/LogoutEndpointTests.cs
+++ b/bff/test/Bff.Tests/Endpoints/Management/LogoutEndpointTests.cs
@@ -109,6 +109,21 @@ namespace Duende.Bff.Tests.Endpoints.Management
         }
 
         [Fact]
+        public async Task can_logout_twice()
+        {
+            await BffHost.BffLoginAsync("alice", "sid123");
+
+            await BffHost.BffLogoutAsync("sid123");
+
+            var response = await BffHost.BrowserClient.GetAsync(BffHost.Url("/bff/logout") + "?sid=123" );
+            response.StatusCode.ShouldBe(HttpStatusCode.Redirect); // endsession
+            response.Headers.Location!.ToString().ToLowerInvariant().ShouldStartWith(IdentityServerHost.Url("/connect/endsession"));
+
+
+            (await BffHost.GetIsUserLoggedInAsync()).ShouldBeFalse();
+        }
+
+        [Fact]
         public async Task logout_endpoint_should_accept_returnUrl()
         {
             await BffHost.BffLoginAsync("alice", "sid123");


### PR DESCRIPTION
**What issue does this PR address?**
When the refresh token is no longer valid, api calls returns a 401 status code. 

In the hosts, the front-end then detects this and attempts to completely terminate the session. However, now then it turned out that signing out twice didn't work. 

Signing out twice should now just work.


**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
