### PR TITLE
remove header from templates

### DIFF
--- a/bff/templates/.editorconfig
+++ b/bff/templates/.editorconfig
@@ -1,0 +1,4 @@
+[*.cs]
+
+# Copyright Header
+file_header_template=unset

--- a/bff/templates/src/BffLocalApi/HostingExtensions.cs
+++ b/bff/templates/src/BffLocalApi/HostingExtensions.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Serilog;
 
 namespace BffLocalApi;

--- a/bff/templates/src/BffLocalApi/Program.cs
+++ b/bff/templates/src/BffLocalApi/Program.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using BffLocalApi;
 using Serilog;
 

--- a/bff/templates/src/BffLocalApi/ToDoController.cs
+++ b/bff/templates/src/BffLocalApi/ToDoController.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Microsoft.AspNetCore.Mvc;
 
 namespace BffLocalApi;

--- a/bff/templates/src/BffRemoteApi/Configuration.cs
+++ b/bff/templates/src/BffRemoteApi/Configuration.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.Bff;
 
 namespace BffRemoteApi;

--- a/bff/templates/src/BffRemoteApi/Program.cs
+++ b/bff/templates/src/BffRemoteApi/Program.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using BffRemoteApi;
 using Duende.Bff.Yarp;
 

--- a/identity-server/templates/.editorconfig
+++ b/identity-server/templates/.editorconfig
@@ -1,0 +1,4 @@
+[*.cs]
+
+# Copyright Header
+file_header_template=unset

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Config.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Config.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer.Models;
 
 namespace IdentityServerAspNetIdentity;

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Data/ApplicationDbContext.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Data/ApplicationDbContext.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using IdentityServerHost.Models;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Data/Migrations/20240123193529_Users.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Data/Migrations/20240123193529_Users.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/HostingExtensions.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/HostingExtensions.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer;
 using IdentityServerAspNetIdentity.Data;
 using IdentityServerHost.Models;

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Models/ApplicationUser.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Models/ApplicationUser.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 
 using Microsoft.AspNetCore.Identity;
 

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Account/AccessDenied.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Account/AccessDenied.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace IdentityServerHost.Pages.Account;

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Account/Login/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Account/Login/Index.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer;
 using Duende.IdentityServer.Events;
 using Duende.IdentityServer.Models;

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Account/Login/InputModel.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Account/Login/InputModel.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using System.ComponentModel.DataAnnotations;
 
 namespace IdentityServerHost.Pages.Login;

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Account/Login/LoginOptions.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Account/Login/LoginOptions.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 namespace IdentityServerHost.Pages.Login;
 
 public static class LoginOptions

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Account/Login/ViewModel.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Account/Login/ViewModel.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 namespace IdentityServerHost.Pages.Login;
 
 public class ViewModel

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Account/Logout/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Account/Logout/Index.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityModel;
 using Duende.IdentityServer.Events;
 using Duende.IdentityServer.Extensions;

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Account/Logout/LoggedOut.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Account/Logout/LoggedOut.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Account/Logout/LoggedOutViewModel.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Account/Logout/LoggedOutViewModel.cs
@@ -1,9 +1,6 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 namespace IdentityServerHost.Pages.Logout;
 
 public class LoggedOutViewModel

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Account/Logout/LogoutOptions.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Account/Logout/LogoutOptions.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 
 namespace IdentityServerHost.Pages.Logout;
 

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Ciba/All.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Ciba/All.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services;
 using Microsoft.AspNetCore.Authorization;

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Ciba/Consent.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Ciba/Consent.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer.Events;
 using Duende.IdentityServer.Extensions;
 using Duende.IdentityServer.Models;

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Ciba/ConsentOptions.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Ciba/ConsentOptions.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 namespace IdentityServerHost.Pages.Ciba;
 
 public static class ConsentOptions

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Ciba/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Ciba/Index.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services;
 using Microsoft.AspNetCore.Authorization;

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Ciba/InputModel.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Ciba/InputModel.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 namespace IdentityServerHost.Pages.Ciba;
 
 public class InputModel

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Ciba/ViewModel.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Ciba/ViewModel.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 namespace IdentityServerHost.Pages.Ciba;
 
 public class ViewModel

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Consent/ConsentOptions.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Consent/ConsentOptions.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 namespace IdentityServerHost.Pages.Consent;
 
 public static class ConsentOptions

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Consent/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Consent/Index.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityModel;
 using Duende.IdentityServer.Events;
 using Duende.IdentityServer.Extensions;

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Consent/InputModel.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Consent/InputModel.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 namespace IdentityServerHost.Pages.Consent;
 
 public class InputModel

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Consent/ViewModel.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Consent/ViewModel.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 namespace IdentityServerHost.Pages.Consent;
 
 public class ViewModel

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Device/DeviceOptions.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Device/DeviceOptions.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 namespace IdentityServerHost.Pages.Device;
 
 public static class DeviceOptions

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Device/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Device/Index.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer.Configuration;
 using Duende.IdentityServer.Events;
 using Duende.IdentityServer.Extensions;

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Device/InputModel.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Device/InputModel.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 namespace IdentityServerHost.Pages.Device;
 
 public class InputModel

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Device/Success.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Device/Success.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Device/ViewModel.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Device/ViewModel.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 namespace IdentityServerHost.Pages.Device;
 
 public class ViewModel

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Diagnostics/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Diagnostics/Index.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Diagnostics/ViewModel.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Diagnostics/ViewModel.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using System.Text;
 using System.Text.Json;
 using Duende.IdentityModel;

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Extensions.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Extensions.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer.Models;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Mvc;

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/ExternalLogin/Callback.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/ExternalLogin/Callback.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using System.Security.Claims;
 using Duende.IdentityModel;
 using Duende.IdentityServer;

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/ExternalLogin/Challenge.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/ExternalLogin/Challenge.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer.Services;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Grants/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Grants/Index.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer.Events;
 using Duende.IdentityServer.Extensions;
 using Duende.IdentityServer.Services;

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Grants/ViewModel.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Grants/ViewModel.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 namespace IdentityServerHost.Pages.Grants;
 
 public class ViewModel

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Home/Error/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Home/Error/Index.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Home/Error/ViewModel.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Home/Error/ViewModel.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer.Models;
 
 namespace IdentityServerHost.Pages.Error;

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/IdentityServerSuppressions.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/IdentityServerSuppressions.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 // This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Index.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using System.Reflection;
 using Duende.IdentityServer;
 using Microsoft.AspNetCore.Authorization;

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Log.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Log.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 namespace IdentityServerHost.Pages;
 
 internal static class Log

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Redirect/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Redirect/Index.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/SecurityHeadersAttribute.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/SecurityHeadersAttribute.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/ServerSideSessions/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/ServerSideSessions/Index.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services;
 using Duende.IdentityServer.Stores;

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Telemetry.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Telemetry.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using System.Diagnostics.Metrics;
 
 namespace IdentityServerHost.Pages;

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Program.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Program.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using System.Globalization;
 using System.Text;
 using Duende.IdentityServer.Licensing;

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/SeedData.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/SeedData.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using System.Security.Claims;
 using Duende.IdentityModel;
 using IdentityServerAspNetIdentity.Data;

