### PR TITLE
Use utf-8 charset

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,7 @@ dotnet_diagnostic.IDE0073.severity = warning
 ## Basic Formatting ##
 indent_style = space
 indent_size = 4
+charset = utf-8
 dotnet_diagnostic.IDE0055.severity = warning
 
 

--- a/.github/workflow-gen/Program.cs
+++ b/.github/workflow-gen/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using Logicality.GitHub.Actions.Workflow;

--- a/bff/hosts/Blazor/PerComponent/Hosts.Bff.Blazor.PerComponent.Client/ClientRenderModeContext.cs
+++ b/bff/hosts/Blazor/PerComponent/Hosts.Bff.Blazor.PerComponent.Client/ClientRenderModeContext.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 namespace Hosts.Bff.Blazor.PerComponent.Client;

--- a/bff/hosts/Blazor/PerComponent/Hosts.Bff.Blazor.PerComponent.Client/IRenderModeContext.cs
+++ b/bff/hosts/Blazor/PerComponent/Hosts.Bff.Blazor.PerComponent.Client/IRenderModeContext.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 namespace Hosts.Bff.Blazor.PerComponent.Client;

--- a/bff/hosts/Blazor/PerComponent/Hosts.Bff.Blazor.PerComponent/ServerRenderModeContext.cs
+++ b/bff/hosts/Blazor/PerComponent/Hosts.Bff.Blazor.PerComponent/ServerRenderModeContext.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Hosts.Bff.Blazor.PerComponent.Client;

--- a/bff/hosts/Blazor/WebAssembly/Hosts.Bff.Blazor.WebAssembly/WeatherEndpoints.cs
+++ b/bff/hosts/Blazor/WebAssembly/Hosts.Bff.Blazor.WebAssembly/WeatherEndpoints.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 namespace Hosts.Bff.Blazor.WebAssembly;

--- a/bff/hosts/Hosts.IdentityServer/Config.cs
+++ b/bff/hosts/Hosts.IdentityServer/Config.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/bff/hosts/Hosts.IdentityServer/Pages/Home/Error/ViewModel.cs
+++ b/bff/hosts/Hosts.IdentityServer/Pages/Home/Error/ViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Duende.IdentityServer.Models;

--- a/bff/hosts/Hosts.IdentityServer/ServiceDiscoveringClientStore.cs
+++ b/bff/hosts/Hosts.IdentityServer/ServiceDiscoveringClientStore.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Duende.IdentityModel;

--- a/bff/hosts/RemoteApis/Hosts.RemoteApi.DPoP/DPoP/DPoPOptions.cs
+++ b/bff/hosts/RemoteApis/Hosts.RemoteApi.DPoP/DPoP/DPoPOptions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 namespace Api.DPoP;

--- a/bff/hosts/RemoteApis/Hosts.RemoteApi.DPoP/DPoP/DefaultReplayCache.cs
+++ b/bff/hosts/RemoteApis/Hosts.RemoteApi.DPoP/DPoP/DefaultReplayCache.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Microsoft.Extensions.Caching.Distributed;

--- a/bff/hosts/RemoteApis/Hosts.RemoteApi.DPoP/EchoController.cs
+++ b/bff/hosts/RemoteApis/Hosts.RemoteApi.DPoP/EchoController.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using System.Security.Claims;

--- a/bff/hosts/RemoteApis/Hosts.RemoteApi.Isolated/EchoController.cs
+++ b/bff/hosts/RemoteApis/Hosts.RemoteApi.Isolated/EchoController.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Microsoft.AspNetCore.Authorization;

--- a/bff/hosts/RemoteApis/Hosts.RemoteApi.Isolated/ToDoController.cs
+++ b/bff/hosts/RemoteApis/Hosts.RemoteApi.Isolated/ToDoController.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Microsoft.AspNetCore.Authorization;

--- a/bff/hosts/RemoteApis/Hosts.RemoteApi/EchoController.cs
+++ b/bff/hosts/RemoteApis/Hosts.RemoteApi/EchoController.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using System.Security.Claims;

--- a/bff/hosts/RemoteApis/Hosts.RemoteApi/ToDoController.cs
+++ b/bff/hosts/RemoteApis/Hosts.RemoteApi/ToDoController.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Microsoft.AspNetCore.Authorization;

--- a/bff/migrations/UserSessionDb/Migrations/UserSessions/20220314155751_UserSessions.cs
+++ b/bff/migrations/UserSessionDb/Migrations/UserSessions/20220314155751_UserSessions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Microsoft.EntityFrameworkCore.Migrations;

--- a/bff/src/Bff.Blazor.Client/AntiforgeryHandler.cs
+++ b/bff/src/Bff.Blazor.Client/AntiforgeryHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 namespace Duende.Bff.Blazor.Client;

--- a/bff/src/Bff.Blazor.Client/BffClientAuthenticationStateProvider.cs
+++ b/bff/src/Bff.Blazor.Client/BffClientAuthenticationStateProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using System.Security.Claims;

--- a/bff/src/Bff.Blazor.Client/ClaimRecord.cs
+++ b/bff/src/Bff.Blazor.Client/ClaimRecord.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using System.Text.Json.Serialization;

--- a/bff/src/Bff.Blazor/ServerSideTokenStore.cs
+++ b/bff/src/Bff.Blazor/ServerSideTokenStore.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using System.Security.Claims;

--- a/bff/src/Bff.EntityFramework/Configuration/BffBuilderExtensions.cs
+++ b/bff/src/Bff.EntityFramework/Configuration/BffBuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Duende.Bff;

--- a/bff/src/Bff.EntityFramework/Configuration/SessionStoreOptions.cs
+++ b/bff/src/Bff.EntityFramework/Configuration/SessionStoreOptions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/bff/src/Bff.EntityFramework/Configuration/TableConfiguration.cs
+++ b/bff/src/Bff.EntityFramework/Configuration/TableConfiguration.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 namespace Duende.Bff.EntityFramework;

