### PR TITLE
Use correct option to validate "Remember Me"

### DIFF
--- a/identity-server/hosts/AspNetIdentity/Pages/Account/Login/Index.cshtml.cs
+++ b/identity-server/hosts/AspNetIdentity/Pages/Account/Login/Index.cshtml.cs
@@ -98,7 +98,7 @@ public class Index : PageModel
         if (ModelState.IsValid)
         {
             // Only remember login if allowed
-            var rememberLogin = View.AllowRememberLogin && Input.RememberLogin;
+            var rememberLogin = LoginOptions.AllowRememberLogin && Input.RememberLogin;
 
             var result = await _signInManager.PasswordSignInAsync(Input.Username!, Input.Password!, isPersistent: rememberLogin, lockoutOnFailure: true);
             if (result.Succeeded)

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Account/Login/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Account/Login/Index.cshtml.cs
@@ -95,7 +95,7 @@ public class Index : PageModel
         if (ModelState.IsValid)
         {
             // Only remember login if allowed
-            var rememberLogin = View.AllowRememberLogin && Input.RememberLogin;
+            var rememberLogin = LoginOptions.AllowRememberLogin && Input.RememberLogin;
 
             var result = await _signInManager.PasswordSignInAsync(Input.Username!, Input.Password!, isPersistent: rememberLogin, lockoutOnFailure: true);
             if (result.Succeeded)


### PR DESCRIPTION
**What issue does this PR address?**
Uses the correct option (`LoginOptions.AllowRememberLogin`) to validate whether Remember Me should be allowed and used, instead of relying on the `View` model as it could be `null`, breaking the login.

**Important: Any code or remarks in your Pull Request are under the following terms:**
If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