--- a/identity-server/templates/src/IdentityServerEmpty/Config.cs
+++ b/identity-server/templates/src/IdentityServerEmpty/Config.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer.Models;
 
 namespace IdentityServerEmpty;

--- a/identity-server/templates/src/IdentityServerEmpty/HostingExtensions.cs
+++ b/identity-server/templates/src/IdentityServerEmpty/HostingExtensions.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Serilog;
 
 namespace IdentityServerEmpty;

--- a/identity-server/templates/src/IdentityServerEmpty/Program.cs
+++ b/identity-server/templates/src/IdentityServerEmpty/Program.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using System.Globalization;
 using System.Text;
 using Duende.IdentityServer.Licensing;

--- a/identity-server/templates/src/IdentityServerEntityFramework/Config.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Config.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer.Models;
 
 namespace IdentityServerEntityFramework;

--- a/identity-server/templates/src/IdentityServerEntityFramework/HostingExtensions.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/HostingExtensions.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer;
 using IdentityServerHost;
 using IdentityServerHost.Pages.Admin.ApiScopes;

--- a/identity-server/templates/src/IdentityServerEntityFramework/Migrations/ConfigurationDb/20240123193245_Configuration.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Migrations/ConfigurationDb/20240123193245_Configuration.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable

--- a/identity-server/templates/src/IdentityServerEntityFramework/Migrations/PersistedGrantDb/20240123193240_Grants.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Migrations/PersistedGrantDb/20240123193240_Grants.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Account/AccessDenied.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Account/AccessDenied.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace IdentityServerHost.Pages.Account;

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Account/Create/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Account/Create/Index.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services;

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Account/Create/InputModel.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Account/Create/InputModel.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using System.ComponentModel.DataAnnotations;
 
 namespace IdentityServerHost.Pages.Create;

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Account/Login/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Account/Login/Index.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer;
 using Duende.IdentityServer.Events;
 using Duende.IdentityServer.Models;

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Account/Login/InputModel.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Account/Login/InputModel.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using System.ComponentModel.DataAnnotations;
 
 namespace IdentityServerHost.Pages.Login;

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Account/Login/LoginOptions.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Account/Login/LoginOptions.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 namespace IdentityServerHost.Pages.Login;
 
 public static class LoginOptions

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Account/Login/ViewModel.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Account/Login/ViewModel.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 namespace IdentityServerHost.Pages.Login;
 
 public class ViewModel

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Account/Logout/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Account/Logout/Index.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityModel;
 using Duende.IdentityServer.Events;
 using Duende.IdentityServer.Extensions;

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Account/Logout/LoggedOut.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Account/Logout/LoggedOut.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Account/Logout/LoggedOutViewModel.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Account/Logout/LoggedOutViewModel.cs
@@ -1,9 +1,6 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 namespace IdentityServerHost.Pages.Logout;
 
 public class LoggedOutViewModel

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Account/Logout/LogoutOptions.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Account/Logout/LogoutOptions.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 
 namespace IdentityServerHost.Pages.Logout;
 

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Admin/ApiScopes/ApiScopeRepository.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Admin/ApiScopes/ApiScopeRepository.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using System.ComponentModel.DataAnnotations;
 using Duende.IdentityServer.EntityFramework.DbContexts;
 using Duende.IdentityServer.EntityFramework.Entities;

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Admin/ApiScopes/Edit.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Admin/ApiScopes/Edit.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Admin/ApiScopes/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Admin/ApiScopes/Index.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Admin/ApiScopes/New.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Admin/ApiScopes/New.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Admin/Clients/ClientRepository.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Admin/Clients/ClientRepository.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using System.ComponentModel.DataAnnotations;
 using Duende.IdentityServer.EntityFramework.DbContexts;
 using Duende.IdentityServer.EntityFramework.Entities;

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Admin/Clients/Edit.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Admin/Clients/Edit.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Admin/Clients/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Admin/Clients/Index.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Admin/Clients/New.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Admin/Clients/New.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityModel;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Admin/IdentityScopes/Edit.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Admin/IdentityScopes/Edit.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Admin/IdentityScopes/IdentityScopeRepository.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Admin/IdentityScopes/IdentityScopeRepository.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using System.ComponentModel.DataAnnotations;
 using Duende.IdentityServer.EntityFramework.DbContexts;
 using Duende.IdentityServer.EntityFramework.Entities;

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Admin/IdentityScopes/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Admin/IdentityScopes/Index.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Admin/IdentityScopes/New.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Admin/IdentityScopes/New.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Admin/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Admin/Index.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Ciba/All.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Ciba/All.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services;
 using Microsoft.AspNetCore.Authorization;

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Ciba/Consent.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Ciba/Consent.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer.Events;
 using Duende.IdentityServer.Extensions;
 using Duende.IdentityServer.Models;

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Ciba/ConsentOptions.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Ciba/ConsentOptions.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 namespace IdentityServerHost.Pages.Ciba;
 
 public static class ConsentOptions

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Ciba/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Ciba/Index.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services;
 using Microsoft.AspNetCore.Authorization;

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Ciba/InputModel.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Ciba/InputModel.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 namespace IdentityServerHost.Pages.Ciba;
 
 public class InputModel

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Ciba/ViewModel.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Ciba/ViewModel.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 namespace IdentityServerHost.Pages.Ciba;
 
 public class ViewModel

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Consent/ConsentOptions.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Consent/ConsentOptions.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 namespace IdentityServerHost.Pages.Consent;
 
 public static class ConsentOptions

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Consent/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Consent/Index.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityModel;
 using Duende.IdentityServer.Events;
 using Duende.IdentityServer.Extensions;

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Consent/InputModel.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Consent/InputModel.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 namespace IdentityServerHost.Pages.Consent;
 
 public class InputModel

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Consent/ViewModel.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Consent/ViewModel.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 namespace IdentityServerHost.Pages.Consent;
 
 public class ViewModel

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Device/DeviceOptions.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Device/DeviceOptions.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 namespace IdentityServerHost.Pages.Device;
 
 public static class DeviceOptions

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Device/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Device/Index.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer.Configuration;
 using Duende.IdentityServer.Events;
 using Duende.IdentityServer.Extensions;

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Device/InputModel.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Device/InputModel.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 namespace IdentityServerHost.Pages.Device;
 
 public class InputModel

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Device/Success.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Device/Success.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Device/ViewModel.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Device/ViewModel.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 namespace IdentityServerHost.Pages.Device;
 
 public class ViewModel

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Diagnostics/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Diagnostics/Index.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Diagnostics/ViewModel.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Diagnostics/ViewModel.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using System.Text;
 using System.Text.Json;
 using Duende.IdentityModel;

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Extensions.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Extensions.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer.Models;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Mvc;

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/ExternalLogin/Callback.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/ExternalLogin/Callback.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using System.Security.Claims;
 using Duende.IdentityModel;
 using Duende.IdentityServer;

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/ExternalLogin/Challenge.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/ExternalLogin/Challenge.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer.Services;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Grants/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Grants/Index.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer.Events;
 using Duende.IdentityServer.Extensions;
 using Duende.IdentityServer.Services;

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Grants/ViewModel.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Grants/ViewModel.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 namespace IdentityServerHost.Pages.Grants;
 
 public class ViewModel

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Home/Error/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Home/Error/Index.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Home/Error/ViewModel.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Home/Error/ViewModel.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer.Models;
 
 namespace IdentityServerHost.Pages.Error;

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/IdentityServerSuppressions.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/IdentityServerSuppressions.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 // This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Index.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using System.Reflection;
 using Duende.IdentityServer;
 using Microsoft.AspNetCore.Authorization;

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Log.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Log.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 namespace IdentityServerHost.Pages;
 
 internal static class Log

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Portal/ClientRepository.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Portal/ClientRepository.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer.EntityFramework.DbContexts;
 using Microsoft.EntityFrameworkCore;
 

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Portal/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Portal/Index.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace IdentityServerHost.Pages.Portal;

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Redirect/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Redirect/Index.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/SecurityHeadersAttribute.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/SecurityHeadersAttribute.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/ServerSideSessions/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/ServerSideSessions/Index.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services;
 using Duende.IdentityServer.Stores;

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Telemetry.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Telemetry.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using System.Diagnostics.Metrics;
 
 namespace IdentityServerHost.Pages;

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/TestUsers.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/TestUsers.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using System.Security.Claims;
 using System.Text.Json;
 using Duende.IdentityModel;