--- a/bff/src/Bff.EntityFramework/Database/ISessionDbContext.cs
+++ b/bff/src/Bff.EntityFramework/Database/ISessionDbContext.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Microsoft.EntityFrameworkCore;

--- a/bff/src/Bff.EntityFramework/Database/ModelBuilderExtensions.cs
+++ b/bff/src/Bff.EntityFramework/Database/ModelBuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Microsoft.EntityFrameworkCore;

--- a/bff/src/Bff.EntityFramework/Database/SessionDbContext.cs
+++ b/bff/src/Bff.EntityFramework/Database/SessionDbContext.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Microsoft.EntityFrameworkCore;

--- a/bff/src/Bff.EntityFramework/Database/UserSessionEntity.cs
+++ b/bff/src/Bff.EntityFramework/Database/UserSessionEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 namespace Duende.Bff.EntityFramework;

--- a/bff/src/Bff.EntityFramework/Store/UserSessionStore.cs
+++ b/bff/src/Bff.EntityFramework/Store/UserSessionStore.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 #nullable disable

--- a/bff/src/Bff/Configuration/Decorator.cs
+++ b/bff/src/Bff/Configuration/Decorator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Microsoft.Extensions.DependencyInjection;

--- a/bff/src/Bff/EndpointProcessing/IBffApiEndpoint.cs
+++ b/bff/src/Bff/EndpointProcessing/IBffApiEndpoint.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 namespace Duende.Bff;

--- a/bff/src/Bff/EndpointProcessing/IBffApiSkipAntiforgery.cs
+++ b/bff/src/Bff/EndpointProcessing/IBffApiSkipAntiforgery.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 namespace Duende.Bff;

--- a/bff/src/Bff/EndpointProcessing/IBffApiSkipResponseHandling.cs
+++ b/bff/src/Bff/EndpointProcessing/IBffApiSkipResponseHandling.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 namespace Duende.Bff;

--- a/bff/src/Bff/EndpointServices/BackchannelLogout/DefaultBackchannelLogoutService.cs
+++ b/bff/src/Bff/EndpointServices/BackchannelLogout/DefaultBackchannelLogoutService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using System.Security.Claims;

--- a/bff/src/Bff/EndpointServices/IBffEndpointService.cs
+++ b/bff/src/Bff/EndpointServices/IBffEndpointService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Microsoft.AspNetCore.Http;

--- a/bff/src/Bff/EndpointServices/Login/DefaultLoginService.cs
+++ b/bff/src/Bff/EndpointServices/Login/DefaultLoginService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Microsoft.AspNetCore.Authentication;

--- a/bff/src/Bff/EndpointServices/Login/ILoginService.cs
+++ b/bff/src/Bff/EndpointServices/Login/ILoginService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 namespace Duende.Bff;

--- a/bff/src/Bff/EndpointServices/Logout/DefaultLogoutService.cs
+++ b/bff/src/Bff/EndpointServices/Logout/DefaultLogoutService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Duende.IdentityModel;

--- a/bff/src/Bff/EndpointServices/Logout/ILogoutService.cs
+++ b/bff/src/Bff/EndpointServices/Logout/ILogoutService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 namespace Duende.Bff;

--- a/bff/src/Bff/EndpointServices/SilentLogin/DefaultSilentLoginCallbackService.cs
+++ b/bff/src/Bff/EndpointServices/SilentLogin/DefaultSilentLoginCallbackService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using System.Text;

--- a/bff/src/Bff/EndpointServices/SilentLogin/DefaultSilentLoginService.cs
+++ b/bff/src/Bff/EndpointServices/SilentLogin/DefaultSilentLoginService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Microsoft.AspNetCore.Authentication;

--- a/bff/src/Bff/EndpointServices/SilentLogin/ISilentLoginCallbackService.cs
+++ b/bff/src/Bff/EndpointServices/SilentLogin/ISilentLoginCallbackService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 namespace Duende.Bff;

--- a/bff/src/Bff/EndpointServices/SilentLogin/ISilentLoginService.cs
+++ b/bff/src/Bff/EndpointServices/SilentLogin/ISilentLoginService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 namespace Duende.Bff;

--- a/bff/src/Bff/EndpointServices/User/IUserService.cs
+++ b/bff/src/Bff/EndpointServices/User/IUserService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 namespace Duende.Bff;

--- a/bff/src/Bff/Extensions/AuthenticationPropertiesExtensions.cs
+++ b/bff/src/Bff/Extensions/AuthenticationPropertiesExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Microsoft.AspNetCore.Authentication;

--- a/bff/src/Bff/Extensions/AuthenticationTicketExtensions.cs
+++ b/bff/src/Bff/Extensions/AuthenticationTicketExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using System.Security.Claims;

--- a/bff/src/Bff/General/IReturnUrlValidator.cs
+++ b/bff/src/Bff/General/IReturnUrlValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 namespace Duende.Bff;

--- a/bff/src/Bff/General/LocalUrlReturnUrlValidator.cs
+++ b/bff/src/Bff/General/LocalUrlReturnUrlValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 namespace Duende.Bff;

--- a/bff/src/Bff/SessionManagement/SessionStore/UserSession.cs
+++ b/bff/src/Bff/SessionManagement/SessionStore/UserSession.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 namespace Duende.Bff;

--- a/bff/src/Bff/SessionManagement/TicketStore/IServerTicketStore.cs
+++ b/bff/src/Bff/SessionManagement/TicketStore/IServerTicketStore.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Microsoft.AspNetCore.Authentication;

--- a/bff/templates/src/BffLocalApi/Program.cs
+++ b/bff/templates/src/BffLocalApi/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using BffLocalApi;

--- a/bff/templates/src/BffLocalApi/ToDoController.cs
+++ b/bff/templates/src/BffLocalApi/ToDoController.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Microsoft.AspNetCore.Mvc;

