### PR TITLE
Revert Change Causing Unnecessary Cookie Re-Issue

### DIFF
--- a/src/IdentityServer/Services/Default/DefaultUserSession.cs
+++ b/src/IdentityServer/Services/Default/DefaultUserSession.cs
@@ -310,8 +310,12 @@ public class DefaultUserSession : IUserSession
         await AuthenticateAsync();
         if (Properties != null)
         {
-            Properties.AddClientId(clientId);
-            await UpdateSessionCookie();
+            var clientIds = Properties.GetClientList();
+            if (!clientIds.Contains(clientId))
+            {
+                Properties.AddClientId(clientId);
+                await UpdateSessionCookie();
+            }
         }
     }
 


### PR DESCRIPTION
**What issue does this PR address?**
Removing the check for if we needed to update the session cookie was leading to scenarios where cookies with sliding sessions were being re-issued with the wrong expiration. This is reported in our GitHub discussions [here](https://github.com/orgs/DuendeSoftware/discussions/78). This PR reverts this change to restore the prior behavior.


**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