--- a/identity-server/templates/src/IdentityServerEntityFramework/Program.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Program.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using System.Globalization;
 using System.Text;
 using Duende.IdentityServer.Licensing;

--- a/identity-server/templates/src/IdentityServerEntityFramework/SeedData.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/SeedData.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer.EntityFramework.DbContexts;
 using Duende.IdentityServer.EntityFramework.Mappers;
 using Duende.IdentityServer.Models;

--- a/identity-server/templates/src/IdentityServerInMem/Config.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Config.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer.Models;
 
 namespace IdentityServerInMem;

--- a/identity-server/templates/src/IdentityServerInMem/HostingExtensions.cs
+++ b/identity-server/templates/src/IdentityServerInMem/HostingExtensions.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer;
 using IdentityServerHost;
 using Serilog;

--- a/identity-server/templates/src/IdentityServerInMem/Pages/Account/AccessDenied.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/Account/AccessDenied.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace IdentityServerHost.Pages.Account;

--- a/identity-server/templates/src/IdentityServerInMem/Pages/Account/Create/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/Account/Create/Index.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services;

--- a/identity-server/templates/src/IdentityServerInMem/Pages/Account/Create/InputModel.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/Account/Create/InputModel.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using System.ComponentModel.DataAnnotations;
 
 namespace IdentityServerHost.Pages.Create;