--- a/bff/test/Bff.Tests/TestFramework/TestPayload.cs
+++ b/bff/test/Bff.Tests/TestFramework/TestPayload.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 namespace Duende.Bff.Tests.TestFramework

--- a/bff/test/Hosts.Tests/BffBlazorWebAssemblyTests.cs
+++ b/bff/test/Hosts.Tests/BffBlazorWebAssemblyTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Hosts.ServiceDefaults;

--- a/bff/test/Hosts.Tests/BlazorPerComponentTests.cs
+++ b/bff/test/Hosts.Tests/BlazorPerComponentTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Hosts.ServiceDefaults;

--- a/bff/test/Hosts.Tests/PageModels/BlazorModel.cs
+++ b/bff/test/Hosts.Tests/PageModels/BlazorModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Microsoft.Playwright;

--- a/bff/test/Hosts.Tests/PageModels/LogOutPageModel.cs
+++ b/bff/test/Hosts.Tests/PageModels/LogOutPageModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Microsoft.Playwright;

--- a/bff/test/Hosts.Tests/PageModels/LoginPageModel.cs
+++ b/bff/test/Hosts.Tests/PageModels/LoginPageModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Microsoft.Playwright;

--- a/bff/test/Hosts.Tests/PageModels/PageModel.cs
+++ b/bff/test/Hosts.Tests/PageModels/PageModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Microsoft.Playwright;

--- a/bff/test/Hosts.Tests/PageModels/PerComponentPageModel.cs
+++ b/bff/test/Hosts.Tests/PageModels/PerComponentPageModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Microsoft.Playwright;

--- a/bff/test/Hosts.Tests/PageModels/WeatherPageModel.cs
+++ b/bff/test/Hosts.Tests/PageModels/WeatherPageModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Microsoft.Playwright;

--- a/bff/test/Hosts.Tests/PageModels/WebAssemblyPageModel.cs
+++ b/bff/test/Hosts.Tests/PageModels/WebAssemblyPageModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Microsoft.Playwright;

--- a/bff/test/Hosts.Tests/PlaywrightTestBase.cs
+++ b/bff/test/Hosts.Tests/PlaywrightTestBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using System.Reflection;

--- a/bff/test/Hosts.Tests/TestInfra/AutoFollowRedirectHandler.cs
+++ b/bff/test/Hosts.Tests/TestInfra/AutoFollowRedirectHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Microsoft.Extensions.Logging;

--- a/bff/test/Hosts.Tests/TestInfra/CookieHandler.cs
+++ b/bff/test/Hosts.Tests/TestInfra/CookieHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Microsoft.Net.Http.Headers;

--- a/bff/test/Hosts.Tests/TestInfra/DelegateDisposable.cs
+++ b/bff/test/Hosts.Tests/TestInfra/DelegateDisposable.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 namespace Hosts.Tests.TestInfra;

--- a/bff/test/Hosts.Tests/TestInfra/DelegateTextWriter.cs
+++ b/bff/test/Hosts.Tests/TestInfra/DelegateTextWriter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using System.Text;

--- a/bff/test/Hosts.Tests/TestInfra/IntegrationTestBase.cs
+++ b/bff/test/Hosts.Tests/TestInfra/IntegrationTestBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Xunit.Abstractions;

--- a/bff/test/Hosts.Tests/TestInfra/RequestLoggingHandler.cs
+++ b/bff/test/Hosts.Tests/TestInfra/RequestLoggingHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using System.Diagnostics;

--- a/bff/test/Hosts.Tests/TestInfra/WriteTestOutput.cs
+++ b/bff/test/Hosts.Tests/TestInfra/WriteTestOutput.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 namespace Hosts.Tests.TestInfra;

--- a/identity-server/clients/src/APIs/DPoPApi/DPoP/DPoPOptions.cs
+++ b/identity-server/clients/src/APIs/DPoPApi/DPoP/DPoPOptions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 namespace DPoPApi;

--- a/identity-server/clients/src/APIs/ResourceBasedApi/IdentityController.cs
+++ b/identity-server/clients/src/APIs/ResourceBasedApi/IdentityController.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Microsoft.AspNetCore.Mvc;

--- a/identity-server/clients/src/APIs/ResourceBasedApi/Startup.cs
+++ b/identity-server/clients/src/APIs/ResourceBasedApi/Startup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 namespace ResourceBasedApi

--- a/identity-server/clients/src/APIs/SimpleApi/IdentityController.cs
+++ b/identity-server/clients/src/APIs/SimpleApi/IdentityController.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Microsoft.AspNetCore.Mvc;

--- a/identity-server/clients/src/ConsoleClientCredentialsFlow/Program.cs
+++ b/identity-server/clients/src/ConsoleClientCredentialsFlow/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Clients;

--- a/identity-server/clients/src/ConsoleClientCredentialsFlowCallingIdentityServerApi/Program.cs
+++ b/identity-server/clients/src/ConsoleClientCredentialsFlowCallingIdentityServerApi/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Clients;

--- a/identity-server/clients/src/ConsoleClientCredentialsFlowPostBody/Program.cs
+++ b/identity-server/clients/src/ConsoleClientCredentialsFlowPostBody/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Clients;

--- a/identity-server/clients/src/ConsoleCode/Program.cs
+++ b/identity-server/clients/src/ConsoleCode/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Clients;

--- a/identity-server/clients/src/ConsoleCustomGrant/Program.cs
+++ b/identity-server/clients/src/ConsoleCustomGrant/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Clients;

--- a/identity-server/clients/src/ConsoleDcrClient/Program.cs
+++ b/identity-server/clients/src/ConsoleDcrClient/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using System.Text.Json;

--- a/identity-server/clients/src/ConsoleEphemeralMtlsClient/Program.cs
+++ b/identity-server/clients/src/ConsoleEphemeralMtlsClient/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using System.Security.Cryptography;

--- a/identity-server/clients/src/ConsoleParameterizedScopeClient/Program.cs
+++ b/identity-server/clients/src/ConsoleParameterizedScopeClient/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Clients;

