### PR TITLE
Add global.json to specify .NET SDK version

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "9.0.103",
+    "rollForward": "latestPatch",
+    "allowPrerelease": false
+  }
+}


### PR DESCRIPTION
This file sets the .NET SDK version to 9.0.103 and ensures using the latest patch updates. It also disables the use of prerelease versions for improved environment consistency.

This is an issue with `dotnet format` in the latest .NET SDK 9.0.200. This will likely be fixed in a future release.