### PR TITLE
set root editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,5 @@
+root = true
+
 [*]
 charset = utf-8
 indent_size = 2


### PR DESCRIPTION
**What issue does this PR address?**

We should really set this as the root, otherwise:

> EditorConfig plugins look for a file named .editorconfig (all lowercase) in the directory of the opened file and in every parent directory

_— <https://editorconfig.org/#file-location>_