--- a/identity-server/clients/src/ConsolePrivateKeyJwtClient/Program.cs
+++ b/identity-server/clients/src/ConsolePrivateKeyJwtClient/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using System.IdentityModel.Tokens.Jwt;

--- a/identity-server/clients/src/ConsoleResourceIndicators/SystemBrowser.cs
+++ b/identity-server/clients/src/ConsoleResourceIndicators/SystemBrowser.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using System.Diagnostics;

--- a/identity-server/clients/src/ConsoleResourceOwnerFlow/Program.cs
+++ b/identity-server/clients/src/ConsoleResourceOwnerFlow/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Clients;

--- a/identity-server/clients/src/ConsoleResourceOwnerFlowPublic/Program.cs
+++ b/identity-server/clients/src/ConsoleResourceOwnerFlowPublic/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Clients;

--- a/identity-server/clients/src/ConsoleResourceOwnerFlowReference/Program.cs
+++ b/identity-server/clients/src/ConsoleResourceOwnerFlowReference/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Clients;

--- a/identity-server/clients/src/ConsoleResourceOwnerFlowRefreshToken/Program.cs
+++ b/identity-server/clients/src/ConsoleResourceOwnerFlowRefreshToken/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Clients;

--- a/identity-server/clients/src/ConsoleResourceOwnerFlowUserInfo/Program.cs
+++ b/identity-server/clients/src/ConsoleResourceOwnerFlowUserInfo/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Clients;

--- a/identity-server/clients/src/Constants/ConsoleExtensions.cs
+++ b/identity-server/clients/src/Constants/ConsoleExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using System.Diagnostics;

--- a/identity-server/clients/src/Constants/Constants.cs
+++ b/identity-server/clients/src/Constants/Constants.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 namespace Clients

--- a/identity-server/clients/src/Constants/TokenResponseExtensions.cs
+++ b/identity-server/clients/src/Constants/TokenResponseExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using System.Text;

--- a/identity-server/clients/src/JsOidc/Program.cs
+++ b/identity-server/clients/src/JsOidc/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Microsoft.AspNetCore;

--- a/identity-server/clients/src/JsOidc/Startup.cs
+++ b/identity-server/clients/src/JsOidc/Startup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 namespace JsOidc

--- a/identity-server/clients/src/MvcHybridBackChannel/Controllers/HomeController.cs
+++ b/identity-server/clients/src/MvcHybridBackChannel/Controllers/HomeController.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using System.Globalization;

--- a/identity-server/clients/src/MvcHybridBackChannel/CookieEventHandler.cs
+++ b/identity-server/clients/src/MvcHybridBackChannel/CookieEventHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Microsoft.AspNetCore.Authentication;

--- a/identity-server/clients/src/MvcHybridBackChannel/LogoutSessionManager.cs
+++ b/identity-server/clients/src/MvcHybridBackChannel/LogoutSessionManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 namespace MvcHybrid

--- a/identity-server/clients/src/MvcHybridBackChannel/Program.cs
+++ b/identity-server/clients/src/MvcHybridBackChannel/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Microsoft.AspNetCore;

--- a/identity-server/clients/src/WindowsConsoleSystemBrowser/CallbackManager.cs
+++ b/identity-server/clients/src/WindowsConsoleSystemBrowser/CallbackManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using System.IO.Pipes;

--- a/identity-server/hosts/AspNetIdentity/Pages/Home/Error/ViewModel.cs
+++ b/identity-server/hosts/AspNetIdentity/Pages/Home/Error/ViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Duende.IdentityServer.Models;

--- a/identity-server/hosts/Configuration/Extensions/NoSubjectExtensionGrantValidator.cs
+++ b/identity-server/hosts/Configuration/Extensions/NoSubjectExtensionGrantValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Duende.IdentityServer.Models;

--- a/identity-server/hosts/Configuration/Pages/Home/Error/ViewModel.cs
+++ b/identity-server/hosts/Configuration/Pages/Home/Error/ViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Duende.IdentityServer.Models;

--- a/identity-server/hosts/EntityFramework/Pages/Home/Error/ViewModel.cs
+++ b/identity-server/hosts/EntityFramework/Pages/Home/Error/ViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Duende.IdentityServer.Models;

--- a/identity-server/hosts/main/Extensions/NoSubjectExtensionGrantValidator.cs
+++ b/identity-server/hosts/main/Extensions/NoSubjectExtensionGrantValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Duende.IdentityServer.Models;

--- a/identity-server/hosts/main/Pages/Home/Error/ViewModel.cs
+++ b/identity-server/hosts/main/Pages/Home/Error/ViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Duende.IdentityServer.Models;

--- a/identity-server/migrations/AspNetIdentityDb/Migrations/UsersDb/20210113185640_Users.cs
+++ b/identity-server/migrations/AspNetIdentityDb/Migrations/UsersDb/20210113185640_Users.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Microsoft.EntityFrameworkCore.Migrations;

--- a/identity-server/migrations/AspNetIdentityDb/Program.cs
+++ b/identity-server/migrations/AspNetIdentityDb/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using IdentityServerHost;

--- a/identity-server/migrations/IdentityServerDb/Migrations/ConfigurationDb/20240104192404_Configuration.cs
+++ b/identity-server/migrations/IdentityServerDb/Migrations/ConfigurationDb/20240104192404_Configuration.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Microsoft.EntityFrameworkCore.Migrations;

--- a/identity-server/migrations/IdentityServerDb/Migrations/PersistedGrantDb/20240104192353_Grants.cs
+++ b/identity-server/migrations/IdentityServerDb/Migrations/PersistedGrantDb/20240104192353_Grants.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Microsoft.EntityFrameworkCore.Migrations;

