### PR TITLE
JWT Validation Clock Skew Option

### DIFF
--- a/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/DPoPOptions.cs
+++ b/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/DPoPOptions.cs
@@ -19,7 +19,7 @@ public class DPoPOptions
     public TimeSpan ProofTokenValidityDuration { get; set; } = TimeSpan.FromMinutes(1);
 
     /// <summary>
-    /// Clock skew used in validating DPoP proof token expiration using a server-senerated nonce value. Defaults to zero.
+    /// Clock skew used in validating DPoP proof token expiration using a server-generated nonce value. Defaults to zero.
     /// </summary>
-    public TimeSpan ServerClockSkew { get; set; } = TimeSpan.FromMinutes(0);
+    public TimeSpan ServerClockSkew { get; set; } = TimeSpan.FromSeconds(10);
 }

--- a/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/DPoPOptions.cs
+++ b/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/DPoPOptions.cs
@@ -19,7 +19,7 @@ public class DPoPOptions
     public TimeSpan ProofTokenValidityDuration { get; set; } = TimeSpan.FromMinutes(1);
 
     /// <summary>
-    /// Clock skew used in validating DPoP proof token expiration using a server-generated nonce value. Defaults to zero.
+    /// Clock skew used in validating DPoP proof token expiration using a server-generated nonce value. Defaults to ten seconds.
     /// </summary>
     public TimeSpan ServerClockSkew { get; set; } = TimeSpan.FromSeconds(10);
 }

--- a/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
+++ b/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
@@ -5,6 +5,7 @@
 #nullable enable
 
 using Duende.IdentityServer.Stores.Serialization;
+using Duende.IdentityServer.Validation;
 
 namespace Duende.IdentityServer.Configuration;
 

--- a/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
+++ b/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
@@ -216,8 +216,7 @@ public class IdentityServerOptions
     /// used in private_key_jwt authentication, JWT secured authorization
     /// requests (JAR), and custom usage of the <see cref="TokenValidator"/>,
     /// such as in a token exchange implementation. Defaults to ten seconds.
-    /// Task<JwtRequestValidationResult>
-    /// ValidateAsync(JwtRequestValidationContext context);
     /// </summary>
     public TimeSpan JwtValidationClockSkew { get; set; } = TimeSpan.FromSeconds(10);
+    
 }

--- a/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
+++ b/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
@@ -207,4 +207,9 @@ public class IdentityServerOptions
     /// Options for Pushed Authorization Requests (PAR).
     /// </summary>
     public PushedAuthorizationOptions PushedAuthorization { get; set; } = new PushedAuthorizationOptions();
+    
+    /// <summary>
+    /// The allowed clock skew for JWT validation.
+    /// </summary>
+    public TimeSpan JwtValidationClockSkew { get; set; } = TimeSpan.FromSeconds(10);
 }

--- a/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
+++ b/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
@@ -209,7 +209,15 @@ public class IdentityServerOptions
     public PushedAuthorizationOptions PushedAuthorization { get; set; } = new PushedAuthorizationOptions();
     
     /// <summary>
-    /// The allowed clock skew for JWT validation.
+    /// The allowed clock skew for JWT lifetime validation. All JWTs that have
+    /// their lifetime validated use this setting to control the clock skew of
+    /// lifetime validation. This includes JWT access tokens passed to the user
+    /// info, introspection, and local api endpoints, client authentication JWTs
+    /// used in private_key_jwt authentication, JWT secured authorization
+    /// requests (JAR), and custom usage of the <see cref="TokenValidator"/>,
+    /// such as in a token exchange implementation. Defaults to ten seconds.
+    /// Task<JwtRequestValidationResult>
+    /// ValidateAsync(JwtRequestValidationContext context);
     /// </summary>
     public TimeSpan JwtValidationClockSkew { get; set; } = TimeSpan.FromSeconds(10);
 }

--- a/identity-server/src/IdentityServer/Validation/Default/JwtRequestValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/Default/JwtRequestValidator.cs
@@ -170,7 +170,9 @@ public class JwtRequestValidator : IJwtRequestValidator
             ValidateAudience = true,
 
             RequireSignedTokens = true,
