### PR TITLE
Introduce the `StrictClientAssertionAudienceValidation` preview feature

### DIFF
--- a/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
+++ b/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
@@ -70,11 +70,6 @@ public class IdentityServerOptions
     public bool StrictJarValidation { get; set; } = false;
 
     /// <summary>
-    /// When clients authenticate with private_key_jwt assertions, validate the audience of the assertion strictly: the audience must be this IdentityServer's issuer identifier as a single string.
-    /// </summary>
-    public bool StrictClientAssertionAudienceValidation { get; set; } = false;
-
-    /// <summary>
     /// Specifies if a user's tenant claim is compared to the tenant acr_values parameter value to determine if the login page is displayed. Defaults to false.
     /// </summary>
     public bool ValidateTenantOnAuthorization { get; set; } = false;

--- a/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/PreviewFeatureOptions.cs
+++ b/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/PreviewFeatureOptions.cs
@@ -2,10 +2,9 @@
 // See LICENSE in the project root for license information.
 
 using System.Diagnostics.CodeAnalysis;
+using System;
 
 namespace Duende.IdentityServer.Configuration;
-
-using System;
 
 /// <summary>
 /// Provides configuration options for enabling and managing preview features in IdentityServer.
@@ -17,6 +16,12 @@ public class PreviewFeatureOptions
     /// </summary>
     [Experimental("DUENDEPREVIEW001", UrlFormat = "https://duende.link/previewfeatures?id={0}")]
     public bool EnableDiscoveryDocumentCache { get; set; } = false;
+
+    /// <summary>
+    /// When clients authenticate with private_key_jwt assertions, validate the audience of the assertion strictly: the audience must be this IdentityServer's issuer identifier as a single string.
+    /// </summary>
+    [Experimental("DUENDEPREVIEW002", UrlFormat = "https://duende.link/previewfeatures?id={0}")]
+    public bool StrictClientAssertionAudienceValidation { get; set; } = false;
 
     /// <summary>
     /// DiscoveryDocument Cache Duration

--- a/identity-server/src/IdentityServer/IdentityServerConstants.cs
+++ b/identity-server/src/IdentityServer/IdentityServerConstants.cs
@@ -68,6 +68,7 @@ public static class IdentityServerConstants
         public const string SharedSecret = "SharedSecret";
         public const string X509Certificate = "X509Certificate";
         public const string JwtBearer = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+        public const string ClientAuthenticationJwt = "client-authentication+jwt";
     }
 
     public static class SecretTypes

--- a/identity-server/src/IdentityServer/IdentityServerConstants.cs
+++ b/identity-server/src/IdentityServer/IdentityServerConstants.cs
@@ -68,7 +68,6 @@ public static class IdentityServerConstants
         public const string SharedSecret = "SharedSecret";
         public const string X509Certificate = "X509Certificate";
         public const string JwtBearer = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
-        public const string ClientAuthenticationJwt = "client-authentication+jwt";
     }
 
     public static class SecretTypes

--- a/identity-server/src/IdentityServer/Validation/Default/PrivateKeyJwtSecretValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/Default/PrivateKeyJwtSecretValidator.cs
@@ -66,12 +66,12 @@ public class PrivateKeyJwtSecretValidator : ISecretValidator
         // Decide whether to enforce strict audience validation or not.
         var enforceStrictAud = _options.Preview.StrictClientAssertionAudienceValidation;
 
-        if (enforceStrictAud && parsedSecret.Type != "client-authentication+jwt")
+        if (enforceStrictAud && parsedSecret.Type != ParsedSecretTypes.ClientAuthenticationJwt)
         {
             return fail;
         }
 
-        if (parsedSecret.Type != ParsedSecretTypes.JwtBearer && parsedSecret.Type != "client-authentication+jwt")
+        if (parsedSecret.Type != ParsedSecretTypes.JwtBearer && parsedSecret.Type != ParsedSecretTypes.ClientAuthenticationJwt)
         {
             return fail;
         }
@@ -101,7 +101,7 @@ public class PrivateKeyJwtSecretValidator : ISecretValidator
 
         // If strict mode is not enabled by option but the type value "client-authentication+jwt" is provided,
         // enforce strict audience validation.
-        if (string.Equals(parsedSecret.Type, "client-authentication+jwt", StringComparison.OrdinalIgnoreCase))
+        if (string.Equals(parsedSecret.Type, ParsedSecretTypes.ClientAuthenticationJwt, StringComparison.OrdinalIgnoreCase))
         {
             enforceStrictAud = true;
         }

--- a/identity-server/src/IdentityServer/Validation/Default/PrivateKeyJwtSecretValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/Default/PrivateKeyJwtSecretValidator.cs
@@ -145,7 +145,7 @@ public class PrivateKeyJwtSecretValidator : ISecretValidator
                        AudiencesMatch(audString, issuer);
             };
 