--- a/identity-server/migrations/IdentityServerDb/Startup.cs
+++ b/identity-server/migrations/IdentityServerDb/Startup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/AspNetIdentity/Decorator.cs
+++ b/identity-server/src/AspNetIdentity/Decorator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/AspNetIdentity/ProfileService.cs
+++ b/identity-server/src/AspNetIdentity/ProfileService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/AspNetIdentity/SecurityStampValidatorCallback.cs
+++ b/identity-server/src/AspNetIdentity/SecurityStampValidatorCallback.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/EntityFramework.Storage/Entities/ApiResourceProperty.cs
+++ b/identity-server/src/EntityFramework.Storage/Entities/ApiResourceProperty.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/EntityFramework.Storage/Entities/ApiResourceSecret.cs
+++ b/identity-server/src/EntityFramework.Storage/Entities/ApiResourceSecret.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/EntityFramework.Storage/Entities/ApiScopeProperty.cs
+++ b/identity-server/src/EntityFramework.Storage/Entities/ApiScopeProperty.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/EntityFramework.Storage/Entities/ClientClaim.cs
+++ b/identity-server/src/EntityFramework.Storage/Entities/ClientClaim.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/EntityFramework.Storage/Entities/ClientCorsOrigin.cs
+++ b/identity-server/src/EntityFramework.Storage/Entities/ClientCorsOrigin.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/EntityFramework.Storage/Entities/ClientGrantType.cs
+++ b/identity-server/src/EntityFramework.Storage/Entities/ClientGrantType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/EntityFramework.Storage/Entities/ClientIdPRestriction.cs
+++ b/identity-server/src/EntityFramework.Storage/Entities/ClientIdPRestriction.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/EntityFramework.Storage/Entities/ClientPostLogoutRedirectUri.cs
+++ b/identity-server/src/EntityFramework.Storage/Entities/ClientPostLogoutRedirectUri.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/EntityFramework.Storage/Entities/ClientProperty.cs
+++ b/identity-server/src/EntityFramework.Storage/Entities/ClientProperty.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/EntityFramework.Storage/Entities/ClientRedirectUri.cs
+++ b/identity-server/src/EntityFramework.Storage/Entities/ClientRedirectUri.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/EntityFramework.Storage/Entities/ClientScope.cs
+++ b/identity-server/src/EntityFramework.Storage/Entities/ClientScope.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/EntityFramework.Storage/Entities/ClientSecret.cs
+++ b/identity-server/src/EntityFramework.Storage/Entities/ClientSecret.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/EntityFramework.Storage/Entities/DeviceFlowCodes.cs
+++ b/identity-server/src/EntityFramework.Storage/Entities/DeviceFlowCodes.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/EntityFramework.Storage/Entities/IdentityResourceClaim.cs
+++ b/identity-server/src/EntityFramework.Storage/Entities/IdentityResourceClaim.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/EntityFramework.Storage/Entities/IdentityResourceProperty.cs
+++ b/identity-server/src/EntityFramework.Storage/Entities/IdentityResourceProperty.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/EntityFramework.Storage/Entities/Property.cs
+++ b/identity-server/src/EntityFramework.Storage/Entities/Property.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/EntityFramework.Storage/Entities/Secret.cs
+++ b/identity-server/src/EntityFramework.Storage/Entities/Secret.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/EntityFramework.Storage/Entities/UserClaim.cs
+++ b/identity-server/src/EntityFramework.Storage/Entities/UserClaim.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/EntityFramework.Storage/Properties/AssemblyInfo.cs
+++ b/identity-server/src/EntityFramework.Storage/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Configuration/DependencyInjection/Decorator.cs
+++ b/identity-server/src/IdentityServer/Configuration/DependencyInjection/Decorator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Events/ApiAuthenticationFailureEvent.cs
+++ b/identity-server/src/IdentityServer/Events/ApiAuthenticationFailureEvent.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Events/ApiAuthenticationSuccessEvent.cs
+++ b/identity-server/src/IdentityServer/Events/ApiAuthenticationSuccessEvent.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Events/ClientAuthenticationSuccessEvent.cs
+++ b/identity-server/src/IdentityServer/Events/ClientAuthenticationSuccessEvent.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Events/Infrastructure/EventType.cs
+++ b/identity-server/src/IdentityServer/Events/Infrastructure/EventType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Events/TokenIssuedFailureEvent.cs
+++ b/identity-server/src/IdentityServer/Events/TokenIssuedFailureEvent.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Events/TokenRevokedSuccessEvent.cs
+++ b/identity-server/src/IdentityServer/Events/TokenRevokedSuccessEvent.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Events/UserLoginFailureEvent.cs
+++ b/identity-server/src/IdentityServer/Events/UserLoginFailureEvent.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Events/UserLoginSuccessEvent.cs
+++ b/identity-server/src/IdentityServer/Events/UserLoginSuccessEvent.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Events/UserLogoutSuccessEvent.cs
+++ b/identity-server/src/IdentityServer/Events/UserLogoutSuccessEvent.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Extensions/AuthorizeResponseExtensions.cs
+++ b/identity-server/src/IdentityServer/Extensions/AuthorizeResponseExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Extensions/ClaimsExtensions.cs
+++ b/identity-server/src/IdentityServer/Extensions/ClaimsExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Extensions/EndpointOptionsExtensions.cs
+++ b/identity-server/src/IdentityServer/Extensions/EndpointOptionsExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Extensions/HashExtensions.cs
+++ b/identity-server/src/IdentityServer/Extensions/HashExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Extensions/HttpRequestExtensions.cs
+++ b/identity-server/src/IdentityServer/Extensions/HttpRequestExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Extensions/NameValueCollectionExtensions.cs
+++ b/identity-server/src/IdentityServer/Extensions/NameValueCollectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Hosting/CorsMiddleware.cs
+++ b/identity-server/src/IdentityServer/Hosting/CorsMiddleware.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Hosting/FederatedSignOut/AuthenticationRequestSignInHandlerWrapper.cs
+++ b/identity-server/src/IdentityServer/Hosting/FederatedSignOut/AuthenticationRequestSignInHandlerWrapper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Hosting/FederatedSignOut/AuthenticationRequestSignOutHandlerWrapper.cs
+++ b/identity-server/src/IdentityServer/Hosting/FederatedSignOut/AuthenticationRequestSignOutHandlerWrapper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Hosting/FederatedSignOut/FederatedSignoutAuthenticationHandlerProvider.cs
+++ b/identity-server/src/IdentityServer/Hosting/FederatedSignOut/FederatedSignoutAuthenticationHandlerProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Infrastructure/Clock/DefaultClock.cs
+++ b/identity-server/src/IdentityServer/Infrastructure/Clock/DefaultClock.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Infrastructure/Clock/LegacyClock.cs
+++ b/identity-server/src/IdentityServer/Infrastructure/Clock/LegacyClock.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Infrastructure/ObjectSerializer.cs
+++ b/identity-server/src/IdentityServer/Infrastructure/ObjectSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Logging/LogSerializer.cs
+++ b/identity-server/src/IdentityServer/Logging/LogSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Logging/Models/AuthorizeResponseLog.cs
+++ b/identity-server/src/IdentityServer/Logging/Models/AuthorizeResponseLog.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Logging/Models/TokenValidationLog.cs
+++ b/identity-server/src/IdentityServer/Logging/Models/TokenValidationLog.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/ResponseHandling/IAuthorizeResponseGenerator.cs
+++ b/identity-server/src/IdentityServer/ResponseHandling/IAuthorizeResponseGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/ResponseHandling/IDiscoveryResponseGenerator.cs
+++ b/identity-server/src/IdentityServer/ResponseHandling/IDiscoveryResponseGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/ResponseHandling/IIntrospectionResponseGenerator.cs
+++ b/identity-server/src/IdentityServer/ResponseHandling/IIntrospectionResponseGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/ResponseHandling/ITokenRevocationResponseGenerator.cs
+++ b/identity-server/src/IdentityServer/ResponseHandling/ITokenRevocationResponseGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/ResponseHandling/IUserInfoResponseGenerator.cs
+++ b/identity-server/src/IdentityServer/ResponseHandling/IUserInfoResponseGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/ResponseHandling/Models/AuthorizeResponse.cs
+++ b/identity-server/src/IdentityServer/ResponseHandling/Models/AuthorizeResponse.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/ResponseHandling/Models/TokenRevocationResponse.cs
+++ b/identity-server/src/IdentityServer/ResponseHandling/Models/TokenRevocationResponse.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Services/Default/DefaultConsentService.cs
+++ b/identity-server/src/IdentityServer/Services/Default/DefaultConsentService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Services/InMemory/InMemoryCorsPolicyService.cs
+++ b/identity-server/src/IdentityServer/Services/InMemory/InMemoryCorsPolicyService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Stores/Default/ConsentMessageStore.cs
+++ b/identity-server/src/IdentityServer/Stores/Default/ConsentMessageStore.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Stores/Default/DefaultUserConsentStore.cs
+++ b/identity-server/src/IdentityServer/Stores/Default/DefaultUserConsentStore.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Stores/IAuthorizationParametersMessageStore.cs
+++ b/identity-server/src/IdentityServer/Stores/IAuthorizationParametersMessageStore.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Stores/IConsentMessageStore.cs
+++ b/identity-server/src/IdentityServer/Stores/IConsentMessageStore.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Stores/IMessageStore.cs
+++ b/identity-server/src/IdentityServer/Stores/IMessageStore.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Stores/ISigningCredentialStore.cs
+++ b/identity-server/src/IdentityServer/Stores/ISigningCredentialStore.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Stores/IValidationKeysStore.cs
+++ b/identity-server/src/IdentityServer/Stores/IValidationKeysStore.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Stores/InMemory/InMemoryClientStore.cs
+++ b/identity-server/src/IdentityServer/Stores/InMemory/InMemoryClientStore.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Stores/InMemory/InMemorySigningCredentialsStore.cs
+++ b/identity-server/src/IdentityServer/Stores/InMemory/InMemorySigningCredentialsStore.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Stores/InMemory/InMemoryValidationKeysStore.cs
+++ b/identity-server/src/IdentityServer/Stores/InMemory/InMemoryValidationKeysStore.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Test/TestUser.cs
+++ b/identity-server/src/IdentityServer/Test/TestUser.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Test/TestUserProfileService.cs
+++ b/identity-server/src/IdentityServer/Test/TestUserProfileService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Test/TestUserResourceOwnerPasswordValidator.cs
+++ b/identity-server/src/IdentityServer/Test/TestUserResourceOwnerPasswordValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Validation/Contexts/ResourceValidationContext.cs
+++ b/identity-server/src/IdentityServer/Validation/Contexts/ResourceValidationContext.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Validation/Default/BearerTokenUsageValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/Default/BearerTokenUsageValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Validation/Default/DefaultCustomTokenRequestValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/Default/DefaultCustomTokenRequestValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Validation/Default/ExtensionGrantValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/Default/ExtensionGrantValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Validation/Default/PlainTextSharedSecretValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/Default/PlainTextSharedSecretValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Validation/Default/PostBodySecretParser.cs
+++ b/identity-server/src/IdentityServer/Validation/Default/PostBodySecretParser.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Validation/Default/SecretValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/Default/SecretValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Validation/Default/TokenRevocationRequestValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/Default/TokenRevocationRequestValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Validation/IAuthorizeRequestValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/IAuthorizeRequestValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Validation/ITokenRevocationRequestValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/ITokenRevocationRequestValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Validation/ITokenValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/ITokenValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Validation/IUserInfoRequestValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/IUserInfoRequestValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Validation/Models/BearerTokenUsageValidationResult.cs
+++ b/identity-server/src/IdentityServer/Validation/Models/BearerTokenUsageValidationResult.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Validation/Models/ScopeSecretValidationResult.cs
+++ b/identity-server/src/IdentityServer/Validation/Models/ScopeSecretValidationResult.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Validation/Models/TokenRevocationRequestValidationResult.cs
+++ b/identity-server/src/IdentityServer/Validation/Models/TokenRevocationRequestValidationResult.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/IdentityServer/Validation/Models/UserInfoRequestValidationResult.cs
+++ b/identity-server/src/IdentityServer/Validation/Models/UserInfoRequestValidationResult.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/Storage/Models/Enums.cs
+++ b/identity-server/src/Storage/Models/Enums.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/Storage/Stores/Serialization/ClaimLite.cs
+++ b/identity-server/src/Storage/Stores/Serialization/ClaimLite.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/src/Storage/Stores/Serialization/IPersistentGrantSerializer.cs
+++ b/identity-server/src/Storage/Stores/Serialization/IPersistentGrantSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Config.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Config.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Duende.IdentityServer.Models;

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Data/ApplicationDbContext.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Data/ApplicationDbContext.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using IdentityServerHost.Models;

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Data/Migrations/20240123193529_Users.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Data/Migrations/20240123193529_Users.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Microsoft.EntityFrameworkCore.Migrations;

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Models/ApplicationUser.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Models/ApplicationUser.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Home/Error/ViewModel.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Home/Error/ViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Duende.IdentityServer.Models;

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Program.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using System.Globalization;

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/SeedData.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/SeedData.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using System.Security.Claims;

