### PR TITLE
Add caching support for discovery documents with preview options

### DIFF
--- a/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
+++ b/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
@@ -207,4 +207,14 @@ public class IdentityServerOptions
     /// Options for Pushed Authorization Requests (PAR).
     /// </summary>
     public PushedAuthorizationOptions PushedAuthorization { get; set; } = new PushedAuthorizationOptions();
+
+    /// <summary>
+    /// Gets or sets the options for enabling and configuring preview features in the server.
+    /// Preview features provide access to experimental or in-progress functionality that may undergo
+    /// further changes before being finalized.
+    /// </summary>
+    /// <value>
+    /// Options for configuring preview features in the server.
+    /// </value>
+    public PreviewFeatureOptions Preview { get; set; } = new PreviewFeatureOptions();
 }

--- a/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/PreviewFeatureOptions.cs
+++ b/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/PreviewFeatureOptions.cs
@@ -15,11 +15,11 @@ public class PreviewFeatureOptions
     /// <summary>
     /// Enables Caching of Discovery Document based on ResponseCaching Interval 
     /// </summary>
+    [Experimental("DUENDEPREVIEW001", UrlFormat = "https://duende.link/previewfeatures?id={0}")]
     public bool EnableDiscoveryDocumentCache { get; set; } = false;
 
     /// <summary>
     /// DiscoveryDocument Cache Duration
     /// </summary>
-    [Experimental("DUENDEPREVIEW001", UrlFormat = "https://duende.link/previewfeatures?id={0}")]
     public TimeSpan DiscoveryDocumentCacheDuration{ get; set; } = TimeSpan.FromMinutes(1);
 }

--- a/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/PreviewFeatureOptions.cs
+++ b/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/PreviewFeatureOptions.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Duende.IdentityServer.Configuration;
+
+using System;
+
+/// <summary>
+/// Provides configuration options for enabling and managing preview features in IdentityServer.
+/// </summary>
+public class PreviewFeatureOptions
+{
+    /// <summary>
+    /// Enables Caching of Discovery Document based on ResponseCaching Interval 
+    /// </summary>
+    public bool EnableDiscoveryDocumentCache { get; set; } = false;
+
+    /// <summary>
+    /// DiscoveryDocument Cache Duration
+    /// </summary>
+    [Experimental("DUENDEPREVIEW001", UrlFormat = "https://duende.link/previewfeatures?id={0}")]
+    public TimeSpan DiscoveryDocumentCacheDuration{ get; set; } = TimeSpan.FromMinutes(1);
+}

--- a/identity-server/src/IdentityServer/Endpoints/DiscoveryEndpoint.cs
+++ b/identity-server/src/IdentityServer/Endpoints/DiscoveryEndpoint.cs
@@ -68,7 +68,9 @@ internal class DiscoveryEndpoint : IEndpointHandler
         // generate response
         _logger.LogTrace("Calling into discovery response generator: {type}", _responseGenerator.GetType().FullName);
 
+#pragma warning disable DUENDEPREVIEW001
         if (_options.Preview.EnableDiscoveryDocumentCache)
+#pragma warning restore DUENDEPREVIEW001
         {
             var distributedCache = context.RequestServices.GetRequiredService<IDistributedCache>();
             if (distributedCache is not null)

--- a/identity-server/src/IdentityServer/Endpoints/Results/DiscoveryDocumentResult.cs
+++ b/identity-server/src/IdentityServer/Endpoints/Results/DiscoveryDocumentResult.cs
@@ -18,20 +18,20 @@ namespace Duende.IdentityServer.Endpoints.Results;
 public class DiscoveryDocumentResult : EndpointResult<DiscoveryDocumentResult>
 {
     /// <summary>
-    /// Gets the entries.
-    /// </summary>
-    /// <value>
-    /// The entries.
-    /// </value>
-    public Dictionary<string, object> Entries { get; }
-
-    /// <summary>
     /// Gets the maximum age.
     /// </summary>
     /// <value>
     /// The maximum age.
     /// </value>
     public int? MaxAge { get; }
+
+    /// <summary>
+    /// Gets or sets the JSON representation of the entries in the discovery document.
+    /// </summary>
+    /// <value>
+    /// A JSON string that represents the entries.
+    /// </value>
+    public string Json { get; set; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DiscoveryDocumentResult" /> class.
@@ -41,8 +41,19 @@ public class DiscoveryDocumentResult : EndpointResult<DiscoveryDocumentResult>
     /// <exception cref="System.ArgumentNullException">entries</exception>
     public DiscoveryDocumentResult(Dictionary<string, object> entries, int? maxAge = null)
     {
-        Entries = entries ?? throw new ArgumentNullException(nameof(entries));
         MaxAge = maxAge;
+
+        // serialize entries ahead of time
+        Json = ObjectSerializer.ToString(entries);
+    }
+
+    /// <summary>
+    /// Represents a result for a discovery document, implementing <see cref="IEndpointResult"/>.
+    /// </summary>
+    public DiscoveryDocumentResult(string json, int? maxAge = null)
+    {
+        MaxAge = maxAge;
+        Json = json;
     }
 }
 
@@ -56,6 +67,6 @@ class DiscoveryDocumentHttpWriter : IHttpResponseWriter<DiscoveryDocumentResult>
             context.Response.SetCache(result.MaxAge.Value, "Origin");
         }
 
-        return context.Response.WriteJsonAsync(result.Entries);
+        return context.Response.WriteJsonAsync(result.Json);
     }
 }

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Discovery/DiscoveryEndpointTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Discovery/DiscoveryEndpointTests.cs
@@ -13,6 +13,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using Duende.IdentityServer;
 using Duende.IdentityServer.Configuration;