-            // Strict audience validation requires that the token type be "JWT"
+            // Strict audience validation requires that the token type be "client-authentication+jwt"
             tokenValidationParameters.ValidTypes = ["client-authentication+jwt"];
         }
         else

--- a/identity-server/src/IdentityServer/Validation/Default/PrivateKeyJwtSecretValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/Default/PrivateKeyJwtSecretValidator.cs
@@ -1,18 +1,20 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
+// Supress the warning for the preview feature `Preview.StrictClientAssertionAudienceValidation`
+#pragma warning disable DUENDEPREVIEW002
 
+using Duende.IdentityServer.Configuration;
+using Duende.IdentityServer.Extensions;
+using Duende.IdentityServer.Models;
+using Duende.IdentityServer.Services;
+using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Duende.IdentityServer.Configuration;
-using Duende.IdentityServer.Models;
-using Duende.IdentityServer.Services;
-using Duende.IdentityServer.Extensions;
-using Microsoft.Extensions.Logging;
-using Microsoft.IdentityModel.JsonWebTokens;
-using Microsoft.IdentityModel.Tokens;
 using static Duende.IdentityServer.IdentityServerConstants;
 
 namespace Duende.IdentityServer.Validation;
@@ -34,7 +36,7 @@ public class PrivateKeyJwtSecretValidator : ISecretValidator
     /// Instantiates an instance of private_key_jwt secret validator
     /// </summary>
     public PrivateKeyJwtSecretValidator(
-        IIssuerNameService issuerNameService, 
+        IIssuerNameService issuerNameService,
         IReplayCache replayCache,
         IServerUrls urls,
         IdentityServerOptions options,
@@ -91,6 +93,29 @@ public class PrivateKeyJwtSecretValidator : ISecretValidator
 
         var issuer = await _issuerNameService.GetCurrentAsync();
 
+        // Decide whether to enforce strict audience validation or not.
+        var enforceStrictAud = _options.Preview.StrictClientAssertionAudienceValidation;
+
+        try
+        {
+            // Read the token so we can get the "typ" header value if it exists.
+            var handlerForHeader = new JsonWebTokenHandler();
+            var tokenForHeader = handlerForHeader.ReadJsonWebToken(jwtTokenString);
+            var jwtTyp = tokenForHeader.GetHeaderValue<string>("typ");
+
+            // If strict mode is not enabled by option but the "typ" header value "client-authentication+jwt" is provided,
+            // enforce strict audience validation.
+            if (string.Equals(jwtTyp, "client-authentication+jwt", StringComparison.OrdinalIgnoreCase) && !enforceStrictAud)
+            {
+                enforceStrictAud = true;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error reading JWT header.");
+            return fail;
+        }
+
         var tokenValidationParameters = new TokenValidationParameters
         {
             IssuerSigningKeys = trustedKeys,
@@ -98,14 +123,14 @@ public class PrivateKeyJwtSecretValidator : ISecretValidator
 
             ValidIssuer = parsedSecret.Id,
             ValidateIssuer = true,
-            
+
             RequireSignedTokens = true,
             RequireExpirationTime = true,
 
             ClockSkew = TimeSpan.FromMinutes(5)
         };
-        
-        if (_options.StrictClientAssertionAudienceValidation)
+
+        if (enforceStrictAud)
         {
             // New strict audience validation requires that the audience be the issuer identifier, disallows multiple
             // audiences in an array, and even disallows wrapping even a single audience in an array 
@@ -122,6 +147,7 @@ public class PrivateKeyJwtSecretValidator : ISecretValidator
         }
         else
         {
+            // Legacy behavior with a set of allowed audiences.
             tokenValidationParameters.ValidateAudience = true;
             tokenValidationParameters.ValidAudiences = new[]
             {
@@ -135,7 +161,7 @@ public class PrivateKeyJwtSecretValidator : ISecretValidator
                 string.Concat(_urls.BaseUrl.EnsureTrailingSlash(), ProtocolRoutePaths.BackchannelAuthentication),
                 // PAR endpoint: https://datatracker.ietf.org/doc/html/rfc9126#name-request
                 string.Concat(_urls.BaseUrl.EnsureTrailingSlash(), ProtocolRoutePaths.PushedAuthorization),
-            
+
             }.Distinct();
         }
 
@@ -180,7 +206,7 @@ public class PrivateKeyJwtSecretValidator : ISecretValidator
 
         return success;
     }
-    
+
     // AudiencesMatch and AudiencesMatchIgnoringTrailingSlash are based on code from 
     // https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/bef98ca10ae55603ce6d37dfb7cd5af27791527c/src/Microsoft.IdentityModel.Tokens/Validators.cs#L158-L193
     private bool AudiencesMatch(string tokenAudience, string validAudience)
@@ -195,7 +221,7 @@ public class PrivateKeyJwtSecretValidator : ISecretValidator
 
         return AudiencesMatchIgnoringTrailingSlash(tokenAudience, validAudience);
     }
