### PR TITLE
DefaultCache<T> should use a keyed lock instead of a global lock for each T

### DIFF
--- a/identity-server/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/identity-server/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -202,6 +202,7 @@ public static class IdentityServerBuilderExtensionsCore
         builder.Services.TryAddTransient<IBackchannelAuthenticationUserValidator, NopBackchannelAuthenticationUserValidator>();
 
         builder.Services.TryAddTransient(typeof(IConcurrencyLock<>), typeof(DefaultConcurrencyLock<>));
+        builder.Services.TryAddSingleton(typeof(IKeyedConcurrencyLock<>), typeof(DefaultKeyedConcurrencyLock<>));
 
         builder.Services.TryAddTransient<IClientStore, EmptyClientStore>();
         builder.Services.TryAddTransient<IResourceStore, EmptyResourceStore>();

--- a/identity-server/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/InMemory.cs
+++ b/identity-server/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/InMemory.cs
@@ -26,7 +26,7 @@ public static class IdentityServerBuilderExtensionsInMemory
     public static IIdentityServerBuilder AddInMemoryCaching(this IIdentityServerBuilder builder)
     {
         builder.Services.TryAddSingleton<IMemoryCache, MemoryCache>();
-        builder.Services.TryAddTransient(typeof(ICache<>), typeof(DefaultCache<>));
+        builder.Services.TryAddSingleton(typeof(ICache<>), typeof(DefaultCache<>));
 
         return builder;
     }

--- a/identity-server/src/IdentityServer/Infrastructure/ConcurrencyLock/DefaultKeyedConcurrencyLock.cs
+++ b/identity-server/src/IdentityServer/Infrastructure/ConcurrencyLock/DefaultKeyedConcurrencyLock.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+using System.Collections.Concurrent;
+
+namespace Duende.IdentityServer.Internal;
+
+/// <summary>
+/// Represents a default implementation of a keyed concurrency lock,
+/// allowing tasks to acquire and release locks based on specific keys.
+/// </summary>
+/// <typeparam name="T">The type associated with the keyed concurrency lock.</typeparam>
+public class DefaultKeyedConcurrencyLock<T> : IKeyedConcurrencyLock<T>
+{
+    readonly ConcurrentDictionary<string, SemaphoreSlim> _locks = new();
+
+    /// <inheritdoc/>
+    public Task<bool> LockAsync(string key, int millisecondsTimeout)
+    {
+        if (millisecondsTimeout <= 0)
+        {
+            throw new ArgumentException("millisecondsTimeout must be greater than zero.");
+        }
+
+        var semaphore = _locks.GetOrAdd(key, _ => new SemaphoreSlim(1, 1));
+        return semaphore.WaitAsync(millisecondsTimeout);
+    }
+
+    /// <inheritdoc/>
+    public void Unlock(string key)
+    {
+        if (_locks.TryGetValue(key, out var semaphore))
+        {
+            semaphore.Release();
+        }
+    }
+}

--- a/identity-server/src/IdentityServer/Infrastructure/ConcurrencyLock/IKeyedConcurrencyLock.cs
+++ b/identity-server/src/IdentityServer/Infrastructure/ConcurrencyLock/IKeyedConcurrencyLock.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+namespace Duende.IdentityServer.Internal;
+
+public interface IKeyedConcurrencyLock<T>
+{
+    /// <summary>
+    /// Attempts to acquire a concurrency lock for a specified key within a given timeout.
+    /// </summary>
+    /// <param name="key">The key associated with the lock to be acquired.</param>
+    /// <param name="millisecondsTimeout">The maximum time, in milliseconds, to wait for acquiring the lock.</param>
+    /// <returns>
+    /// A task that represents the asynchronous operation. The task result contains a boolean indicating
+    /// whether the lock was successfully acquired (true) or timed out (false).
+    /// </returns>
+    Task<bool> LockAsync(string key, int millisecondsTimeout);
+
+    /// <summary>
+    /// Releases the concurrency lock associated with the specified key.
+    /// </summary>
+    /// <param name="key">The key for which the lock should be released.</param>
+    void Unlock(string key);
+}

--- a/identity-server/src/IdentityServer/Services/Default/DefaultCache.cs
+++ b/identity-server/src/IdentityServer/Services/Default/DefaultCache.cs
@@ -32,7 +32,7 @@ public class DefaultCache<T> : ICache<T>
     /// <summary>
     /// A lock used for concurrency.
     /// </summary>