--- a/identity-server/templates/src/IdentityServerEmpty/Config.cs
+++ b/identity-server/templates/src/IdentityServerEmpty/Config.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Duende.IdentityServer.Models;

--- a/identity-server/templates/src/IdentityServerEmpty/Program.cs
+++ b/identity-server/templates/src/IdentityServerEmpty/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using System.Globalization;

--- a/identity-server/templates/src/IdentityServerEntityFramework/Config.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Config.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Duende.IdentityServer.Models;

--- a/identity-server/templates/src/IdentityServerEntityFramework/Migrations/ConfigurationDb/20240123193245_Configuration.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Migrations/ConfigurationDb/20240123193245_Configuration.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Microsoft.EntityFrameworkCore.Migrations;

--- a/identity-server/templates/src/IdentityServerEntityFramework/Migrations/PersistedGrantDb/20240123193240_Grants.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Migrations/PersistedGrantDb/20240123193240_Grants.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Microsoft.EntityFrameworkCore.Migrations;

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Home/Error/ViewModel.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Home/Error/ViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Duende.IdentityServer.Models;

--- a/identity-server/templates/src/IdentityServerEntityFramework/Program.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using System.Globalization;

--- a/identity-server/templates/src/IdentityServerEntityFramework/SeedData.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/SeedData.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Duende.IdentityServer.EntityFramework.DbContexts;