-            
+
     private bool AudiencesMatchIgnoringTrailingSlash(string tokenAudience, string validAudience)
     {
         int length = -1;

--- a/identity-server/test/IdentityServer.UnitTests/Validation/Secrets/PrivateKeyJwtSecretValidation.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Validation/Secrets/PrivateKeyJwtSecretValidation.cs
@@ -263,12 +263,11 @@ public class PrivateKeyJwtSecretValidation
         var clientId = "certificate_base64_valid";
         var client = await _clients.FindEnabledClientByIdAsync(clientId);
         var token = new JwtSecurityTokenHandler().WriteToken(CreateToken(clientId));
-
         var secret = new ParsedSecret
         {
             Id = clientId,
             Credential = token,
-            Type = "client-authentication+jwt"
+            Type = IdentityServerConstants.ParsedSecretTypes.JwtBearer
         };
 
         var result = await _validator.ValidateAsync(client.ClientSecrets, secret);

--- a/identity-server/test/IdentityServer.UnitTests/Validation/Secrets/PrivateKeyJwtSecretValidation.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Validation/Secrets/PrivateKeyJwtSecretValidation.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
+// Supress the warning for the preview feature `Preview.StrictClientAssertionAudienceValidation`
+#pragma warning disable DUENDEPREVIEW002
 
 using System;
 using System.Collections.Generic;
@@ -168,8 +170,8 @@ public class PrivateKeyJwtSecretValidation
     [InlineData("https://idsrv.com/connect/par", false)]
     public async Task Valid_strict_aud(string aud, bool expectSuccess)
     {
-        _options.StrictClientAssertionAudienceValidation = true;
-        
+        _options.Preview.StrictClientAssertionAudienceValidation = true;
+
         var clientId = "certificate_base64_valid";
         var client = await _clients.FindEnabledClientByIdAsync(clientId);
 
@@ -193,8 +195,8 @@ public class PrivateKeyJwtSecretValidation
     [InlineData("https://idsrv.com/connect/par")]
     public async Task StrictAudience_does_not_allow_single_valued_arrays(string aud)
     {
-        _options.StrictClientAssertionAudienceValidation = true;
-        
+        _options.Preview.StrictClientAssertionAudienceValidation = true;
+
         var clientId = "certificate_base64_valid";
         var client = await _clients.FindEnabledClientByIdAsync(clientId);
         
@@ -213,8 +215,8 @@ public class PrivateKeyJwtSecretValidation
     [Fact]
     public async Task StrictAudience_does_not_allow_multi_valued_arrays()
     {
-        _options.StrictClientAssertionAudienceValidation = true;
-        
+        _options.Preview.StrictClientAssertionAudienceValidation = true;
+
         var clientId = "certificate_base64_valid";
         var client = await _clients.FindEnabledClientByIdAsync(clientId);
         

--- a/identity-server/test/IdentityServer.UnitTests/Validation/Secrets/PrivateKeyJwtSecretValidation.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Validation/Secrets/PrivateKeyJwtSecretValidation.cs
@@ -234,8 +234,8 @@ public class PrivateKeyJwtSecretValidation
     }
 
     [Theory]
-    [InlineData("client-authentication+jwt", true, true)]
-    [InlineData("client-authentication+jwt", false, true)]
+    [InlineData(IdentityServerConstants.ParsedSecretTypes.ClientAuthenticationJwt, true, true)]
+    [InlineData(IdentityServerConstants.ParsedSecretTypes.ClientAuthenticationJwt, false, true)]
     [InlineData(IdentityServerConstants.ParsedSecretTypes.JwtBearer, true, false)]
     [InlineData(IdentityServerConstants.ParsedSecretTypes.JwtBearer, false, true)]
     public async Task StrictAudience_only_allows_correct_type(string type, bool setStrict, bool expectedResult)


### PR DESCRIPTION
**What issue does this PR address?**
This PR introduces the new `StrictClientAssertionAudienceValidation` preview flag.
The preview will enable users to optionally enforce a `typ` header requirement for client authentication jwts while also allowing clients to voluntarily opt into strict validation by setting the `typ` header value to `client-authentication+jwt`.

**Setting the flag within the IdentityServer host configuration**
In a typical IdentityServer host, users may set the preview flag through `options.Preview` feature flags, for example;
```csharp
builder.Services.AddIdentityServer(options =>
{
      options.Preview.StrictClientAssertionAudienceValidation = true;
})
```
Setting this flag will mean that when clients authenticate with private_key_jwt assertions, IdentityServer will validate the audience of the assertion strictly, ie; the audience must be this IdentityServer's issuer identifier as a single string.

**Important: Any code or remarks in your Pull Request are under the following terms:**
If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
