### PR TITLE
EditorConfig: Enforce that 'this.' should not be used when it's redundant

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,3 +20,6 @@ file_header_template = Copyright (c) Duende Software. All rights reserved.\nSee 
 
 dotnet_diagnostic.IDE0161.severity = error  # Use file-scoped namespace
 csharp_style_namespace_declarations = file_scoped
+
+dotnet_diagnostic.IDE0003.severity = error # Enforce that 'this.' should not be used when it's redundant
+

--- a/.editorconfig
+++ b/.editorconfig
@@ -27,7 +27,7 @@ csharp_style_namespace_declarations = file_scoped
 
 # Remove this or Me qualification
 dotnet_diagnostic.IDE0003.severity = error
-dotnet_style_qualification_for_field = false:error
-dotnet_style_qualification_for_property = false:error
-dotnet_style_qualification_for_method = false:error
 dotnet_style_qualification_for_event = false:error
+dotnet_style_qualification_for_field = false:error
+dotnet_style_qualification_for_method = false:error
+dotnet_style_qualification_for_property = false:error

--- a/.editorconfig
+++ b/.editorconfig
@@ -25,7 +25,8 @@ file_header_template = Copyright (c) Duende Software. All rights reserved.\nSee 
 dotnet_diagnostic.IDE0161.severity = error  
 csharp_style_namespace_declarations = file_scoped
 
-dotnet_diagnostic.IDE0003.severity = error # Enforce that 'this.' should not be used when it's redundant
+# Remove this or Me qualification
+dotnet_diagnostic.IDE0003.severity = error
 dotnet_style_qualification_for_field = false:error
 dotnet_style_qualification_for_property = false:error
 dotnet_style_qualification_for_method = false:error

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,16 +10,23 @@ insert_final_newline = true
 
 indent_size = 4
 
-dotnet_diagnostic.IDE0005.severity = warning  # Remove unnecessary using directives
+# Remove unnecessary using directives
+dotnet_diagnostic.IDE0005.severity = warning
 
-dotnet_diagnostic.IDE0055.severity = warning  # Formatting rule
+ # Formatting rule
+dotnet_diagnostic.IDE0055.severity = warning 
 dotnet_sort_system_directives_first = true
 
-dotnet_diagnostic.IDE0073.severity = warning  # Require file header
+# Require file header
+dotnet_diagnostic.IDE0073.severity = warning  
 file_header_template = Copyright (c) Duende Software. All rights reserved.\nSee LICENSE in the project root for license information.
 
-dotnet_diagnostic.IDE0161.severity = error  # Use file-scoped namespace
+# Use file-scoped namespace
+dotnet_diagnostic.IDE0161.severity = error  
 csharp_style_namespace_declarations = file_scoped
 
 dotnet_diagnostic.IDE0003.severity = error # Enforce that 'this.' should not be used when it's redundant
-
+dotnet_style_qualification_for_field = false:error
+dotnet_style_qualification_for_property = false:error
+dotnet_style_qualification_for_method = false:error
+dotnet_style_qualification_for_event = false:error

--- a/.editorconfig
+++ b/.editorconfig
@@ -7,8 +7,14 @@ indent_style = space
 insert_final_newline = true
 
 [*.cs]
-
 indent_size = 4
+
+# Remove this or Me qualification
+dotnet_diagnostic.IDE0003.severity = error
+dotnet_style_qualification_for_event = false:error
+dotnet_style_qualification_for_field = false:error
+dotnet_style_qualification_for_method = false:error
+dotnet_style_qualification_for_property = false:error
 
 # Remove unnecessary using directives
 dotnet_diagnostic.IDE0005.severity = warning
@@ -24,10 +30,3 @@ file_header_template = Copyright (c) Duende Software. All rights reserved.\nSee 
 # Use file-scoped namespace
 dotnet_diagnostic.IDE0161.severity = error  
 csharp_style_namespace_declarations = file_scoped
-
-# Remove this or Me qualification
-dotnet_diagnostic.IDE0003.severity = error
-dotnet_style_qualification_for_event = false:error
-dotnet_style_qualification_for_field = false:error
-dotnet_style_qualification_for_method = false:error
-dotnet_style_qualification_for_property = false:error

--- a/bff/src/Bff/EndpointProcessing/BffUserAccessTokenParameters.cs
+++ b/bff/src/Bff/EndpointProcessing/BffUserAccessTokenParameters.cs
@@ -57,10 +57,10 @@ public class BffUserAccessTokenParameters
     {
         return new UserTokenRequestParameters()
         {
-            SignInScheme = this.SignInScheme,
-            ChallengeScheme = this.ChallengeScheme,
-            ForceRenewal = this.ForceRenewal,
-            Resource = this.Resource
+            SignInScheme = SignInScheme,
+            ChallengeScheme = ChallengeScheme,
+            ForceRenewal = ForceRenewal,
+            Resource = Resource
         };
     }
 }

--- a/bff/test/Bff.Tests/TestFramework/GenericHost.cs
+++ b/bff/test/Bff.Tests/TestFramework/GenericHost.cs
@@ -73,9 +73,9 @@ public class GenericHost(WriteTestOutput writeOutput, string baseAddress = "http
 
         Server = host.GetTestServer();
         BrowserClient = new TestBrowserClient(Server.CreateHandler());
-        BrowserClient.BaseAddress = new Uri(this._baseAddress);
+        BrowserClient.BaseAddress = new Uri(_baseAddress);
         HttpClient = Server.CreateClient();
-        BrowserClient.BaseAddress = new Uri(this._baseAddress);
+        BrowserClient.BaseAddress = new Uri(_baseAddress);
     }
 
     public event Action<IServiceCollection> OnConfigureServices = _ => { };

--- a/bff/test/Hosts.Tests/TestInfra/AppHostFixture.cs
+++ b/bff/test/Hosts.Tests/TestInfra/AppHostFixture.cs
@@ -259,7 +259,7 @@ public class AppHostFixture : IAsyncLifetime
         {
 #if !DEBUG_NCRUNCH
             if (_app == null) throw new NullReferenceException("App should not be null");
-            return this._app.GetEndpoint(clientName);
+            return _app.GetEndpoint(clientName);
 #else
             Skip.If(true, "When running the Host.Tests using NCrunch, you must start the Hosts.AppHost project manually. IE: dotnet run -p bff/samples/Hosts.AppHost. Or start without debugging from the UI. ");
             return null!;


### PR DESCRIPTION
**What issue does this PR address?**

Enforce that 'this.' should not be used when it's redundant.

This PR is stacked on #1869 and will be rebased when that is merged.

**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
