### PR TITLE
Remove server polling interval

### DIFF
--- a/bff/src/Bff.Blazor.Client/BffBlazorOptions.cs
+++ b/bff/src/Bff.Blazor.Client/BffBlazorOptions.cs
@@ -38,17 +38,4 @@ public class BffBlazorOptions
     /// ms.
     /// </summary>
     public int WebAssemblyStateProviderPollingInterval { get; set; } = 5000;
-
-    /// <summary>
-    /// The delay, in milliseconds, before the BffServerAuthenticationStateProvider will
-    /// start polling the /bff/user endpoint. Defaults to 1000 ms.
-    /// </summary>
-    public int ServerStateProviderPollingDelay { get; set; } = 1000;
-
-    /// <summary>
-    /// The delay, in milliseconds, between polling requests by the
-    /// BffServerAuthenticationStateProvider to the /bff/user endpoint. Defaults to 5000
-    /// ms.
-    /// </summary>
-    public int ServerStateProviderPollingInterval { get; set; } = 5000;
 }

--- a/identity-server/aspire/aspire.orchestrator/aspire.orchestrator.AppHost/aspire.orchestrator.AppHost.v3.ncrunchproject
+++ b/identity-server/aspire/aspire.orchestrator/aspire.orchestrator.AppHost/aspire.orchestrator.AppHost.v3.ncrunchproject
@@ -1,0 +1,5 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <IgnoreThisComponentCompletely>True</IgnoreThisComponentCompletely>
+  </Settings>
+</ProjectConfiguration>


### PR DESCRIPTION
**What issue does this PR address?**
The server polling interval is no longer needed. 

fixes: https://github.com/DuendeSoftware/products/issues/1864

**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