--- a/identity-server/templates/src/IdentityServerInMem/Pages/Account/Login/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/Account/Login/Index.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer;
 using Duende.IdentityServer.Events;
 using Duende.IdentityServer.Models;

--- a/identity-server/templates/src/IdentityServerInMem/Pages/Account/Login/InputModel.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/Account/Login/InputModel.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using System.ComponentModel.DataAnnotations;
 
 namespace IdentityServerHost.Pages.Login;

--- a/identity-server/templates/src/IdentityServerInMem/Pages/Account/Login/LoginOptions.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/Account/Login/LoginOptions.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 namespace IdentityServerHost.Pages.Login;
 
 public static class LoginOptions

--- a/identity-server/templates/src/IdentityServerInMem/Pages/Account/Login/ViewModel.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/Account/Login/ViewModel.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 namespace IdentityServerHost.Pages.Login;
 
 public class ViewModel

--- a/identity-server/templates/src/IdentityServerInMem/Pages/Account/Logout/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/Account/Logout/Index.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityModel;
 using Duende.IdentityServer.Events;
 using Duende.IdentityServer.Extensions;

--- a/identity-server/templates/src/IdentityServerInMem/Pages/Account/Logout/LoggedOut.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/Account/Logout/LoggedOut.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;

--- a/identity-server/templates/src/IdentityServerInMem/Pages/Account/Logout/LoggedOutViewModel.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/Account/Logout/LoggedOutViewModel.cs
@@ -1,9 +1,6 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 namespace IdentityServerHost.Pages.Logout;
 
 public class LoggedOutViewModel

