### PR TITLE
move serveroptions to server project

### DIFF
--- a/bff/src/Bff.Blazor/BffBlazorServerOptions.cs
+++ b/bff/src/Bff.Blazor/BffBlazorServerOptions.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
-namespace Duende.Bff.Blazor.Client;
+namespace Duende.Bff.Blazor;
 
 /// <summary>
 /// Options for Blazor BFF on the server. 

--- a/bff/src/Bff.Blazor/BffBuilderExtensions.cs
+++ b/bff/src/Bff.Blazor/BffBuilderExtensions.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
-using Duende.Bff.Blazor.Client;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Components.Authorization;

--- a/bff/src/Bff.Blazor/BffServerAuthenticationStateProvider.cs
+++ b/bff/src/Bff.Blazor/BffServerAuthenticationStateProvider.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using System.Security.Claims;
-using Duende.Bff.Blazor.Client;
 using Duende.IdentityModel;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Authorization;


### PR DESCRIPTION
**What issue does this PR address?**

Moved BffServerOptions from the 'client' project to the Bff.Blazor project.

**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