-            RequireExpirationTime = true
+            RequireExpirationTime = true,
+            
+            ClockSkew = Options.JwtValidationClockSkew
         };
 
         var strictJarValidation = context.StrictJarValidation.HasValue ? context.StrictJarValidation.Value : Options.StrictJarValidation;

--- a/identity-server/src/IdentityServer/Validation/Default/PrivateKeyJwtSecretValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/Default/PrivateKeyJwtSecretValidator.cs
@@ -102,7 +102,7 @@ public class PrivateKeyJwtSecretValidator : ISecretValidator
             RequireSignedTokens = true,
             RequireExpirationTime = true,
 
-            ClockSkew = TimeSpan.FromMinutes(5)
+            ClockSkew = _options.JwtValidationClockSkew
         };
         
         if (_options.StrictClientAssertionAudienceValidation)

--- a/identity-server/src/IdentityServer/Validation/Default/TokenValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/Default/TokenValidator.cs
@@ -282,7 +282,8 @@ internal class TokenValidator : ITokenValidator
         {
             ValidIssuer = await _issuerNameService.GetCurrentAsync(),
             IssuerSigningKeys = validationKeys.Select(k => k.Key),
-            ValidateLifetime = validateLifetime
+            ValidateLifetime = validateLifetime,
+            ClockSkew = _options.JwtValidationClockSkew
         };
 
         if (audience.IsPresent())

--- a/identity-server/test/IdentityServer.UnitTests/Validation/AccessTokenValidation.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Validation/AccessTokenValidation.cs
@@ -2,18 +2,13 @@
 // See LICENSE in the project root for license information.
 
 
-using System;
 using System.IdentityModel.Tokens.Jwt;
-using System.Linq;
-using System.Threading.Tasks;
 using Duende.IdentityServer.Configuration;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Stores;
-using Shouldly;
 using Duende.IdentityModel;
 using UnitTests.Common;
 using UnitTests.Validation.Setup;
-using Xunit;
 
 namespace UnitTests.Validation;
 
@@ -231,6 +226,45 @@ public class AccessTokenValidation
         var validator = Factory.CreateTokenValidator(null);
         var result = await validator.ValidateAccessTokenAsync(jwt);
 
