### PR TITLE
Update .NET version to 9.0.103 in workflows

### DIFF
--- a/.github/workflow-gen/Program.cs
+++ b/.github/workflow-gen/Program.cs
@@ -415,7 +415,7 @@ public static class StepExtensions
     public static void StepSetupDotNet(this Job job)
         => job.Step()
             .Name("Setup .NET")
-            .ActionsSetupDotNet("3e891b0cb619bf60e2c25674b222b8940e2c1c25", ["6.0.x", "8.0.x", "9.0.x"]); // v4.1.0
+            .ActionsSetupDotNet("3e891b0cb619bf60e2c25674b222b8940e2c1c25", ["6.0.x", "8.0.x", "9.0.103"]); // v4.1.0
 
     /// <summary>
     /// Only run this for a main build

--- a/.github/workflows/bff-ci.yml
+++ b/.github/workflows/bff-ci.yml
@@ -42,7 +42,7 @@ jobs:
         dotnet-version: |-
           6.0.x
           8.0.x
-          9.0.x
+          9.0.103
     - name: Restore
       run: dotnet restore bff.slnf
     - name: Verify Formatting

--- a/.github/workflows/bff-codeql-analysis.yml
+++ b/.github/workflows/bff-codeql-analysis.yml
@@ -41,7 +41,7 @@ jobs:
         dotnet-version: |-
           6.0.x
           8.0.x
-          9.0.x
+          9.0.103
     - name: Restore
       run: dotnet restore bff.slnf
     - name: Build

--- a/.github/workflows/bff-release.yml
+++ b/.github/workflows/bff-release.yml
@@ -64,7 +64,7 @@ jobs:
         dotnet-version: |-
           6.0.x
           8.0.x
-          9.0.x
+          9.0.103
     - name: Pack bff.slnf
       run: dotnet pack -c Release bff.slnf -o artifacts
     - name: Tool restore
@@ -104,7 +104,7 @@ jobs:
         dotnet-version: |-
           6.0.x
           8.0.x
-          9.0.x
+          9.0.103
     - name: List files
       run: tree
       shell: bash

--- a/.github/workflows/identity-server-ci.yml
+++ b/.github/workflows/identity-server-ci.yml
@@ -42,7 +42,7 @@ jobs:
         dotnet-version: |-
           6.0.x
           8.0.x
-          9.0.x
+          9.0.103
     - name: Restore
       run: dotnet restore identity-server.slnf
     - name: Verify Formatting

--- a/.github/workflows/identity-server-codeql-analysis.yml
+++ b/.github/workflows/identity-server-codeql-analysis.yml
@@ -41,7 +41,7 @@ jobs:
         dotnet-version: |-
           6.0.x
           8.0.x
-          9.0.x
+          9.0.103
     - name: Restore
       run: dotnet restore identity-server.slnf
     - name: Build

--- a/.github/workflows/identity-server-release.yml
+++ b/.github/workflows/identity-server-release.yml
@@ -64,7 +64,7 @@ jobs:
         dotnet-version: |-
           6.0.x
           8.0.x
-          9.0.x
+          9.0.103
     - name: Git tag
       run: |-
         git config --global user.email "github-bot@duendesoftware.com"
@@ -110,7 +110,7 @@ jobs:
         dotnet-version: |-
           6.0.x
           8.0.x
-          9.0.x
+          9.0.103
     - name: List files
       run: tree
       shell: bash

--- a/.github/workflows/templates-release.yml
+++ b/.github/workflows/templates-release.yml
@@ -34,7 +34,7 @@ jobs:
         dotnet-version: |-
           6.0.x
           8.0.x
-          9.0.x
+          9.0.103
     - name: Checkout target branch
       if: github.event.inputs.branch != 'main'
       run: git checkout ${{ github.event.inputs.branch }}
@@ -94,7 +94,7 @@ jobs:
         dotnet-version: |-
           6.0.x
           8.0.x
-          9.0.x
+          9.0.103
     - name: List files
       run: tree
       shell: bash


### PR DESCRIPTION
This pull request replaces the generic "9.0.x" with the explicit version "9.0.103" across multiple GitHub Actions workflows. The change ensures consistency, improves build reliability, and eliminates ambiguity regarding the .NET version used.