### PR TITLE
Removing redundant tag step in release workflow

### DIFF
--- a/.github/workflow-gen/Program.cs
+++ b/.github/workflow-gen/Program.cs
@@ -99,13 +99,6 @@ void GenerateIdentityServerReleaseWorkflow(Product product)
 
     job.StepSetupDotNet();
 
-    job.Step()
-        .Name("Git tag")
-        .Run($@"git config --global user.email ""github-bot@duendesoftware.com""
-git config --global user.name ""Duende Software GitHub Bot""
-git tag -a {product.TagPrefix}-{contexts.Event.Input.Version} -m ""Release v{contexts.Event.Input.Version}""
-git push origin {product.TagPrefix}-{contexts.Event.Input.Version}");
-
     job.StepPack(product.Solution);
 
     job.StepToolRestore();
@@ -415,7 +408,7 @@ public static class StepExtensions
     internal static Step StepGitPushTag(this Job job, Product component, GitHubContexts contexts)
     {
         return job.Step()
-            .Name("Git Config")
+            .Name("Git Tag")
             .Run($"""
                  git tag -a {component.TagPrefix}-{contexts.Event.Input.Version} -m "Release v{contexts.Event.Input.Version}"
                  git push origin {component.TagPrefix}-{contexts.Event.Input.Version}

--- a/.github/workflows/identity-server-release.yml
+++ b/.github/workflows/identity-server-release.yml
@@ -54,7 +54,7 @@ jobs:
         else
           echo 'Tag is-${{ github.event.inputs.version }} does not exist.'
         fi
-    - name: Git Config
+    - name: Git Tag
       run: |-
         git tag -a is-${{ github.event.inputs.version }} -m "Release v${{ github.event.inputs.version }}"
         git push origin is-${{ github.event.inputs.version }}
@@ -65,12 +65,6 @@ jobs:
           6.0.x
           8.0.x
           9.0.x
-    - name: Git tag
-      run: |-
-        git config --global user.email "github-bot@duendesoftware.com"
-        git config --global user.name "Duende Software GitHub Bot"
-        git tag -a is-${{ github.event.inputs.version }} -m "Release v${{ github.event.inputs.version }}"
-        git push origin is-${{ github.event.inputs.version }}
     - name: Pack Duende.IdentityServer.sln
       run: dotnet pack -c Release Duende.IdentityServer.sln -o artifacts
     - name: Tool restore


### PR DESCRIPTION
**What issue does this PR address?**
The back ported workflow from main contained an extra tag step which was causing the release workflow to fail. These changes remove the extra tag step.


**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