+        result.IsError.ShouldBeTrue();
+        result.Error.ShouldBe(OidcConstants.ProtectedResourceErrors.InvalidToken);
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task JWT_respects_clock_skew_setting_to_allow_token_with_off_time()
+    {
+        var futureClock = new StubClock();
+        var definitelyNotNow = DateTime.UtcNow.AddSeconds(9);
+        futureClock.UtcNowFunc = () => definitelyNotNow;
+        var signer = Factory.CreateDefaultTokenCreator(clock: futureClock);
+        var token = TokenFactory.CreateAccessToken(new Client { ClientId = "roclient" }, "valid", 600, "read", "write");
+        var jwt = await signer.CreateTokenAsync(token);
+        
+        var options = TestIdentityServerOptions.Create();
+        options.JwtValidationClockSkew = TimeSpan.FromSeconds(10);
+        var validator = Factory.CreateTokenValidator(options: options);
+        var result = await validator.ValidateAccessTokenAsync(jwt);
+        
+        result.IsError.ShouldBeFalse();
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task Jwt_when_token_time_outside_of_configured_clock_skew_token_is_considered_invalid()
+    {
+        var futureClock = new StubClock();
+        var definitelyNotNow = DateTime.UtcNow.AddSeconds(10);
+        futureClock.UtcNowFunc = () => definitelyNotNow;
+        var signer = Factory.CreateDefaultTokenCreator(clock: futureClock);
+        var token = TokenFactory.CreateAccessToken(new Client { ClientId = "roclient" }, "valid", 600, "read", "write");
+        var jwt = await signer.CreateTokenAsync(token);
+
+        var options = TestIdentityServerOptions.Create();
+        options.JwtValidationClockSkew = TimeSpan.FromSeconds(5);
+        var validator = Factory.CreateTokenValidator(options: options);
+        var result = await validator.ValidateAccessTokenAsync(jwt);
+        
         result.IsError.ShouldBeTrue();
         result.Error.ShouldBe(OidcConstants.ProtectedResourceErrors.InvalidToken);
     }

--- a/identity-server/test/IdentityServer.UnitTests/Validation/Secrets/PrivateKeyJwtSecretValidation.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Validation/Secrets/PrivateKeyJwtSecretValidation.cs
@@ -2,26 +2,21 @@
 // See LICENSE in the project root for license information.
 
 
-using System;
-using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text.Json;
-using System.Threading.Tasks;
 using Duende.IdentityServer;
 using Duende.IdentityServer.Configuration;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services;
 using Duende.IdentityServer.Stores;
 using Duende.IdentityServer.Validation;
-using Shouldly;
 using Duende.IdentityModel;
 using UnitTests.Common;
 using UnitTests.Services.Default;
 using UnitTests.Validation.Setup;
 using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.Tokens;
-using Xunit;
 
 namespace UnitTests.Validation.Secrets;
 
@@ -350,5 +345,47 @@ public class PrivateKeyJwtSecretValidation
         var result = await _validator.ValidateAsync(client.ClientSecrets, secret);
 
         result.Success.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task Invalid_Not_Yet_Valid_Token()
+    {
+        var clientId = "certificate_base64_valid";
+        var client = await _clients.FindEnabledClientByIdAsync(clientId);
+
+        var token = CreateToken(clientId, nowOverride: DateTime.UtcNow.AddSeconds(30));
+        var secret = new ParsedSecret
+        {
+            Id = clientId,
+            Credential = new JwtSecurityTokenHandler().WriteToken(token),
+            Type = IdentityServerConstants.ParsedSecretTypes.JwtBearer
+        };
+
+        _options.JwtValidationClockSkew = TimeSpan.FromSeconds(5);
+
+        var result = await _validator.ValidateAsync(client.ClientSecrets, secret);
+
+        result.Success.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task Configuration_Allows_For_Clock_Skew_In_Token()
+    {
+        var clientId = "certificate_base64_valid";
+        var client = await _clients.FindEnabledClientByIdAsync(clientId);
+
+        var token = CreateToken(clientId, nowOverride: DateTime.UtcNow.AddSeconds(5));
+        var secret = new ParsedSecret
+        {
+            Id = clientId,
+            Credential = new JwtSecurityTokenHandler().WriteToken(token),
+            Type = IdentityServerConstants.ParsedSecretTypes.JwtBearer
+        };
+
+        _options.JwtValidationClockSkew = TimeSpan.FromSeconds(10);
+
+        var result = await _validator.ValidateAsync(client.ClientSecrets, secret);
+
+        result.Success.ShouldBeTrue();
     }
 }

--- a/identity-server/test/IdentityServer.UnitTests/Validation/Setup/Factory.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Validation/Setup/Factory.cs
@@ -175,10 +175,11 @@ internal static class Factory
         return new DefaultResourceValidator(store, new DefaultScopeParser(TestLogger.Create<DefaultScopeParser>()), TestLogger.Create<DefaultResourceValidator>());
     }
 
-    internal static ITokenCreationService CreateDefaultTokenCreator(IdentityServerOptions options = null)
+    internal static ITokenCreationService CreateDefaultTokenCreator(IdentityServerOptions options = null,
+        IClock clock = null)
     {
         return new DefaultTokenCreationService(
-            new StubClock(),
+            clock ?? new StubClock(),
             new DefaultKeyMaterialService(
                 new IValidationKeysStore[] { },
                 new ISigningCredentialStore[] { new InMemorySigningCredentialsStore(TestCert.LoadSigningCredentials()) },


### PR DESCRIPTION
**What issue does this PR address?**
Added a new option for clock skew when validating JWTs. Currently, we use the default value of 5 minutes which is much higher than it needs to be and outside of the allowed range for the FAPI 2.0 Security Profile. The default value is within the range of the FAPI 2.0 Security Profile and allows for customizing as needed.

**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