-    protected IConcurrencyLock<DefaultCache<T>> ConcurrencyLock { get; }
+    protected IKeyedConcurrencyLock<DefaultCache<T>> ConcurrencyLock { get; }
 
     /// <summary>
     /// The logger.
@@ -46,7 +46,7 @@ public class DefaultCache<T> : ICache<T>
     /// <param name="cache">The cache.</param>
     /// <param name="concurrencyLock"></param>
     /// <param name="logger">The logger.</param>
-    public DefaultCache(IdentityServerOptions identityServerOptions, IMemoryCache cache, IConcurrencyLock<DefaultCache<T>> concurrencyLock, ILogger<DefaultCache<T>> logger)
+    public DefaultCache(IdentityServerOptions identityServerOptions, IMemoryCache cache, IKeyedConcurrencyLock<DefaultCache<T>> concurrencyLock, ILogger<DefaultCache<T>> logger)
     {
         IdentityServerOptions = identityServerOptions;
         Cache = cache;
@@ -106,7 +106,7 @@ public class DefaultCache<T> : ICache<T>
 
         if (item == null)
         {
-            if (false == await ConcurrencyLock.LockAsync((int)IdentityServerOptions.Caching.CacheLockTimeout.TotalMilliseconds))
+            if (false == await ConcurrencyLock.LockAsync(GetKey(key), (int)IdentityServerOptions.Caching.CacheLockTimeout.TotalMilliseconds))
             {
                 throw new Exception($"Failed to obtain cache lock for: '{GetType()}'");
             }
@@ -135,7 +135,7 @@ public class DefaultCache<T> : ICache<T>
             }
             finally
             {
-                ConcurrencyLock.Unlock();
+                ConcurrencyLock.Unlock(GetKey(key));
             }
         }
         else

--- a/identity-server/test/IdentityServer.IntegrationTests/Hosting/CachingClientStoreTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Hosting/CachingClientStoreTests.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+using Duende.IdentityServer.IntegrationTests.TestFramework;
+using Duende.IdentityServer.Models;
+using Duende.IdentityServer.Stores;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace IdentityServer.IntegrationTests.Hosting;
+
+public class CachingClientStoreTests
+{
+    private GenericHost _host;
+
+    private class SlowClientStore : IClientStore
+    {
+        public async Task<Client> FindClientByIdAsync(string clientId)
+        {
+            await Task.Delay(TimeSpan.FromSeconds(1.5));
+            return new Client
+            {
+                ClientId = clientId,
+                ClientSecrets = { new Secret("secret".Sha256()) },
+                AllowedGrantTypes = GrantTypes.ClientCredentials,
+                AllowedScopes = { "scope1" },
+            };
+        }
+    }
+
+    public CachingClientStoreTests()
+    {
+        _host = new GenericHost("https://server");
+        _host.OnConfigureServices += services =>
+        {
+            services.AddRouting();
+
+            services.AddIdentityServer(options =>
+                {
+                    options.Caching.CacheLockTimeout = TimeSpan.FromSeconds(2);
+                })
+                .AddInMemoryIdentityResources(Array.Empty<IdentityResource>())
+                .AddInMemoryCaching()
+                .AddClientStoreCache<SlowClientStore>();
+        };
+        _host.OnConfigure += app =>
+        {
+            app.UseRouting();
+            app.UseIdentityServer();
+        };
+
+        _host.InitializeAsync().Wait();
+    }
+
+    [Fact]
+    public async Task does_not_throw_exception_failed_to_obtain_cache_lock()
+    {
+        var clientStore = _host.Resolve<IClientStore>();
+
+        // Queue up a good amount of concurrent access
+        await Parallel.ForAsync(1, Environment.ProcessorCount * 4, async (i, _) =>
+        {
+            var expectedClientId = $"client_{i % Environment.ProcessorCount}";
+            var client = await clientStore.FindClientByIdAsync(expectedClientId);
+
+            Assert.NotNull(client);
+            Assert.Equal(expectedClientId, client.ClientId);
+        });
+    }
+}


### PR DESCRIPTION
Debugging what seemed like a race condition resulted in discovering `DefaultCache<T>` locks globally instead of per cache key. Especially in the client stores this is an issue, as retrieving and trying to cache clientA results in requests for clientB having to wait for the lock to become available.

In addition ,we found that some dependencies were registered as transient where a longer lifetime makes more sense.

This PR serves as a discussion:
* Is locking per cache key better than locking the cache altogether?
* Do we want to expand lifetimes where we changed them in this PR?