--- a/identity-server/templates/src/IdentityServerInMem/Pages/Account/Logout/LogoutOptions.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/Account/Logout/LogoutOptions.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 
 namespace IdentityServerHost.Pages.Logout;
 

--- a/identity-server/templates/src/IdentityServerInMem/Pages/Ciba/All.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/Ciba/All.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services;
 using Microsoft.AspNetCore.Authorization;

--- a/identity-server/templates/src/IdentityServerInMem/Pages/Ciba/Consent.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/Ciba/Consent.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer.Events;
 using Duende.IdentityServer.Extensions;
 using Duende.IdentityServer.Models;

--- a/identity-server/templates/src/IdentityServerInMem/Pages/Ciba/ConsentOptions.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/Ciba/ConsentOptions.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 namespace IdentityServerHost.Pages.Ciba;
 
 public static class ConsentOptions

--- a/identity-server/templates/src/IdentityServerInMem/Pages/Ciba/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/Ciba/Index.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services;
 using Microsoft.AspNetCore.Authorization;

--- a/identity-server/templates/src/IdentityServerInMem/Pages/Ciba/InputModel.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/Ciba/InputModel.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 namespace IdentityServerHost.Pages.Ciba;
 
 public class InputModel

--- a/identity-server/templates/src/IdentityServerInMem/Pages/Ciba/ViewModel.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/Ciba/ViewModel.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 namespace IdentityServerHost.Pages.Ciba;
 
 public class ViewModel

--- a/identity-server/templates/src/IdentityServerInMem/Pages/Consent/ConsentOptions.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/Consent/ConsentOptions.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 namespace IdentityServerHost.Pages.Consent;
 
 public static class ConsentOptions

--- a/identity-server/templates/src/IdentityServerInMem/Pages/Consent/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/Consent/Index.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityModel;
 using Duende.IdentityServer.Events;
 using Duende.IdentityServer.Extensions;

--- a/identity-server/templates/src/IdentityServerInMem/Pages/Consent/InputModel.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/Consent/InputModel.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 namespace IdentityServerHost.Pages.Consent;
 
 public class InputModel

--- a/identity-server/templates/src/IdentityServerInMem/Pages/Consent/ViewModel.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/Consent/ViewModel.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 namespace IdentityServerHost.Pages.Consent;
 
 public class ViewModel

--- a/identity-server/templates/src/IdentityServerInMem/Pages/Device/DeviceOptions.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/Device/DeviceOptions.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 namespace IdentityServerHost.Pages.Device;
 
 public static class DeviceOptions