--- a/identity-server/templates/src/IdentityServerInMem/Config.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Config.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Duende.IdentityServer.Models;

--- a/identity-server/templates/src/IdentityServerInMem/Pages/Home/Error/ViewModel.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/Home/Error/ViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using Duende.IdentityServer.Models;

--- a/identity-server/templates/src/IdentityServerInMem/Program.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using System.Globalization;

--- a/identity-server/test/EntityFramework.IntegrationTests/DatabaseProviderFixture.cs
+++ b/identity-server/test/EntityFramework.IntegrationTests/DatabaseProviderFixture.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/EntityFramework.IntegrationTests/FakeLogger.cs
+++ b/identity-server/test/EntityFramework.IntegrationTests/FakeLogger.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/EntityFramework.IntegrationTests/Storage/DbContexts/ClientDbContextTests.cs
+++ b/identity-server/test/EntityFramework.IntegrationTests/Storage/DbContexts/ClientDbContextTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.IntegrationTests/Clients/Setup/CustomProfileService.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Clients/Setup/CustomProfileService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.IntegrationTests/Clients/Setup/CustomResponseDto.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Clients/Setup/CustomResponseDto.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.IntegrationTests/Clients/Setup/CustomResponseExtensionGrantValidator.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Clients/Setup/CustomResponseExtensionGrantValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.IntegrationTests/Clients/Setup/CustomResponseResourceOwnerValidator.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Clients/Setup/CustomResponseResourceOwnerValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.IntegrationTests/Clients/Setup/DynamicParameterExtensionGrantValidator.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Clients/Setup/DynamicParameterExtensionGrantValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.IntegrationTests/Clients/Setup/ExtensionGrantValidator.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Clients/Setup/ExtensionGrantValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.IntegrationTests/Clients/Setup/ExtensionGrantValidator2.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Clients/Setup/ExtensionGrantValidator2.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.IntegrationTests/Clients/Setup/NoSubjectExtensionGrantValidator.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Clients/Setup/NoSubjectExtensionGrantValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.IntegrationTests/Clients/Setup/Scopes.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Clients/Setup/Scopes.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.IntegrationTests/Clients/Setup/TestCustomTokenRequestValidator.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Clients/Setup/TestCustomTokenRequestValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.IntegrationTests/Clients/Setup/Users.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Clients/Setup/Users.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.IntegrationTests/Common/BrowserClient.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Common/BrowserClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.IntegrationTests/Common/MessageHandlerWrapper.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Common/MessageHandlerWrapper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.IntegrationTests/Conformance/Basic/RedirectUriTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Conformance/Basic/RedirectUriTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Authorize/SessionIdTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Authorize/SessionIdTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/CheckSession/CheckSessionTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/CheckSession/CheckSessionTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Introspection/Setup/Scopes.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Introspection/Setup/Scopes.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Introspection/Setup/Users.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Introspection/Setup/Users.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.IntegrationTests/Extensibility/CustomProfileServiceTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Extensibility/CustomProfileServiceTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.IntegrationTests/Hosting/FederatedSignoutTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Hosting/FederatedSignoutTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Common/IAuthenticationSchemeHandler.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Common/IAuthenticationSchemeHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Common/MockAuthenticationHandler.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Common/MockAuthenticationHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Common/MockAuthenticationHandlerProvider.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Common/MockAuthenticationHandlerProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Common/MockAuthenticationSchemeProvider.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Common/MockAuthenticationSchemeProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Common/MockAuthenticationService.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Common/MockAuthenticationService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Common/MockClaimsService.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Common/MockClaimsService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Common/MockConsentMessageStore.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Common/MockConsentMessageStore.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Common/MockConsentService.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Common/MockConsentService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Common/MockKeyMaterialService.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Common/MockKeyMaterialService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Common/MockLogoutNotificationService.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Common/MockLogoutNotificationService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Common/MockMessageStore.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Common/MockMessageStore.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Common/MockPersistedGrantService.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Common/MockPersistedGrantService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Common/MockProfileService.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Common/MockProfileService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Common/MockResourceValidator.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Common/MockResourceValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Common/MockReturnUrlParser.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Common/MockReturnUrlParser.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Common/StubAuthorizeResponseGenerator.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Common/StubAuthorizeResponseGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Common/StubHandleGenerationService.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Common/StubHandleGenerationService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Common/TestCert.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Common/TestCert.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Common/TestIdentityServerOptions.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Common/TestIdentityServerOptions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Common/TestLogger.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Common/TestLogger.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Common/TestUserConsentStore.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Common/TestUserConsentStore.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Cors/MockCorsPolicyProvider.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Cors/MockCorsPolicyProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Cors/MockCorsPolicyService.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Cors/MockCorsPolicyService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Endpoints/Authorize/StubAuthorizeInteractionResponseGenerator.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Endpoints/Authorize/StubAuthorizeInteractionResponseGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Endpoints/EndSession/EndSessionCallbackEndpointTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Endpoints/EndSession/EndSessionCallbackEndpointTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Endpoints/EndSession/StubBackChannelLogoutClient.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Endpoints/EndSession/StubBackChannelLogoutClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Endpoints/EndSession/StubEndSessionRequestValidator.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Endpoints/EndSession/StubEndSessionRequestValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Extensions/EndpointOptionsExtensionsTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Extensions/EndpointOptionsExtensionsTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Extensions/IdentityServerBuilderExtensionsCacheStoreTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Extensions/IdentityServerBuilderExtensionsCacheStoreTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Extensions/IdentityServerBuilderExtensionsCryptoTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Extensions/IdentityServerBuilderExtensionsCryptoTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Stores/InMemoryClientStoreTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Stores/InMemoryClientStoreTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Stores/InMemoryResourcesStoreTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Stores/InMemoryResourcesStoreTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Validation/AccessTokenValidation.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Validation/AccessTokenValidation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ClientValidation_Code.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ClientValidation_Code.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ClientValidation_IdToken.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ClientValidation_IdToken.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ClientValidation_Invalid.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ClientValidation_Invalid.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ClientValidation_Token.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ClientValidation_Token.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ClientValidation_Valid.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ClientValidation_Valid.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ProtocolValidation_CustomValidator.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ProtocolValidation_CustomValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Validation/EndSessionRequestValidation/EndSessionRequestValidatorTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Validation/EndSessionRequestValidation/EndSessionRequestValidatorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Validation/EndSessionRequestValidation/StubRedirectUriValidator.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Validation/EndSessionRequestValidation/StubRedirectUriValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Validation/EndSessionRequestValidation/StubTokenValidator.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Validation/EndSessionRequestValidation/StubTokenValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Validation/GrantTypesValidation.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Validation/GrantTypesValidation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Validation/RevocationRequestValidation.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Validation/RevocationRequestValidation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Validation/Secrets/ClientSecretValidation.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Validation/Secrets/ClientSecretValidation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Validation/Secrets/FormPostCredentialParsing.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Validation/Secrets/FormPostCredentialParsing.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Validation/Secrets/HashedSharedSecretValidation.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Validation/Secrets/HashedSharedSecretValidation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Validation/Secrets/PlainTextClientSecretValidation.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Validation/Secrets/PlainTextClientSecretValidation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Validation/Secrets/SecretValidation.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Validation/Secrets/SecretValidation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Validation/Setup/TestGrantValidator.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Validation/Setup/TestGrantValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Validation/Setup/TestIssuerNameService.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Validation/Setup/TestIssuerNameService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Validation/Setup/TestProfileService.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Validation/Setup/TestProfileService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Validation/Setup/TestResourceOwnerPasswordValidator.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Validation/Setup/TestResourceOwnerPasswordValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Validation/Setup/TestTokenValidator.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Validation/Setup/TestTokenValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Validation/Setup/TokenFactory.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Validation/Setup/TokenFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Validation/Setup/ValidationExtensions.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Validation/Setup/ValidationExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Validation/TokenRequest Validation/TokenRequestValidation_ExtensionGrants_Invalid.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Validation/TokenRequest Validation/TokenRequestValidation_ExtensionGrants_Invalid.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Validation/TokenRequest Validation/TokenRequestValidation_PKCE.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Validation/TokenRequest Validation/TokenRequestValidation_PKCE.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/identity-server/test/IdentityServer.UnitTests/Validation/UserInfoRequestValidation.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Validation/UserInfoRequestValidation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 

--- a/shared/ShouldlyExtensions/ShouldlyExtensions.cs
+++ b/shared/ShouldlyExtensions/ShouldlyExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 namespace Shouldly;

--- a/templates/build/Program.cs
+++ b/templates/build/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
 using System.Diagnostics.CodeAnalysis;


### PR DESCRIPTION
This sets the charset in editorconfig to utf-8. Previously, there was a mixture of file encodings with some including a BOM (byte order mark) and some not. Most tools will not show the BOM, and so the diff of this commit may appear mostly empty. All the files in the diff, apart from .editorconfig, simply had the BOM removed.