### PR TITLE
Add [ExperimentalAttribute] on preview feature toggles

### DIFF
--- a/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
+++ b/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
@@ -209,7 +209,7 @@ public class IdentityServerOptions
     public PushedAuthorizationOptions PushedAuthorization { get; set; } = new PushedAuthorizationOptions();
 
     /// <summary>
-    /// Preview Features. Warning these can be removed and may break in future release
+    /// Preview Features. Warning: these can be removed and may break in future releases.
     /// </summary>
     public PreviewFeaturesOptions Preview { get; set; } = new PreviewFeaturesOptions();
 }

--- a/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/PreviewFeaturesOptions.cs
+++ b/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/PreviewFeaturesOptions.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Duende.IdentityServer.Configuration;
 
 /// <summary>
@@ -8,6 +10,7 @@ public class PreviewFeaturesOptions
     /// <summary>
     /// Enables Caching of Discovery Document based on ResponseCaching Interval 
     /// </summary>
+    [Experimental("DUENDEPREVIEW001", UrlFormat = "https://duende.link/previewfeatures?id={0}")]
     public bool EnableDiscoveryDocumentCache { get; set; } = false;
     
     /// <summary>

--- a/identity-server/src/IdentityServer/Endpoints/DiscoveryEndpoint.cs
+++ b/identity-server/src/IdentityServer/Endpoints/DiscoveryEndpoint.cs
@@ -68,8 +68,10 @@ internal class DiscoveryEndpoint : IEndpointHandler
 
         // generate response
         _logger.LogTrace("Calling into discovery response generator: {type}", _responseGenerator.GetType().FullName);
-
+    
+#pragma warning disable DUENDEPREVIEW001
         if (_options.Preview.EnableDiscoveryDocumentCache)
+#pragma warning restore DUENDEPREVIEW001
         {
             // the cache key accounts for multi-tenancy in Enterprise instances 
             return await _cache.GetOrCreateAsync($"discoveryDocument/{baseUrl}/{issuerUri}", async entry =>

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Discovery/DiscoveryEndpointTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Discovery/DiscoveryEndpointTests.cs
@@ -284,7 +284,9 @@ public class DiscoveryEndpointTests
         IdentityServerPipeline pipeline = new IdentityServerPipeline();
         pipeline.Initialize("/root");
         
+#pragma warning disable DUENDEPREVIEW001
         pipeline.Options.Preview.EnableDiscoveryDocumentCache = true;
+#pragma warning restore DUENDEPREVIEW001
         pipeline.Options.Preview.DiscoveryDocumentCacheDuration = TimeSpan.FromSeconds(1);
         
         // cache


### PR DESCRIPTION
This PR goes on top of #1830 and adds the [ExperimentalAttribute] to feature preview toggles.

When a preview feature toggle is used in consuming code, a diagnostic is reported and has to be suppressed to explicitly acknowledge using the toggle:

![image](https://github.com/user-attachments/assets/115c86a8-1bcd-4fb1-b8cd-706d93541d1b)

To disable, the developer can:
* Add `<PropertyGroup><NoWarn>DUENDEPREVIEW001</NoWarn></PropertyGroup>` to the project file
* Add `#pragma warning disable DUENDEPREVIEW001` at the call site

The diagnostic will also log a link to `https://duende.link/previewfeatures?id={0}` (with the format string replaced by the diagnostic) so we can explain what the feature preview is, how to opt-in, etc.

Background in https://blog.maartenballiauw.be/post/2023/11/08/opt-in-to-experimental-apis-using-csharp-12-experimentalattribute.html.