--- a/identity-server/templates/src/IdentityServerInMem/Pages/Device/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/Device/Index.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer.Configuration;
 using Duende.IdentityServer.Events;
 using Duende.IdentityServer.Extensions;

--- a/identity-server/templates/src/IdentityServerInMem/Pages/Device/InputModel.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/Device/InputModel.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 namespace IdentityServerHost.Pages.Device;
 
 public class InputModel

--- a/identity-server/templates/src/IdentityServerInMem/Pages/Device/Success.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/Device/Success.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 

--- a/identity-server/templates/src/IdentityServerInMem/Pages/Device/ViewModel.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/Device/ViewModel.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 namespace IdentityServerHost.Pages.Device;
 
 public class ViewModel

--- a/identity-server/templates/src/IdentityServerInMem/Pages/Diagnostics/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/Diagnostics/Index.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;

--- a/identity-server/templates/src/IdentityServerInMem/Pages/Diagnostics/ViewModel.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/Diagnostics/ViewModel.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using System.Text;
 using System.Text.Json;
 using Duende.IdentityModel;

--- a/identity-server/templates/src/IdentityServerInMem/Pages/Extensions.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/Extensions.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer.Models;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Mvc;

--- a/identity-server/templates/src/IdentityServerInMem/Pages/ExternalLogin/Callback.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/ExternalLogin/Callback.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using System.Security.Claims;
 using Duende.IdentityModel;
 using Duende.IdentityServer;

--- a/identity-server/templates/src/IdentityServerInMem/Pages/ExternalLogin/Challenge.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/ExternalLogin/Challenge.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer.Services;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;

--- a/identity-server/templates/src/IdentityServerInMem/Pages/Grants/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/Grants/Index.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer.Events;
 using Duende.IdentityServer.Extensions;
 using Duende.IdentityServer.Services;

--- a/identity-server/templates/src/IdentityServerInMem/Pages/Grants/ViewModel.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/Grants/ViewModel.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 namespace IdentityServerHost.Pages.Grants;
 
 public class ViewModel

--- a/identity-server/templates/src/IdentityServerInMem/Pages/Home/Error/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/Home/Error/Index.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;

--- a/identity-server/templates/src/IdentityServerInMem/Pages/Home/Error/ViewModel.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/Home/Error/ViewModel.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer.Models;
 
 namespace IdentityServerHost.Pages.Error;

--- a/identity-server/templates/src/IdentityServerInMem/Pages/IdentityServerSuppressions.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/IdentityServerSuppressions.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 // This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given

--- a/identity-server/templates/src/IdentityServerInMem/Pages/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/Index.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using System.Reflection;
 using Duende.IdentityServer;
 using Microsoft.AspNetCore.Authorization;

--- a/identity-server/templates/src/IdentityServerInMem/Pages/Log.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/Log.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 namespace IdentityServerHost.Pages;
 
 internal static class Log

--- a/identity-server/templates/src/IdentityServerInMem/Pages/Redirect/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/Redirect/Index.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;

--- a/identity-server/templates/src/IdentityServerInMem/Pages/SecurityHeadersAttribute.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/SecurityHeadersAttribute.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 

--- a/identity-server/templates/src/IdentityServerInMem/Pages/ServerSideSessions/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/ServerSideSessions/Index.cshtml.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services;
 using Duende.IdentityServer.Stores;

--- a/identity-server/templates/src/IdentityServerInMem/Pages/Telemetry.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/Telemetry.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using System.Diagnostics.Metrics;
 
 namespace IdentityServerHost.Pages;

--- a/identity-server/templates/src/IdentityServerInMem/Pages/TestUsers.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/TestUsers.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using System.Security.Claims;
 using System.Text.Json;
 using Duende.IdentityModel;

--- a/identity-server/templates/src/IdentityServerInMem/Program.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Program.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Duende Software. All rights reserved.
-// See LICENSE in the project root for license information.
-
 using System.Globalization;
 using System.Text;
 using Duende.IdentityServer.Licensing;


### PR DESCRIPTION
**What issue does this PR address?**
Removes the header from the templates as this would end up in our customer's codebases. 

This PR works by introducing a cascading .editorconfig in the templates folder. It overrides the file_header_template.


**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
