### PR TITLE
Use `DefaultConcurrencyLock` as a Singleton instead of Transient.

### DIFF
--- a/identity-server/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/identity-server/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -201,7 +201,7 @@ public static class IdentityServerBuilderExtensionsCore
 
         builder.Services.TryAddTransient<IBackchannelAuthenticationUserValidator, NopBackchannelAuthenticationUserValidator>();
 
-        builder.Services.TryAddTransient(typeof(IConcurrencyLock<>), typeof(DefaultConcurrencyLock<>));
+        builder.Services.TryAddSingleton(typeof(IConcurrencyLock<>), typeof(DefaultConcurrencyLock<>));
 
         builder.Services.TryAddTransient<IClientStore, EmptyClientStore>();
         builder.Services.TryAddTransient<IResourceStore, EmptyResourceStore>();

--- a/identity-server/src/IdentityServer/Infrastructure/ConcurrencyLock/DefaultConcurrencyLock.cs
+++ b/identity-server/src/IdentityServer/Infrastructure/ConcurrencyLock/DefaultConcurrencyLock.cs
@@ -9,7 +9,7 @@ namespace Duende.IdentityServer.Internal;
 /// </summary>
 public class DefaultConcurrencyLock<T> : IConcurrencyLock<T>
 {
-    static readonly SemaphoreSlim Lock = new SemaphoreSlim(1);
+    readonly SemaphoreSlim Lock = new SemaphoreSlim(1);
 
     /// <inheritdoc/>
     public Task<bool> LockAsync(int millisecondsTimeout)


### PR DESCRIPTION
Changed the DI registration of `IConcurrencyLock<>` to Singleton to ensure consistent state for `SemaphoreSlim` locks. Also removed the static modifier from `SemaphoreSlim` to align its lifecycle with the class instance.