+using Duende.IdentityServer.Endpoints.Results;
 using Duende.IdentityServer.Models;
 using Xunit;
 using JsonWebKey = Microsoft.IdentityModel.Tokens.JsonWebKey;
@@ -312,5 +313,25 @@ public class DiscoveryEndpointTests
 
         // we got a result back
         data.ContainsKey("after_cache_key").Should().BeFalse();
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public void Cannot_set_entries_for_document_discovery_cache_if_enabled()
+    {
+        var result = new DiscoveryDocumentResult("{}", null);
+        
+        Assert.Throws<InvalidOperationException>(() =>
+            result.Entries = new Dictionary<string, object>());
+    }
+    
+    [Fact]
+    [Trait("Category", Category)]
+    public void Cannot_get_entries_for_document_discovery_cache_if_enabled()
+    {
+        var result = new DiscoveryDocumentResult("{}", null);
+
+        Assert.Throws<InvalidOperationException>(() =>
+            result.Entries.Add("Joe", "Good Stuff"));
     }
 }

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Discovery/DiscoveryEndpointTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Discovery/DiscoveryEndpointTests.cs
@@ -291,10 +291,10 @@ public class DiscoveryEndpointTests
         IdentityServerPipeline pipeline = new IdentityServerPipeline();
         pipeline.Initialize("/root");
 
-        pipeline.Options.Preview.EnableDiscoveryDocumentCache = true;
 #pragma warning disable DUENDEPREVIEW001
-        pipeline.Options.Preview.DiscoveryDocumentCacheDuration = TimeSpan.FromSeconds(1);
+        pipeline.Options.Preview.EnableDiscoveryDocumentCache = true;
 #pragma warning restore DUENDEPREVIEW001
+        pipeline.Options.Preview.DiscoveryDocumentCacheDuration = TimeSpan.FromSeconds(1);
 
         // cache
         _ = await pipeline.BackChannelClient.GetAsync("https://server/root/.well-known/openid-configuration");

--- a/identity-server/test/IdentityServer.UnitTests/Infrastructure/ObjectSerializerTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Infrastructure/ObjectSerializerTests.cs
@@ -6,19 +6,41 @@ using System;
 using Duende.IdentityServer.Models;
 using FluentAssertions;
 using Xunit;
+using System.Collections.Generic;
 
 namespace UnitTests.Infrastructure;
 
 public class ObjectSerializerTests
 {
-    public ObjectSerializerTests()
-    {
-    }
-
     [Fact]
     public void Can_be_deserialize_message()
     {
-        Action a = () => Duende.IdentityServer.ObjectSerializer.FromString<Message<ErrorMessage>>("{\"created\":0, \"data\": {\"error\": \"error\"}}");
+        Action a = () =>
+            Duende.IdentityServer.ObjectSerializer.FromString<Message<ErrorMessage>>(
+                "{\"created\":0, \"data\": {\"error\": \"error\"}}");
         a.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Can_serialize_and_deserialize_dictionary()
+    {
+        var jsonObject = new Dictionary<string, object>
+        {
+            { "key", "value" },
+            { "key2", new { key = "value" } },
+            { "key3", new List<string> { "value1", "value2" } },
+            {
+                "key4", new Dictionary<string, string>
+                {
+                    { "key1", "value1" },
+                    { "key2", "value2" }
+                }
+            }
+        };
+
+        var json = Duende.IdentityServer.ObjectSerializer.ToString(jsonObject);
+        var result = Duende.IdentityServer.ObjectSerializer.FromString<Dictionary<string, object>>(json);
+
+        result.Should().NotBeNull();
     }
 }


### PR DESCRIPTION
Introduced a caching mechanism for the discovery document, configurable through the new `PreviewFeatureOptions`. This feature includes settings for enabling the cache and defining its duration. Updated related tests and classes to support and validate the caching implementation.

I ended up going with `IDistributedCache` to avoid any extra steps folks have to take.