### PR TITLE
EditorConfig: Enforce using built-in type keywords (e.g., 'string' instead of 'String')

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,6 +19,11 @@ dotnet_style_qualification_for_property = false:error
 # Remove unnecessary using directives
 dotnet_diagnostic.IDE0005.severity = warning
 
+# Use language keywords instead of framework type names for type references 
+dotnet_diagnostic.IDE0049.severity = error
+dotnet_style_predefined_type_for_locals_parameters_members = true
+dotnet_style_predefined_type_for_member_access = true
+
  # Formatting rule
 dotnet_diagnostic.IDE0055.severity = warning 
 dotnet_sort_system_directives_first = true

--- a/bff/hosts/Hosts.IdentityServer/Pages/Account/Login/ViewModel.cs
+++ b/bff/hosts/Hosts.IdentityServer/Pages/Account/Login/ViewModel.cs
@@ -10,7 +10,7 @@ public class ViewModel
     public bool EnableLocalLogin { get; set; } = true;
 
     public IEnumerable<ViewModel.ExternalProvider> ExternalProviders { get; set; } = Enumerable.Empty<ExternalProvider>();
-    public IEnumerable<ViewModel.ExternalProvider> VisibleExternalProviders => ExternalProviders.Where(x => !String.IsNullOrWhiteSpace(x.DisplayName));
+    public IEnumerable<ViewModel.ExternalProvider> VisibleExternalProviders => ExternalProviders.Where(x => !string.IsNullOrWhiteSpace(x.DisplayName));
 
     public bool IsExternalLoginOnly => EnableLocalLogin == false && ExternalProviders?.Count() == 1;
     public string ExternalLoginScheme => IsExternalLoginOnly ? ExternalProviders?.SingleOrDefault()?.AuthenticationScheme : null;

--- a/bff/hosts/Hosts.IdentityServer/Pages/Account/Logout/LoggedOut.cshtml.cs
+++ b/bff/hosts/Hosts.IdentityServer/Pages/Account/Logout/LoggedOut.cshtml.cs
@@ -29,7 +29,7 @@ public class LoggedOut : PageModel
         {
             AutomaticRedirectAfterSignOut = LogoutOptions.AutomaticRedirectAfterSignOut,
             PostLogoutRedirectUri = logout?.PostLogoutRedirectUri,
-            ClientName = String.IsNullOrEmpty(logout?.ClientName) ? logout?.ClientId : logout?.ClientName,
+            ClientName = string.IsNullOrEmpty(logout?.ClientName) ? logout?.ClientId : logout?.ClientName,
             SignOutIframeUrl = logout?.SignOutIFrameUrl
         };
     }

--- a/bff/hosts/Hosts.IdentityServer/Pages/Ciba/Consent.cshtml.cs
+++ b/bff/hosts/Hosts.IdentityServer/Pages/Ciba/Consent.cshtml.cs
@@ -193,7 +193,7 @@ public class Consent : PageModel
     public ScopeViewModel CreateScopeViewModel(ParsedScopeValue parsedScopeValue, ApiScope apiScope, bool check)
     {
         var displayName = apiScope.DisplayName ?? apiScope.Name;
-        if (!String.IsNullOrWhiteSpace(parsedScopeValue.ParsedParameter))
+        if (!string.IsNullOrWhiteSpace(parsedScopeValue.ParsedParameter))
         {
             displayName += ":" + parsedScopeValue.ParsedParameter;
         }

--- a/bff/hosts/Hosts.IdentityServer/Pages/Consent/Index.cshtml.cs
+++ b/bff/hosts/Hosts.IdentityServer/Pages/Consent/Index.cshtml.cs
@@ -199,7 +199,7 @@ public class Index : PageModel
     public ScopeViewModel CreateScopeViewModel(ParsedScopeValue parsedScopeValue, ApiScope apiScope, bool check)
     {
         var displayName = apiScope.DisplayName ?? apiScope.Name;
-        if (!String.IsNullOrWhiteSpace(parsedScopeValue.ParsedParameter))
+        if (!string.IsNullOrWhiteSpace(parsedScopeValue.ParsedParameter))
         {
             displayName += ":" + parsedScopeValue.ParsedParameter;
         }

--- a/bff/hosts/Hosts.IdentityServer/Pages/Device/Index.cshtml.cs
+++ b/bff/hosts/Hosts.IdentityServer/Pages/Device/Index.cshtml.cs
@@ -43,7 +43,7 @@ public class Index : PageModel
 
     public async Task<IActionResult> OnGet(string userCode)
     {
-        if (String.IsNullOrWhiteSpace(userCode))
+        if (string.IsNullOrWhiteSpace(userCode))
         {
             View = new ViewModel();
             Input = new InputModel();

--- a/bff/hosts/RemoteApis/Hosts.RemoteApi.DPoP/DPoP/DPoPProofValidator.cs
+++ b/bff/hosts/RemoteApis/Hosts.RemoteApi.DPoP/DPoP/DPoPProofValidator.cs
@@ -52,7 +52,7 @@ public class DPoPProofValidator
 
         try
         {
-            if (String.IsNullOrEmpty(context?.ProofToken))
+            if (string.IsNullOrEmpty(context?.ProofToken))
             {
                 result.IsError = true;
                 result.ErrorDescription = "Missing DPoP proof value.";
@@ -214,7 +214,7 @@ public class DPoPProofValidator
             result.AccessTokenHash = ath as string;
         }
 
-        if (String.IsNullOrEmpty(result.AccessTokenHash))
+        if (string.IsNullOrEmpty(result.AccessTokenHash))
         {
             result.IsError = true;
             result.ErrorDescription = "Invalid 'ath' value.";
@@ -240,7 +240,7 @@ public class DPoPProofValidator
             result.TokenId = jti as string;
         }
 
-        if (String.IsNullOrEmpty(result.TokenId))
+        if (string.IsNullOrEmpty(result.TokenId))
         {
             result.IsError = true;
             result.ErrorDescription = "Invalid 'jti' value.";
@@ -385,7 +385,7 @@ public class DPoPProofValidator
     /// </summary>
     protected virtual async Task ValidateNonceAsync(DPoPProofValidatonContext context, DPoPProofValidatonResult result)
     {
-        if (String.IsNullOrWhiteSpace(result.Nonce))
+        if (string.IsNullOrWhiteSpace(result.Nonce))
         {
             result.IsError = true;
             result.Error = OidcConstants.TokenErrors.UseDPoPNonce;
@@ -437,7 +437,7 @@ public class DPoPProofValidator
         try
         {
             var value = DataProtector.Unprotect(result.Nonce);
-            if (Int64.TryParse(value, out long iat))
+            if (long.TryParse(value, out long iat))
             {
                 return ValueTask.FromResult(iat);
             }

--- a/bff/src/Bff.EntityFramework/Database/ModelBuilderExtensions.cs
+++ b/bff/src/Bff.EntityFramework/Database/ModelBuilderExtensions.cs
@@ -15,7 +15,7 @@ public static class ModelBuilderExtensions
     private static EntityTypeBuilder<TEntity> ToTable<TEntity>(this EntityTypeBuilder<TEntity> entityTypeBuilder, TableConfiguration configuration)
         where TEntity : class
     {
-        return String.IsNullOrWhiteSpace(configuration.Schema) ?
+        return string.IsNullOrWhiteSpace(configuration.Schema) ?
             entityTypeBuilder.ToTable(configuration.Name) :
             entityTypeBuilder.ToTable(configuration.Name, configuration.Schema);
     }
@@ -27,7 +27,7 @@ public static class ModelBuilderExtensions
     /// <param name="storeOptions">The store options.</param>
     public static void ConfigureSessionContext(this ModelBuilder modelBuilder, SessionStoreOptions storeOptions)
     {
-        if (!String.IsNullOrWhiteSpace(storeOptions.DefaultSchema))
+        if (!string.IsNullOrWhiteSpace(storeOptions.DefaultSchema))
         {
             modelBuilder.HasDefaultSchema(storeOptions.DefaultSchema);
         }

--- a/bff/src/Bff.EntityFramework/Store/UserSessionStore.cs
+++ b/bff/src/Bff.EntityFramework/Store/UserSessionStore.cs
@@ -112,17 +112,17 @@ public class UserSessionStore : IUserSessionStore, IUserSessionStoreCleanup
         filter.Validate();
 
         var query = _sessionDbContext.UserSessions.Where(x => x.ApplicationName == _applicationDiscriminator).AsQueryable();
-        if (!String.IsNullOrWhiteSpace(filter.SubjectId))
+        if (!string.IsNullOrWhiteSpace(filter.SubjectId))
         {
             query = query.Where(x => x.SubjectId == filter.SubjectId);
         }
-        if (!String.IsNullOrWhiteSpace(filter.SessionId))
+        if (!string.IsNullOrWhiteSpace(filter.SessionId))
         {
             query = query.Where(x => x.SessionId == filter.SessionId);
         }
 
         var items = await query.Where(x => x.ApplicationName == _applicationDiscriminator).ToArrayAsync(cancellationToken);
-        if (!String.IsNullOrWhiteSpace(filter.SubjectId))
+        if (!string.IsNullOrWhiteSpace(filter.SubjectId))
         {
             items = items.Where(x => x.SubjectId == filter.SubjectId).ToArray();
         }
@@ -181,21 +181,21 @@ public class UserSessionStore : IUserSessionStore, IUserSessionStoreCleanup
         filter.Validate();
 
         var query = _sessionDbContext.UserSessions.Where(x => x.ApplicationName == _applicationDiscriminator).AsQueryable();
-        if (!String.IsNullOrWhiteSpace(filter.SubjectId))
+        if (!string.IsNullOrWhiteSpace(filter.SubjectId))
         {
             query = query.Where(x => x.SubjectId == filter.SubjectId);
         }
-        if (!String.IsNullOrWhiteSpace(filter.SessionId))
+        if (!string.IsNullOrWhiteSpace(filter.SessionId))
         {
             query = query.Where(x => x.SessionId == filter.SessionId);
         }
 
         var items = await query.Where(x => x.ApplicationName == _applicationDiscriminator).ToArrayAsync(cancellationToken);
-        if (!String.IsNullOrWhiteSpace(filter.SubjectId))
+        if (!string.IsNullOrWhiteSpace(filter.SubjectId))
         {
             items = items.Where(x => x.SubjectId == filter.SubjectId).ToArray();
         }
-        if (!String.IsNullOrWhiteSpace(filter.SessionId))
+        if (!string.IsNullOrWhiteSpace(filter.SessionId))
         {
             items = items.Where(x => x.SessionId == filter.SessionId).ToArray();
         }

--- a/bff/src/Bff/EndpointServices/BackchannelLogout/DefaultBackchannelLogoutService.cs
+++ b/bff/src/Bff/EndpointServices/BackchannelLogout/DefaultBackchannelLogoutService.cs
@@ -73,7 +73,7 @@ public class DefaultBackchannelLogoutService : IBackchannelLogoutService
             {
                 var logoutToken = context.Request.Form[OidcConstants.BackChannelLogoutRequest.LogoutToken].FirstOrDefault();
 
-                if (!String.IsNullOrWhiteSpace(logoutToken))
+                if (!string.IsNullOrWhiteSpace(logoutToken))
                 {
                     var user = await ValidateLogoutTokenAsync(logoutToken);
                     if (user != null)
@@ -133,14 +133,14 @@ public class DefaultBackchannelLogoutService : IBackchannelLogoutService
         }
 
         var nonce = claims.FindFirst("nonce")?.Value;
-        if (!String.IsNullOrWhiteSpace(nonce))
+        if (!string.IsNullOrWhiteSpace(nonce))
         {
             Logger.BackChannelLogoutError("Logout token should not contain nonce claim.");
             return null;
         }
 
         var eventsJson = claims.FindFirst("events")?.Value;
-        if (String.IsNullOrWhiteSpace(eventsJson))
+        if (string.IsNullOrWhiteSpace(eventsJson))
         {
             Logger.BackChannelLogoutError("Logout token missing events claim.");
             return null;

--- a/bff/src/Bff/EndpointServices/Login/DefaultLoginService.cs
+++ b/bff/src/Bff/EndpointServices/Login/DefaultLoginService.cs
@@ -58,7 +58,7 @@ public class DefaultLoginService : ILoginService
             }
         }
 
-        if (String.IsNullOrWhiteSpace(returnUrl))
+        if (string.IsNullOrWhiteSpace(returnUrl))
         {
             if (context.Request.PathBase.HasValue)
             {

--- a/bff/src/Bff/EndpointServices/Logout/DefaultLogoutService.cs
+++ b/bff/src/Bff/EndpointServices/Logout/DefaultLogoutService.cs
@@ -63,7 +63,7 @@ public class DefaultLogoutService : ILogoutService
         if (result.Succeeded && result.Principal?.Identity?.IsAuthenticated == true)
         {
             var userSessionId = result.Principal.FindFirst(JwtClaimTypes.SessionId)?.Value;
-            if (!String.IsNullOrWhiteSpace(userSessionId))
+            if (!string.IsNullOrWhiteSpace(userSessionId))
             {
                 var passedSessionId = context.Request.Query[JwtClaimTypes.SessionId].FirstOrDefault();
                 // for an authenticated user, if they have a session id claim,
@@ -89,7 +89,7 @@ public class DefaultLogoutService : ILogoutService
         var signInScheme = await AuthenticationSchemeProvider.GetDefaultSignInSchemeAsync();
         await context.SignOutAsync(signInScheme?.Name);
 
-        if (String.IsNullOrWhiteSpace(returnUrl))
+        if (string.IsNullOrWhiteSpace(returnUrl))
         {
             if (context.Request.PathBase.HasValue)
             {

--- a/bff/src/Bff/Licensing/License.cs
+++ b/bff/src/Bff/Licensing/License.cs
@@ -19,7 +19,7 @@ internal class License
 
     public License(ClaimsPrincipal claims)
     {
-        if (Int32.TryParse(claims.FindFirst("id")?.Value, out var id))
+        if (int.TryParse(claims.FindFirst("id")?.Value, out var id))
         {
             Id = id;
         }
@@ -27,7 +27,7 @@ internal class License
         CompanyName = claims.FindFirst("company_name")?.Value;
         ContactInfo = claims.FindFirst("contact_info")?.Value;
 
-        if (Int64.TryParse(claims.FindFirst("exp")?.Value, out var exp))
+        if (long.TryParse(claims.FindFirst("exp")?.Value, out var exp))
         {
             var expDate = DateTimeOffset.FromUnixTimeSeconds(exp);
             Expiration = expDate.UtcDateTime;
@@ -161,7 +161,7 @@ internal class License
                 }
             }
 
-            if (Int32.TryParse(claims.FindFirst("client_limit")?.Value, out var clientLimit))
+            if (int.TryParse(claims.FindFirst("client_limit")?.Value, out var clientLimit))
             {
                 // explicit, so use that value
                 ClientLimit = clientLimit;
@@ -186,7 +186,7 @@ internal class License
             // default 
             IssuerLimit = 1;
 
-            if (Int32.TryParse(claims.FindFirst("issuer_limit")?.Value, out var issuerLimit))
+            if (int.TryParse(claims.FindFirst("issuer_limit")?.Value, out var issuerLimit))
             {
                 IssuerLimit = issuerLimit;
             }

--- a/bff/src/Bff/Licensing/LicenseValidator.cs
+++ b/bff/src/Bff/Licensing/LicenseValidator.cs
@@ -124,7 +124,7 @@ internal partial class LicenseValidator
 
     internal static License ValidateKey(string licenseKey)
     {
-        if (!String.IsNullOrWhiteSpace(licenseKey))
+        if (!string.IsNullOrWhiteSpace(licenseKey))
         {
             var handler = new JsonWebTokenHandler();
 

--- a/bff/src/Bff/SessionManagement/Revocation/SessionRevocationService.cs
+++ b/bff/src/Bff/SessionManagement/Revocation/SessionRevocationService.cs
@@ -54,7 +54,7 @@ public class SessionRevocationService : ISessionRevocationService
                 foreach (var ticket in tickets)
                 {
                     var refreshToken = ticket.Properties.GetTokenValue("refresh_token");
-                    if (!String.IsNullOrWhiteSpace(refreshToken))
+                    if (!string.IsNullOrWhiteSpace(refreshToken))
                     {
                         await _tokenEndpoint.RevokeRefreshTokenAsync(new UserToken { RefreshToken = refreshToken }, new UserTokenRequestParameters(), cancellationToken);
 

--- a/bff/src/Bff/SessionManagement/SessionStore/InMemoryUserSessionStore.cs
+++ b/bff/src/Bff/SessionManagement/SessionStore/InMemoryUserSessionStore.cs
@@ -51,11 +51,11 @@ public class InMemoryUserSessionStore : IUserSessionStore
         filter.Validate();
 
         var query = _store.Values.AsQueryable();
-        if (!String.IsNullOrWhiteSpace(filter.SubjectId))
+        if (!string.IsNullOrWhiteSpace(filter.SubjectId))
         {
             query = query.Where(x => x.SubjectId == filter.SubjectId);
         }
-        if (!String.IsNullOrWhiteSpace(filter.SessionId))
+        if (!string.IsNullOrWhiteSpace(filter.SessionId))
         {
             query = query.Where(x => x.SessionId == filter.SessionId);
         }
@@ -70,11 +70,11 @@ public class InMemoryUserSessionStore : IUserSessionStore
         filter.Validate();
 
         var query = _store.Values.AsQueryable();
-        if (!String.IsNullOrWhiteSpace(filter.SubjectId))
+        if (!string.IsNullOrWhiteSpace(filter.SubjectId))
         {
             query = query.Where(x => x.SubjectId == filter.SubjectId);
         }
-        if (!String.IsNullOrWhiteSpace(filter.SessionId))
+        if (!string.IsNullOrWhiteSpace(filter.SessionId))
         {
             query = query.Where(x => x.SessionId == filter.SessionId);
         }

--- a/bff/src/Bff/SessionManagement/SessionStore/UserSessionsFilter.cs
+++ b/bff/src/Bff/SessionManagement/SessionStore/UserSessionsFilter.cs
@@ -23,7 +23,7 @@ public class UserSessionsFilter
     /// </summary>
     public void Validate()
     {
-        if (String.IsNullOrWhiteSpace(SubjectId) && String.IsNullOrWhiteSpace(SessionId))
+        if (string.IsNullOrWhiteSpace(SubjectId) && string.IsNullOrWhiteSpace(SessionId))
         {
             throw new ArgumentNullException("SubjectId or SessionId is required.");
         }

--- a/bff/test/Bff.Tests/TestFramework/GenericHost.cs
+++ b/bff/test/Bff.Tests/TestFramework/GenericHost.cs
@@ -39,7 +39,7 @@ public class GenericHost(WriteTestOutput writeOutput, string baseAddress = "http
 
     public string Url(string? path = null)
     {
-        path ??= String.Empty;
+        path ??= string.Empty;
         if (!path.StartsWith("/")) path = "/" + path;
         return _baseAddress + path;
     }

--- a/bff/test/Bff.Tests/TestHosts/IdentityServerHost.cs
+++ b/bff/test/Bff.Tests/TestHosts/IdentityServerHost.cs
@@ -106,7 +106,7 @@ public class IdentityServerHost : GenericHost
     {
         var props = new AuthenticationProperties();
 
-        if (!String.IsNullOrWhiteSpace(sid))
+        if (!string.IsNullOrWhiteSpace(sid))
         {
             props.Items.Add("session_id", sid);
         }

--- a/identity-server/clients/src/APIs/DPoPApi/DPoP/DPoPProofValidator.cs
+++ b/identity-server/clients/src/APIs/DPoPApi/DPoP/DPoPProofValidator.cs
@@ -52,7 +52,7 @@ public class DPoPProofValidator
 
         try
         {
-            if (String.IsNullOrEmpty(context?.ProofToken))
+            if (string.IsNullOrEmpty(context?.ProofToken))
             {
                 result.IsError = true;
                 result.ErrorDescription = "Missing DPoP proof value.";
@@ -85,7 +85,7 @@ public class DPoPProofValidator
         }
         finally
         {
-            if (result.IsError && String.IsNullOrWhiteSpace(result.Error))
+            if (result.IsError && string.IsNullOrWhiteSpace(result.Error))
             {
                 result.Error = OidcConstants.TokenErrors.InvalidDPoPProof;
             }
@@ -214,7 +214,7 @@ public class DPoPProofValidator
             result.AccessTokenHash = ath as string;
         }
 
-        if (String.IsNullOrEmpty(result.AccessTokenHash))
+        if (string.IsNullOrEmpty(result.AccessTokenHash))
         {
             result.IsError = true;
             result.ErrorDescription = "Invalid 'ath' value.";
@@ -240,7 +240,7 @@ public class DPoPProofValidator
             result.TokenId = jti as string;
         }
 
-        if (String.IsNullOrEmpty(result.TokenId))
+        if (string.IsNullOrEmpty(result.TokenId))
         {
             result.IsError = true;
             result.ErrorDescription = "Invalid 'jti' value.";
@@ -388,7 +388,7 @@ public class DPoPProofValidator
     /// </summary>
     protected virtual async Task ValidateNonceAsync(DPoPProofValidatonContext context, DPoPProofValidatonResult result)
     {
-        if (String.IsNullOrWhiteSpace(result.Nonce))
+        if (string.IsNullOrWhiteSpace(result.Nonce))
         {
             result.IsError = true;
             result.Error = OidcConstants.TokenErrors.UseDPoPNonce;
@@ -440,7 +440,7 @@ public class DPoPProofValidator
         try
         {
             var value = DataProtector.Unprotect(result.Nonce);
-            if (Int64.TryParse(value, out long iat))
+            if (long.TryParse(value, out long iat))
             {
                 return ValueTask.FromResult(iat);
             }

--- a/identity-server/clients/src/ConsoleCode/SystemBrowser.cs
+++ b/identity-server/clients/src/ConsoleCode/SystemBrowser.cs
@@ -50,7 +50,7 @@ public class SystemBrowser : IBrowser
             try
             {
                 var result = await listener.WaitForCallbackAsync();
-                if (String.IsNullOrWhiteSpace(result))
+                if (string.IsNullOrWhiteSpace(result))
                 {
                     return new BrowserResult { ResultType = BrowserResultType.UnknownError, Error = "Empty response." };
                 }
@@ -110,7 +110,7 @@ public class LoopbackHttpListener : IDisposable
 
     public LoopbackHttpListener(int port, string path = null)
     {
-        path = path ?? String.Empty;
+        path = path ?? string.Empty;
         if (path.StartsWith("/")) path = path.Substring(1);
 
         _url = $"http://127.0.0.1:{port}/{path}";

--- a/identity-server/clients/src/ConsoleResourceIndicators/LoopbackHttpListener.cs
+++ b/identity-server/clients/src/ConsoleResourceIndicators/LoopbackHttpListener.cs
@@ -19,7 +19,7 @@ public class LoopbackHttpListener : IDisposable
 
     public LoopbackHttpListener(int port, string path = null)
     {
-        path ??= String.Empty;
+        path ??= string.Empty;
         if (path.StartsWith("/")) path = path.Substring(1);
 
         _url = $"http://127.0.0.1:{port}/{path}";

--- a/identity-server/clients/src/ConsoleResourceIndicators/SystemBrowser.cs
+++ b/identity-server/clients/src/ConsoleResourceIndicators/SystemBrowser.cs
@@ -46,7 +46,7 @@ public class SystemBrowser : IBrowser
             try
             {
                 var result = await listener.WaitForCallbackAsync();
-                if (String.IsNullOrWhiteSpace(result))
+                if (string.IsNullOrWhiteSpace(result))
                 {
                     return new BrowserResult { ResultType = BrowserResultType.UnknownError, Error = "Empty response." };
                 }

--- a/identity-server/clients/src/Constants/ConsoleExtensions.cs
+++ b/identity-server/clients/src/Constants/ConsoleExtensions.cs
@@ -26,7 +26,7 @@ public static class ConsoleExtensions
     public static void ConsoleBox(this string text, ConsoleColor color)
     {
         var len = text.Length + 4;
-        var line = new String('*', len);
+        var line = new string('*', len);
         line.ColoredWriteLine(ConsoleColor.Green);
         $"* {text} *".ColoredWriteLine(ConsoleColor.Green);
         line.ColoredWriteLine(ConsoleColor.Green);

--- a/identity-server/clients/src/MvcHybridBackChannel/Controllers/LogoutController.cs
+++ b/identity-server/clients/src/MvcHybridBackChannel/Controllers/LogoutController.cs
@@ -53,10 +53,10 @@ public class LogoutController : Controller
         if (claims.FindFirst("sub") == null && claims.FindFirst("sid") == null) throw new Exception("Invalid logout token");
 
         var nonce = claims.FindFirstValue("nonce");
-        if (!String.IsNullOrWhiteSpace(nonce)) throw new Exception("Invalid logout token");
+        if (!string.IsNullOrWhiteSpace(nonce)) throw new Exception("Invalid logout token");
 
         var eventsJson = claims.FindFirst("events")?.Value;
-        if (String.IsNullOrWhiteSpace(eventsJson)) throw new Exception("Invalid logout token");
+        if (string.IsNullOrWhiteSpace(eventsJson)) throw new Exception("Invalid logout token");
 
         var events = JsonDocument.Parse(eventsJson).RootElement;
         var logoutEvent = events.TryGetString("http://schemas.openid.net/event/backchannel-logout");

--- a/identity-server/clients/src/WindowsConsoleSystemBrowser/Program.cs
+++ b/identity-server/clients/src/WindowsConsoleSystemBrowser/Program.cs
@@ -33,7 +33,7 @@ class Program
     private static async Task ProcessCallback(string args)
     {
         var response = new AuthorizeResponse(args);
-        if (!String.IsNullOrWhiteSpace(response.State))
+        if (!string.IsNullOrWhiteSpace(response.State))
         {
             Console.WriteLine($"Found state: {response.State}");
             var callbackManager = new CallbackManager(response.State);

--- a/identity-server/clients/src/WindowsConsoleSystemBrowser/RegistryConfig.cs
+++ b/identity-server/clients/src/WindowsConsoleSystemBrowser/RegistryConfig.cs
@@ -36,7 +36,7 @@ class RegistryConfig
 
     const string CommandKeyValueName = "";
     const string CommandKeyValueFormat = "\"{0}\" \"%1\"";
-    static string CommandKeyValueValue => String.Format(CommandKeyValueFormat, Assembly.GetExecutingAssembly().Location);
+    static string CommandKeyValueValue => string.Format(CommandKeyValueFormat, Assembly.GetExecutingAssembly().Location);
 
     const string UrlProtocolValueName = "URL Protocol";
     const string UrlProtocolValueValue = "";

--- a/identity-server/hosts/AspNetIdentity/Pages/Account/Login/ViewModel.cs
+++ b/identity-server/hosts/AspNetIdentity/Pages/Account/Login/ViewModel.cs
@@ -9,7 +9,7 @@ public class ViewModel
     public bool EnableLocalLogin { get; set; } = true;
 
     public IEnumerable<ViewModel.ExternalProvider> ExternalProviders { get; set; } = Enumerable.Empty<ExternalProvider>();
-    public IEnumerable<ViewModel.ExternalProvider> VisibleExternalProviders => ExternalProviders.Where(x => !String.IsNullOrWhiteSpace(x.DisplayName));
+    public IEnumerable<ViewModel.ExternalProvider> VisibleExternalProviders => ExternalProviders.Where(x => !string.IsNullOrWhiteSpace(x.DisplayName));
 
     public bool IsExternalLoginOnly => EnableLocalLogin == false && ExternalProviders?.Count() == 1;
     public string? ExternalLoginScheme => IsExternalLoginOnly ? ExternalProviders?.SingleOrDefault()?.AuthenticationScheme : null;

--- a/identity-server/hosts/AspNetIdentity/Pages/Account/Logout/LoggedOut.cshtml.cs
+++ b/identity-server/hosts/AspNetIdentity/Pages/Account/Logout/LoggedOut.cshtml.cs
@@ -29,7 +29,7 @@ public class LoggedOut : PageModel
         {
             AutomaticRedirectAfterSignOut = LogoutOptions.AutomaticRedirectAfterSignOut,
             PostLogoutRedirectUri = logout?.PostLogoutRedirectUri,
-            ClientName = String.IsNullOrEmpty(logout?.ClientName) ? logout?.ClientId : logout?.ClientName,
+            ClientName = string.IsNullOrEmpty(logout?.ClientName) ? logout?.ClientId : logout?.ClientName,
             SignOutIframeUrl = logout?.SignOutIFrameUrl
         };
     }

--- a/identity-server/hosts/AspNetIdentity/Pages/Ciba/Consent.cshtml.cs
+++ b/identity-server/hosts/AspNetIdentity/Pages/Ciba/Consent.cshtml.cs
@@ -197,7 +197,7 @@ public class Consent : PageModel
     private static ScopeViewModel CreateScopeViewModel(ParsedScopeValue parsedScopeValue, ApiScope apiScope, bool check)
     {
         var displayName = apiScope.DisplayName ?? apiScope.Name;
-        if (!String.IsNullOrWhiteSpace(parsedScopeValue.ParsedParameter))
+        if (!string.IsNullOrWhiteSpace(parsedScopeValue.ParsedParameter))
         {
             displayName += ":" + parsedScopeValue.ParsedParameter;
         }

--- a/identity-server/hosts/AspNetIdentity/Pages/Consent/Index.cshtml.cs
+++ b/identity-server/hosts/AspNetIdentity/Pages/Consent/Index.cshtml.cs
@@ -205,7 +205,7 @@ public class Index : PageModel
     private static ScopeViewModel CreateScopeViewModel(ParsedScopeValue parsedScopeValue, ApiScope apiScope, bool check)
     {
         var displayName = apiScope.DisplayName ?? apiScope.Name;
-        if (!String.IsNullOrWhiteSpace(parsedScopeValue.ParsedParameter))
+        if (!string.IsNullOrWhiteSpace(parsedScopeValue.ParsedParameter))
         {
             displayName += ":" + parsedScopeValue.ParsedParameter;
         }

--- a/identity-server/hosts/AspNetIdentity/Pages/Device/Index.cshtml.cs
+++ b/identity-server/hosts/AspNetIdentity/Pages/Device/Index.cshtml.cs
@@ -43,7 +43,7 @@ public class Index : PageModel
 
     public async Task<IActionResult> OnGet(string? userCode)
     {
-        if (String.IsNullOrWhiteSpace(userCode))
+        if (string.IsNullOrWhiteSpace(userCode))
         {
             return Page();
         }

--- a/identity-server/hosts/Configuration/Pages/Account/Login/ViewModel.cs
+++ b/identity-server/hosts/Configuration/Pages/Account/Login/ViewModel.cs
@@ -9,7 +9,7 @@ public class ViewModel
     public bool EnableLocalLogin { get; set; } = true;
 
     public IEnumerable<ViewModel.ExternalProvider> ExternalProviders { get; set; } = Enumerable.Empty<ExternalProvider>();
-    public IEnumerable<ViewModel.ExternalProvider> VisibleExternalProviders => ExternalProviders.Where(x => !String.IsNullOrWhiteSpace(x.DisplayName));
+    public IEnumerable<ViewModel.ExternalProvider> VisibleExternalProviders => ExternalProviders.Where(x => !string.IsNullOrWhiteSpace(x.DisplayName));
 
     public bool IsExternalLoginOnly => EnableLocalLogin == false && ExternalProviders?.Count() == 1;
     public string? ExternalLoginScheme => IsExternalLoginOnly ? ExternalProviders?.SingleOrDefault()?.AuthenticationScheme : null;

--- a/identity-server/hosts/Configuration/Pages/Account/Logout/LoggedOut.cshtml.cs
+++ b/identity-server/hosts/Configuration/Pages/Account/Logout/LoggedOut.cshtml.cs
@@ -29,7 +29,7 @@ public class LoggedOut : PageModel
         {
             AutomaticRedirectAfterSignOut = LogoutOptions.AutomaticRedirectAfterSignOut,
             PostLogoutRedirectUri = logout?.PostLogoutRedirectUri,
-            ClientName = String.IsNullOrEmpty(logout?.ClientName) ? logout?.ClientId : logout?.ClientName,
+            ClientName = string.IsNullOrEmpty(logout?.ClientName) ? logout?.ClientId : logout?.ClientName,
             SignOutIframeUrl = logout?.SignOutIFrameUrl
         };
     }

--- a/identity-server/hosts/Configuration/Pages/Ciba/Consent.cshtml.cs
+++ b/identity-server/hosts/Configuration/Pages/Ciba/Consent.cshtml.cs
@@ -197,7 +197,7 @@ public class Consent : PageModel
     private static ScopeViewModel CreateScopeViewModel(ParsedScopeValue parsedScopeValue, ApiScope apiScope, bool check)
     {
         var displayName = apiScope.DisplayName ?? apiScope.Name;
-        if (!String.IsNullOrWhiteSpace(parsedScopeValue.ParsedParameter))
+        if (!string.IsNullOrWhiteSpace(parsedScopeValue.ParsedParameter))
         {
             displayName += ":" + parsedScopeValue.ParsedParameter;
         }

--- a/identity-server/hosts/Configuration/Pages/Consent/Index.cshtml.cs
+++ b/identity-server/hosts/Configuration/Pages/Consent/Index.cshtml.cs
@@ -205,7 +205,7 @@ public class Index : PageModel
     private static ScopeViewModel CreateScopeViewModel(ParsedScopeValue parsedScopeValue, ApiScope apiScope, bool check)
     {
         var displayName = apiScope.DisplayName ?? apiScope.Name;
-        if (!String.IsNullOrWhiteSpace(parsedScopeValue.ParsedParameter))
+        if (!string.IsNullOrWhiteSpace(parsedScopeValue.ParsedParameter))
         {
             displayName += ":" + parsedScopeValue.ParsedParameter;
         }

--- a/identity-server/hosts/Configuration/Pages/Device/Index.cshtml.cs
+++ b/identity-server/hosts/Configuration/Pages/Device/Index.cshtml.cs
@@ -43,7 +43,7 @@ public class Index : PageModel
 
     public async Task<IActionResult> OnGet(string? userCode)
     {
-        if (String.IsNullOrWhiteSpace(userCode))
+        if (string.IsNullOrWhiteSpace(userCode))
         {
             return Page();
         }

--- a/identity-server/hosts/EntityFramework/Pages/Account/Login/ViewModel.cs
+++ b/identity-server/hosts/EntityFramework/Pages/Account/Login/ViewModel.cs
@@ -9,7 +9,7 @@ public class ViewModel
     public bool EnableLocalLogin { get; set; } = true;
 
     public IEnumerable<ViewModel.ExternalProvider> ExternalProviders { get; set; } = Enumerable.Empty<ExternalProvider>();
-    public IEnumerable<ViewModel.ExternalProvider> VisibleExternalProviders => ExternalProviders.Where(x => !String.IsNullOrWhiteSpace(x.DisplayName));
+    public IEnumerable<ViewModel.ExternalProvider> VisibleExternalProviders => ExternalProviders.Where(x => !string.IsNullOrWhiteSpace(x.DisplayName));
 
     public bool IsExternalLoginOnly => EnableLocalLogin == false && ExternalProviders?.Count() == 1;
     public string? ExternalLoginScheme => IsExternalLoginOnly ? ExternalProviders?.SingleOrDefault()?.AuthenticationScheme : null;

--- a/identity-server/hosts/EntityFramework/Pages/Account/Logout/LoggedOut.cshtml.cs
+++ b/identity-server/hosts/EntityFramework/Pages/Account/Logout/LoggedOut.cshtml.cs
@@ -29,7 +29,7 @@ public class LoggedOut : PageModel
         {
             AutomaticRedirectAfterSignOut = LogoutOptions.AutomaticRedirectAfterSignOut,
             PostLogoutRedirectUri = logout?.PostLogoutRedirectUri,
-            ClientName = String.IsNullOrEmpty(logout?.ClientName) ? logout?.ClientId : logout?.ClientName,
+            ClientName = string.IsNullOrEmpty(logout?.ClientName) ? logout?.ClientId : logout?.ClientName,
             SignOutIframeUrl = logout?.SignOutIFrameUrl
         };
     }

--- a/identity-server/hosts/EntityFramework/Pages/Admin/ApiScopes/ApiScopeRepository.cs
+++ b/identity-server/hosts/EntityFramework/Pages/Admin/ApiScopes/ApiScopeRepository.cs
@@ -37,7 +37,7 @@ public class ApiScopeRepository
             .Include(x => x.UserClaims)
             .AsQueryable();
 
-        if (!String.IsNullOrWhiteSpace(filter))
+        if (!string.IsNullOrWhiteSpace(filter))
         {
             query = query.Where(x => x.Name.Contains(filter) || x.DisplayName.Contains(filter));
         }
@@ -106,7 +106,7 @@ public class ApiScopeRepository
         }
 
         var claims = model.UserClaims?.Split(' ', StringSplitOptions.RemoveEmptyEntries).ToArray() ?? Enumerable.Empty<string>();
-        var currentClaims = (scope.UserClaims.Select(x => x.Type) ?? Enumerable.Empty<String>()).ToArray();
+        var currentClaims = (scope.UserClaims.Select(x => x.Type) ?? Enumerable.Empty<string>()).ToArray();
 
         var claimsToAdd = claims.Except(currentClaims).ToArray();
         var claimsToRemove = currentClaims.Except(claims).ToArray();

--- a/identity-server/hosts/EntityFramework/Pages/Admin/Clients/ClientRepository.cs
+++ b/identity-server/hosts/EntityFramework/Pages/Admin/Clients/ClientRepository.cs
@@ -76,7 +76,7 @@ public class ClientRepository
             .Include(x => x.AllowedGrantTypes)
             .Where(x => x.AllowedGrantTypes.Count == 1 && x.AllowedGrantTypes.Any(grant => grants.Contains(grant.GrantType)));
 
-        if (!String.IsNullOrWhiteSpace(filter))
+        if (!string.IsNullOrWhiteSpace(filter))
         {
             query = query.Where(x => x.ClientId.Contains(filter) || x.ClientName.Contains(filter));
         }
@@ -164,7 +164,7 @@ public class ClientRepository
         }
 
         var scopes = model.AllowedScopes.Split(' ', StringSplitOptions.RemoveEmptyEntries).ToArray();
-        var currentScopes = (client.AllowedScopes.Select(x => x.Scope) ?? Enumerable.Empty<String>()).ToArray();
+        var currentScopes = (client.AllowedScopes.Select(x => x.Scope) ?? Enumerable.Empty<string>()).ToArray();
 
         var scopesToAdd = scopes.Except(currentScopes).ToArray();
         var scopesToRemove = currentScopes.Except(scopes).ToArray();

--- a/identity-server/hosts/EntityFramework/Pages/Admin/IdentityScopes/IdentityScopeRepository.cs
+++ b/identity-server/hosts/EntityFramework/Pages/Admin/IdentityScopes/IdentityScopeRepository.cs
@@ -37,7 +37,7 @@ public class IdentityScopeRepository
             .Include(x => x.UserClaims)
             .AsQueryable();
 
-        if (!String.IsNullOrWhiteSpace(filter))
+        if (!string.IsNullOrWhiteSpace(filter))
         {
             query = query.Where(x => x.Name.Contains(filter) || x.DisplayName.Contains(filter));
         }
@@ -105,7 +105,7 @@ public class IdentityScopeRepository
         }
 
         var claims = model.UserClaims?.Split(' ', StringSplitOptions.RemoveEmptyEntries).ToArray() ?? Enumerable.Empty<string>();
-        var currentClaims = (scope.UserClaims.Select(x => x.Type) ?? Enumerable.Empty<String>()).ToArray();
+        var currentClaims = (scope.UserClaims.Select(x => x.Type) ?? Enumerable.Empty<string>()).ToArray();
 
         var claimsToAdd = claims.Except(currentClaims).ToArray();
         var claimsToRemove = currentClaims.Except(claims).ToArray();

--- a/identity-server/hosts/EntityFramework/Pages/Ciba/Consent.cshtml.cs
+++ b/identity-server/hosts/EntityFramework/Pages/Ciba/Consent.cshtml.cs
@@ -197,7 +197,7 @@ public class Consent : PageModel
     private static ScopeViewModel CreateScopeViewModel(ParsedScopeValue parsedScopeValue, ApiScope apiScope, bool check)
     {
         var displayName = apiScope.DisplayName ?? apiScope.Name;
-        if (!String.IsNullOrWhiteSpace(parsedScopeValue.ParsedParameter))
+        if (!string.IsNullOrWhiteSpace(parsedScopeValue.ParsedParameter))
         {
             displayName += ":" + parsedScopeValue.ParsedParameter;
         }

--- a/identity-server/hosts/EntityFramework/Pages/Consent/Index.cshtml.cs
+++ b/identity-server/hosts/EntityFramework/Pages/Consent/Index.cshtml.cs
@@ -205,7 +205,7 @@ public class Index : PageModel
     private static ScopeViewModel CreateScopeViewModel(ParsedScopeValue parsedScopeValue, ApiScope apiScope, bool check)
     {
         var displayName = apiScope.DisplayName ?? apiScope.Name;
-        if (!String.IsNullOrWhiteSpace(parsedScopeValue.ParsedParameter))
+        if (!string.IsNullOrWhiteSpace(parsedScopeValue.ParsedParameter))
         {
             displayName += ":" + parsedScopeValue.ParsedParameter;
         }

--- a/identity-server/hosts/EntityFramework/Pages/Device/Index.cshtml.cs
+++ b/identity-server/hosts/EntityFramework/Pages/Device/Index.cshtml.cs
@@ -43,7 +43,7 @@ public class Index : PageModel
 
     public async Task<IActionResult> OnGet(string? userCode)
     {
-        if (String.IsNullOrWhiteSpace(userCode))
+        if (string.IsNullOrWhiteSpace(userCode))
         {
             return Page();
         }

--- a/identity-server/hosts/EntityFramework/Pages/Portal/ClientRepository.cs
+++ b/identity-server/hosts/EntityFramework/Pages/Portal/ClientRepository.cs
@@ -27,7 +27,7 @@ public class ClientRepository
         var query = _context.Clients
             .Where(c => c.InitiateLoginUri != null);
 
-        if (!String.IsNullOrWhiteSpace(filter))
+        if (!string.IsNullOrWhiteSpace(filter))
         {
             query = query.Where(x => x.ClientId.Contains(filter) || x.ClientName.Contains(filter));
         }

--- a/identity-server/hosts/main/Pages/Account/Login/ViewModel.cs
+++ b/identity-server/hosts/main/Pages/Account/Login/ViewModel.cs
@@ -9,7 +9,7 @@ public class ViewModel
     public bool EnableLocalLogin { get; set; } = true;
 
     public IEnumerable<ViewModel.ExternalProvider> ExternalProviders { get; set; } = Enumerable.Empty<ExternalProvider>();
-    public IEnumerable<ViewModel.ExternalProvider> VisibleExternalProviders => ExternalProviders.Where(x => !String.IsNullOrWhiteSpace(x.DisplayName));
+    public IEnumerable<ViewModel.ExternalProvider> VisibleExternalProviders => ExternalProviders.Where(x => !string.IsNullOrWhiteSpace(x.DisplayName));
 
     public bool IsExternalLoginOnly => EnableLocalLogin == false && ExternalProviders?.Count() == 1;
     public string? ExternalLoginScheme => IsExternalLoginOnly ? ExternalProviders?.SingleOrDefault()?.AuthenticationScheme : null;

--- a/identity-server/hosts/main/Pages/Account/Logout/LoggedOut.cshtml.cs
+++ b/identity-server/hosts/main/Pages/Account/Logout/LoggedOut.cshtml.cs
@@ -29,7 +29,7 @@ public class LoggedOut : PageModel
         {
             AutomaticRedirectAfterSignOut = LogoutOptions.AutomaticRedirectAfterSignOut,
             PostLogoutRedirectUri = logout?.PostLogoutRedirectUri,
-            ClientName = String.IsNullOrEmpty(logout?.ClientName) ? logout?.ClientId : logout?.ClientName,
+            ClientName = string.IsNullOrEmpty(logout?.ClientName) ? logout?.ClientId : logout?.ClientName,
             SignOutIframeUrl = logout?.SignOutIFrameUrl
         };
     }

--- a/identity-server/hosts/main/Pages/Ciba/Consent.cshtml.cs
+++ b/identity-server/hosts/main/Pages/Ciba/Consent.cshtml.cs
@@ -197,7 +197,7 @@ public class Consent : PageModel
     private static ScopeViewModel CreateScopeViewModel(ParsedScopeValue parsedScopeValue, ApiScope apiScope, bool check)
     {
         var displayName = apiScope.DisplayName ?? apiScope.Name;
-        if (!String.IsNullOrWhiteSpace(parsedScopeValue.ParsedParameter))
+        if (!string.IsNullOrWhiteSpace(parsedScopeValue.ParsedParameter))
         {
             displayName += ":" + parsedScopeValue.ParsedParameter;
         }

--- a/identity-server/hosts/main/Pages/Consent/Index.cshtml.cs
+++ b/identity-server/hosts/main/Pages/Consent/Index.cshtml.cs
@@ -205,7 +205,7 @@ public class Index : PageModel
     private static ScopeViewModel CreateScopeViewModel(ParsedScopeValue parsedScopeValue, ApiScope apiScope, bool check)
     {
         var displayName = apiScope.DisplayName ?? apiScope.Name;
-        if (!String.IsNullOrWhiteSpace(parsedScopeValue.ParsedParameter))
+        if (!string.IsNullOrWhiteSpace(parsedScopeValue.ParsedParameter))
         {
             displayName += ":" + parsedScopeValue.ParsedParameter;
         }

--- a/identity-server/hosts/main/Pages/Device/Index.cshtml.cs
+++ b/identity-server/hosts/main/Pages/Device/Index.cshtml.cs
@@ -43,7 +43,7 @@ public class Index : PageModel
 
     public async Task<IActionResult> OnGet(string? userCode)
     {
-        if (String.IsNullOrWhiteSpace(userCode))
+        if (string.IsNullOrWhiteSpace(userCode))
         {
             return Page();
         }

--- a/identity-server/src/AspNetIdentity/UserClaimsFactory.cs
+++ b/identity-server/src/AspNetIdentity/UserClaimsFactory.cs
@@ -48,7 +48,7 @@ internal class UserClaimsFactory<TUser> : IUserClaimsPrincipalFactory<TUser>
         if (_userManager.SupportsUserEmail)
         {
             var email = await _userManager.GetEmailAsync(user);
-            if (!String.IsNullOrWhiteSpace(email))
+            if (!string.IsNullOrWhiteSpace(email))
             {
                 identity.AddClaims(new[]
                 {
@@ -61,7 +61,7 @@ internal class UserClaimsFactory<TUser> : IUserClaimsPrincipalFactory<TUser>
         if (_userManager.SupportsUserPhoneNumber)
         {
             var phoneNumber = await _userManager.GetPhoneNumberAsync(user);
-            if (!String.IsNullOrWhiteSpace(phoneNumber))
+            if (!string.IsNullOrWhiteSpace(phoneNumber))
             {
                 identity.AddClaims(new[]
                 {

--- a/identity-server/src/Configuration/Licensing/License.cs
+++ b/identity-server/src/Configuration/Licensing/License.cs
@@ -29,7 +29,7 @@ public abstract class License
     {
         Claims = claims;
 
-        if (Int32.TryParse(claims.FindFirst("id")?.Value, out var id))
+        if (int.TryParse(claims.FindFirst("id")?.Value, out var id))
         {
             SerialNumber = id;
         }
@@ -37,7 +37,7 @@ public abstract class License
         CompanyName = claims.FindFirst("company_name")?.Value;
         ContactInfo = claims.FindFirst("contact_info")?.Value;
 
-        if (Int64.TryParse(claims.FindFirst("exp")?.Value, out var exp))
+        if (long.TryParse(claims.FindFirst("exp")?.Value, out var exp))
         {
             var expDate = DateTimeOffset.FromUnixTimeSeconds(exp);
             Expiration = expDate.UtcDateTime;

--- a/identity-server/src/Configuration/Licensing/LicenseValidator.cs
+++ b/identity-server/src/Configuration/Licensing/LicenseValidator.cs
@@ -142,7 +142,7 @@ internal class LicenseValidator<T>
 
     internal T ValidateKey(string licenseKey)
     {
-        if (!String.IsNullOrWhiteSpace(licenseKey))
+        if (!string.IsNullOrWhiteSpace(licenseKey))
         {
             var handler = new JsonWebTokenHandler();
 

--- a/identity-server/src/EntityFramework.Storage/Extensions/StringsExtensions.cs
+++ b/identity-server/src/EntityFramework.Storage/Extensions/StringsExtensions.cs
@@ -17,7 +17,7 @@ internal static class StringExtensions
             return string.Empty;
         }
 
-        return String.Join(' ', list);
+        return string.Join(' ', list);
     }
 
     [DebuggerStepThrough]
@@ -120,7 +120,7 @@ internal static class StringExtensions
     [DebuggerStepThrough]
     public static string CleanUrlPath(this string url)
     {
-        if (String.IsNullOrWhiteSpace(url)) url = "/";
+        if (string.IsNullOrWhiteSpace(url)) url = "/";
 
         if (url != "/" && url.EndsWith('/'))
         {

--- a/identity-server/src/EntityFramework.Storage/Mappers/AllowedSigningAlgorithmsConverter.cs
+++ b/identity-server/src/EntityFramework.Storage/Mappers/AllowedSigningAlgorithmsConverter.cs
@@ -18,7 +18,7 @@ internal static class AllowedSigningAlgorithmsConverter
     public static ICollection<string> Convert(string sourceMember)
     {
         var list = new HashSet<string>();
-        if (!String.IsNullOrWhiteSpace(sourceMember))
+        if (!string.IsNullOrWhiteSpace(sourceMember))
         {
             sourceMember = sourceMember.Trim();
             foreach (var item in sourceMember.Split(',', StringSplitOptions.RemoveEmptyEntries).Distinct())

--- a/identity-server/src/EntityFramework.Storage/Mappers/PropertiesConverter.cs
+++ b/identity-server/src/EntityFramework.Storage/Mappers/PropertiesConverter.cs
@@ -15,7 +15,7 @@ internal static class PropertiesConverter
 
     public static Dictionary<string, string> Convert(string sourceMember)
     {
-        if (String.IsNullOrWhiteSpace(sourceMember))
+        if (string.IsNullOrWhiteSpace(sourceMember))
         {
             return new Dictionary<string, string>();
         }

--- a/identity-server/src/EntityFramework.Storage/Stores/PersistedGrantStore.cs
+++ b/identity-server/src/EntityFramework.Storage/Stores/PersistedGrantStore.cs
@@ -172,22 +172,22 @@ public class PersistedGrantStore : Duende.IdentityServer.Stores.IPersistedGrantS
         if (filter.ClientIds != null)
         {
             var ids = filter.ClientIds.ToList();
-            if (!String.IsNullOrWhiteSpace(filter.ClientId))
+            if (!string.IsNullOrWhiteSpace(filter.ClientId))
             {
                 ids.Add(filter.ClientId);
             }
             query = query.Where(x => ids.Contains(x.ClientId));
         }
-        else if (!String.IsNullOrWhiteSpace(filter.ClientId))
+        else if (!string.IsNullOrWhiteSpace(filter.ClientId))
         {
             query = query.Where(x => x.ClientId == filter.ClientId);
         }
 
-        if (!String.IsNullOrWhiteSpace(filter.SessionId))
+        if (!string.IsNullOrWhiteSpace(filter.SessionId))
         {
             query = query.Where(x => x.SessionId == filter.SessionId);
         }
-        if (!String.IsNullOrWhiteSpace(filter.SubjectId))
+        if (!string.IsNullOrWhiteSpace(filter.SubjectId))
         {
             query = query.Where(x => x.SubjectId == filter.SubjectId);
         }
@@ -195,13 +195,13 @@ public class PersistedGrantStore : Duende.IdentityServer.Stores.IPersistedGrantS
         if (filter.Types != null)
         {
             var types = filter.Types.ToList();
-            if (!String.IsNullOrWhiteSpace(filter.Type))
+            if (!string.IsNullOrWhiteSpace(filter.Type))
             {
                 types.Add(filter.Type);
             }
             query = query.Where(x => types.Contains(x.Type));
         }
-        else if (!String.IsNullOrWhiteSpace(filter.Type))
+        else if (!string.IsNullOrWhiteSpace(filter.Type))
         {
             query = query.Where(x => x.Type == filter.Type);
         }

--- a/identity-server/src/EntityFramework.Storage/Stores/ServerSideSessionStore.cs
+++ b/identity-server/src/EntityFramework.Storage/Stores/ServerSideSessionStore.cs
@@ -242,11 +242,11 @@ public class ServerSideSessionStore : IServerSideSessionStore
 
     private IQueryable<Entities.ServerSideSession> Filter(IQueryable<Entities.ServerSideSession> query, SessionFilter filter)
     {
-        if (!String.IsNullOrWhiteSpace(filter.SubjectId))
+        if (!string.IsNullOrWhiteSpace(filter.SubjectId))
         {
             query = query.Where(x => x.SubjectId == filter.SubjectId);
         }
-        if (!String.IsNullOrWhiteSpace(filter.SessionId))
+        if (!string.IsNullOrWhiteSpace(filter.SessionId))
         {
             query = query.Where(x => x.SessionId == filter.SessionId);
         }
@@ -473,8 +473,8 @@ public class ServerSideSessionStore : IServerSideSessionStore
             var parts = filter.ResultsToken.Split(',', StringSplitOptions.RemoveEmptyEntries);
             if (parts != null && parts.Length == 2)
             {
-                Int32.TryParse(parts[0], out first);
-                Int32.TryParse(parts[1], out last);
+                int.TryParse(parts[0], out first);
+                int.TryParse(parts[1], out last);
             }
         }
 
@@ -489,9 +489,9 @@ public class ServerSideSessionStore : IServerSideSessionStore
     /// </summary>
     protected virtual IQueryable<Entities.ServerSideSession> ApplyFilter(IQueryable<Entities.ServerSideSession> query, SessionQuery filter)
     {
-        if (!String.IsNullOrWhiteSpace(filter.DisplayName) ||
-            !String.IsNullOrWhiteSpace(filter.SubjectId) ||
-            !String.IsNullOrWhiteSpace(filter.SessionId))
+        if (!string.IsNullOrWhiteSpace(filter.DisplayName) ||
+            !string.IsNullOrWhiteSpace(filter.SubjectId) ||
+            !string.IsNullOrWhiteSpace(filter.SessionId))
         {
             query = query.Where(x =>
                 (filter.SubjectId == null || x.SubjectId.Contains(filter.SubjectId)) &&

--- a/identity-server/src/EntityFramework.Storage/TokenCleanup/TokenCleanupService.cs
+++ b/identity-server/src/EntityFramework.Storage/TokenCleanup/TokenCleanupService.cs
@@ -75,7 +75,7 @@ public class TokenCleanupService : ITokenCleanupService
     /// <returns></returns>
     protected virtual async Task RemoveExpiredPersistedGrantsAsync(CancellationToken cancellationToken = default)
     {
-        var found = Int32.MaxValue;
+        var found = int.MaxValue;
 
         while (found >= _options.TokenCleanupBatchSize)
         {
@@ -144,7 +144,7 @@ public class TokenCleanupService : ITokenCleanupService
     /// <returns></returns>
     protected virtual async Task RemoveConsumedPersistedGrantsAsync(CancellationToken cancellationToken = default)
     {
-        var found = Int32.MaxValue;
+        var found = int.MaxValue;
 
         var delay = TimeSpan.FromSeconds(_options.ConsumedTokenCleanupDelay);
         var consumedTimeThreshold = DateTime.UtcNow.Subtract(delay);
@@ -207,7 +207,7 @@ public class TokenCleanupService : ITokenCleanupService
     /// <returns></returns>
     protected virtual async Task RemoveDeviceCodesAsync(CancellationToken cancellationToken = default)
     {
-        var found = Int32.MaxValue;
+        var found = int.MaxValue;
 
         while (found >= _options.TokenCleanupBatchSize)
         {
@@ -263,7 +263,7 @@ public class TokenCleanupService : ITokenCleanupService
     /// </summary>
     protected virtual async Task RemovePushedAuthorizationRequestsAsync(CancellationToken cancellationToken = default)
     {
-        var found = Int32.MaxValue;
+        var found = int.MaxValue;
 
         var query = _persistedGrantDbContext.PushedAuthorizationRequests
             .Where(par => par.ExpiresAtUtc < DateTime.UtcNow)

--- a/identity-server/src/IdentityServer/Extensions/AuthenticationTicketExtensions.cs
+++ b/identity-server/src/IdentityServer/Extensions/AuthenticationTicketExtensions.cs
@@ -46,7 +46,7 @@ public static class AuthenticationTicketExtensions
     /// </summary>
     public static string GetDisplayName(this AuthenticationTicket ticket, string displayNameClaimType)
     {
-        return String.IsNullOrWhiteSpace(displayNameClaimType) ?
+        return string.IsNullOrWhiteSpace(displayNameClaimType) ?
             null : ticket.Principal.FindFirst(displayNameClaimType)?.Value;
     }
 

--- a/identity-server/src/IdentityServer/Extensions/ClaimsExtensions.cs
+++ b/identity-server/src/IdentityServer/Extensions/ClaimsExtensions.cs
@@ -51,7 +51,7 @@ internal static class ClaimsExtensions
         if (claim.ValueType == ClaimValueTypes.Integer ||
             claim.ValueType == ClaimValueTypes.Integer32)
         {
-            if (Int32.TryParse(claim.Value, out var value))
+            if (int.TryParse(claim.Value, out var value))
             {
                 return value;
             }
@@ -59,7 +59,7 @@ internal static class ClaimsExtensions
 
         if (claim.ValueType == ClaimValueTypes.Integer64)
         {
-            if (Int64.TryParse(claim.Value, out var value))
+            if (long.TryParse(claim.Value, out var value))
             {
                 return value;
             }
@@ -67,7 +67,7 @@ internal static class ClaimsExtensions
 
         if (claim.ValueType == ClaimValueTypes.Double)
         {
-            if (Double.TryParse(claim.Value, out var value))
+            if (double.TryParse(claim.Value, out var value))
             {
                 return value;
             }

--- a/identity-server/src/IdentityServer/Extensions/IReadableStringCollectionExtensions.cs
+++ b/identity-server/src/IdentityServer/Extensions/IReadableStringCollectionExtensions.cs
@@ -22,7 +22,7 @@ public static class IReadableStringCollectionExtensions
             foreach (var val in field.Value)
             {
                 // special check for some Azure product: https://github.com/DuendeSoftware/Support/issues/48
-                if (!String.IsNullOrWhiteSpace(val))
+                if (!string.IsNullOrWhiteSpace(val))
                 {
                     nv.Add(field.Key, val);
                 }
@@ -42,7 +42,7 @@ public static class IReadableStringCollectionExtensions
             foreach (var item in field.Value)
             {
                 // special check for some Azure product: https://github.com/DuendeSoftware/Support/issues/48
-                if (!String.IsNullOrWhiteSpace(item))
+                if (!string.IsNullOrWhiteSpace(item))
                 {
                     nv.Add(field.Key, item);
                 }

--- a/identity-server/src/IdentityServer/Extensions/NameValueCollectionExtensions.cs
+++ b/identity-server/src/IdentityServer/Extensions/NameValueCollectionExtensions.cs
@@ -34,7 +34,7 @@ internal static class NameValueCollectionExtensions
     {
         if (collection.Count == 0)
         {
-            return String.Empty;
+            return string.Empty;
         }
 
         var builder = new StringBuilder(128);
@@ -44,7 +44,7 @@ internal static class NameValueCollectionExtensions
             var values = collection.GetValues(name);
             if (values == null || values.Length == 0)
             {
-                first = AppendNameValuePair(builder, first, true, name, String.Empty);
+                first = AppendNameValuePair(builder, first, true, name, string.Empty);
             }
             else
             {
@@ -136,10 +136,10 @@ internal static class NameValueCollectionExtensions
 
     private static bool AppendNameValuePair(StringBuilder builder, bool first, bool urlEncode, string name, string value)
     {
-        var effectiveName = name ?? String.Empty;
+        var effectiveName = name ?? string.Empty;
         var encodedName = urlEncode ? UrlEncoder.Default.Encode(effectiveName) : effectiveName;
 
-        var effectiveValue = value ?? String.Empty;
+        var effectiveValue = value ?? string.Empty;
         var encodedValue = urlEncode ? UrlEncoder.Default.Encode(effectiveValue) : effectiveValue;
         encodedValue = ConvertFormUrlEncodedSpacesToUrlEncodedSpaces(encodedValue);
 
@@ -153,7 +153,7 @@ internal static class NameValueCollectionExtensions
         }
 
         builder.Append(encodedName);
-        if (!String.IsNullOrEmpty(encodedValue))
+        if (!string.IsNullOrEmpty(encodedValue))
         {
             builder.Append('=');
             builder.Append(encodedValue);

--- a/identity-server/src/IdentityServer/Extensions/StringsExtensions.cs
+++ b/identity-server/src/IdentityServer/Extensions/StringsExtensions.cs
@@ -21,7 +21,7 @@ internal static class StringExtensions
             return string.Empty;
         }
 
-        return String.Join(' ', list);
+        return string.Join(' ', list);
     }
 
     [DebuggerStepThrough]
@@ -128,7 +128,7 @@ internal static class StringExtensions
     [DebuggerStepThrough]
     public static string CleanUrlPath(this string? url)
     {
-        if (String.IsNullOrWhiteSpace(url)) url = "/";
+        if (string.IsNullOrWhiteSpace(url)) url = "/";
 
         if (url != "/" && url.EndsWith('/'))
         {

--- a/identity-server/src/IdentityServer/Hosting/DynamicProviders/DynamicSchemes/DynamicAuthenticationSchemeCache.cs
+++ b/identity-server/src/IdentityServer/Hosting/DynamicProviders/DynamicSchemes/DynamicAuthenticationSchemeCache.cs
@@ -23,7 +23,7 @@ public class DynamicAuthenticationSchemeCache
     /// </summary>
     public void Add(string name, DynamicAuthenticationScheme item)
     {
-        name = name ?? String.Empty;
+        name = name ?? string.Empty;
         _cache.TryAdd(name, item);
     }
 
@@ -32,7 +32,7 @@ public class DynamicAuthenticationSchemeCache
     /// </summary>
     public DynamicAuthenticationScheme Get(string name)
     {
-        name = name ?? String.Empty;
+        name = name ?? string.Empty;
         _cache.TryGetValue(name, out var item);
         return item;
     }

--- a/identity-server/src/IdentityServer/Hosting/FederatedSignOut/AuthenticationRequestHandlerWrapper.cs
+++ b/identity-server/src/IdentityServer/Hosting/FederatedSignOut/AuthenticationRequestHandlerWrapper.cs
@@ -87,7 +87,7 @@ internal class AuthenticationRequestHandlerWrapper : IAuthenticationRequestHandl
 
         if (_context.Response.Body.CanWrite)
         {
-            var iframe = String.Format(IframeHtml, iframeUrl);
+            var iframe = string.Format(IframeHtml, iframeUrl);
             _context.Response.ContentType = "text/html";
             await _context.Response.WriteAsync(iframe);
             await _context.Response.Body.FlushAsync();

--- a/identity-server/src/IdentityServer/Hosting/ServerSideSessionCleanupHost.cs
+++ b/identity-server/src/IdentityServer/Hosting/ServerSideSessionCleanupHost.cs
@@ -129,7 +129,7 @@ public class ServerSideSessionCleanupHost : IHostedService
                 var serverSideTicketStore = serviceScope.ServiceProvider.GetRequiredService<IServerSideTicketStore>();
                 var sessionCoordinationService = serviceScope.ServiceProvider.GetRequiredService<ISessionCoordinationService>();
 
-                var found = Int32.MaxValue;
+                var found = int.MaxValue;
 
                 while (found > 0)
                 {

--- a/identity-server/src/IdentityServer/Infrastructure/DistributedCacheStateDataFormatter.cs
+++ b/identity-server/src/IdentityServer/Infrastructure/DistributedCacheStateDataFormatter.cs
@@ -90,7 +90,7 @@ public class DistributedCacheStateDataFormatter : ISecureDataFormat<Authenticati
     /// <returns></returns>
     public AuthenticationProperties Unprotect(string protectedText, string purpose)
     {
-        if (String.IsNullOrWhiteSpace(protectedText))
+        if (string.IsNullOrWhiteSpace(protectedText))
         {
             return null;
         }

--- a/identity-server/src/IdentityServer/Licensing/IdentityServerLicense.cs
+++ b/identity-server/src/IdentityServer/Licensing/IdentityServerLicense.cs
@@ -120,7 +120,7 @@ public class IdentityServerLicense : License
                 }
             }
 
-            if (Int32.TryParse(claims.FindFirst("client_limit")?.Value, out var clientLimit))
+            if (int.TryParse(claims.FindFirst("client_limit")?.Value, out var clientLimit))
             {
                 // explicit, so use that value
                 ClientLimit = clientLimit;
@@ -145,7 +145,7 @@ public class IdentityServerLicense : License
             // default 
             IssuerLimit = 1;
 
-            if (Int32.TryParse(claims.FindFirst("issuer_limit")?.Value, out var issuerLimit))
+            if (int.TryParse(claims.FindFirst("issuer_limit")?.Value, out var issuerLimit))
             {
                 IssuerLimit = issuerLimit;
             }

--- a/identity-server/src/IdentityServer/Licensing/IdentityServerLicenseValidator.cs
+++ b/identity-server/src/IdentityServer/Licensing/IdentityServerLicenseValidator.cs
@@ -196,7 +196,7 @@ internal class IdentityServerLicenseValidator : LicenseValidator<IdentityServerL
     bool ValidateResourceIndicatorsWarned = false;
     public void ValidateResourceIndicators(string resourceIndicator)
     {
-        if (!String.IsNullOrWhiteSpace(resourceIndicator))
+        if (!string.IsNullOrWhiteSpace(resourceIndicator))
         {
             if (License != null)
             {

--- a/identity-server/src/IdentityServer/Licensing/License.cs
+++ b/identity-server/src/IdentityServer/Licensing/License.cs
@@ -29,7 +29,7 @@ public abstract class License
     {
         Claims = claims;
 
-        if (Int32.TryParse(claims.FindFirst("id")?.Value, out var id))
+        if (int.TryParse(claims.FindFirst("id")?.Value, out var id))
         {
             SerialNumber = id;
         }
@@ -37,7 +37,7 @@ public abstract class License
         CompanyName = claims.FindFirst("company_name")?.Value;
         ContactInfo = claims.FindFirst("contact_info")?.Value;
 
-        if (Int64.TryParse(claims.FindFirst("exp")?.Value, out var exp))
+        if (long.TryParse(claims.FindFirst("exp")?.Value, out var exp))
         {
             var expDate = DateTimeOffset.FromUnixTimeSeconds(exp);
             Expiration = expDate.UtcDateTime;

--- a/identity-server/src/IdentityServer/Licensing/LicenseValidator.cs
+++ b/identity-server/src/IdentityServer/Licensing/LicenseValidator.cs
@@ -144,7 +144,7 @@ internal class LicenseValidator<T>
 
     internal T ValidateKey(string licenseKey)
     {
-        if (!String.IsNullOrWhiteSpace(licenseKey))
+        if (!string.IsNullOrWhiteSpace(licenseKey))
         {
             var handler = new JsonWebTokenHandler();
 

--- a/identity-server/src/IdentityServer/Licensing/V2/License.cs
+++ b/identity-server/src/IdentityServer/Licensing/V2/License.cs
@@ -26,7 +26,7 @@ internal class License
     /// </summary>
     internal License(ClaimsPrincipal claims)
     {
-        if (Int32.TryParse(claims.FindFirst("id")?.Value, out var id))
+        if (int.TryParse(claims.FindFirst("id")?.Value, out var id))
         {
             SerialNumber = id;
         }
@@ -34,7 +34,7 @@ internal class License
         CompanyName = claims.FindFirst("company_name")?.Value;
         ContactInfo = claims.FindFirst("contact_info")?.Value;
 
-        if (Int64.TryParse(claims.FindFirst("exp")?.Value, out var exp))
+        if (long.TryParse(claims.FindFirst("exp")?.Value, out var exp))
         {
             Expiration = DateTimeOffset.FromUnixTimeSeconds(exp);
         }

--- a/identity-server/src/IdentityServer/ResponseHandling/Models/BackchannelAuthenticationResponse.cs
+++ b/identity-server/src/IdentityServer/ResponseHandling/Models/BackchannelAuthenticationResponse.cs
@@ -30,7 +30,7 @@ public class BackchannelAuthenticationResponse
     /// <summary>
     /// Indicates if this response represents an error.
     /// </summary>
-    public bool IsError => !String.IsNullOrWhiteSpace(Error);
+    public bool IsError => !string.IsNullOrWhiteSpace(Error);
 
     /// <summary>
     /// Gets or sets the error.

--- a/identity-server/src/IdentityServer/Services/Default/DefaultCorsPolicyService.cs
+++ b/identity-server/src/IdentityServer/Services/Default/DefaultCorsPolicyService.cs
@@ -50,7 +50,7 @@ public class DefaultCorsPolicyService : ICorsPolicyService
     {
         using var activity = Tracing.ServiceActivitySource.StartActivity("DefaultCorsPolicyService.IsOriginAllowed");
 
-        if (!String.IsNullOrWhiteSpace(origin))
+        if (!string.IsNullOrWhiteSpace(origin))
         {
             if (AllowAll)
             {

--- a/identity-server/src/IdentityServer/Services/Default/DefaultSessionCoordinationService.cs
+++ b/identity-server/src/IdentityServer/Services/Default/DefaultSessionCoordinationService.cs
@@ -238,7 +238,7 @@ public class DefaultSessionCoordinationService : ISessionCoordinationService
                             await ServerSideTicketStore.RetrieveAsync(session.Key) is
                             { Properties: { IsPersistent: true, AllowRefresh: null or true } } ticket)
                         {
-                            ticket.Properties.SetString(IdentityServerConstants.ForceCookieRenewalFlag, String.Empty);
+                            ticket.Properties.SetString(IdentityServerConstants.ForceCookieRenewalFlag, string.Empty);
                             ticket.Properties.IssuedUtc = session.Renewed;
                             ticket.Properties.ExpiresUtc = session.Expires;
                             await ServerSideTicketStore.RenewAsync(session.Key, ticket);

--- a/identity-server/src/IdentityServer/Stores/Default/ProtectedDataMessageStore.cs
+++ b/identity-server/src/IdentityServer/Stores/Default/ProtectedDataMessageStore.cs
@@ -46,7 +46,7 @@ public class ProtectedDataMessageStore<TModel> : IMessageStore<TModel>
 
         Message<TModel> result = null;
 
-        if (!String.IsNullOrWhiteSpace(value))
+        if (!string.IsNullOrWhiteSpace(value))
         {
             try
             {

--- a/identity-server/src/IdentityServer/Stores/Default/ServerSideTicketStore.cs
+++ b/identity-server/src/IdentityServer/Stores/Default/ServerSideTicketStore.cs
@@ -136,7 +136,7 @@ public class ServerSideTicketStore : IServerSideTicketStore
 
         var sub = ticket.GetSubjectId();
         var sid = ticket.GetSessionId();
-        var name = String.IsNullOrWhiteSpace(_options.ServerSideSessions.UserDisplayNameClaimType) ? null : ticket.Principal.FindFirst(_options.ServerSideSessions.UserDisplayNameClaimType)?.Value;
+        var name = string.IsNullOrWhiteSpace(_options.ServerSideSessions.UserDisplayNameClaimType) ? null : ticket.Principal.FindFirst(_options.ServerSideSessions.UserDisplayNameClaimType)?.Value;
 
         var isNew = session.SubjectId != sub || session.SessionId != sid;
         if (isNew)

--- a/identity-server/src/IdentityServer/Stores/InMemory/InMemoryPersistedGrantStore.cs
+++ b/identity-server/src/IdentityServer/Stores/InMemory/InMemoryPersistedGrantStore.cs
@@ -86,22 +86,22 @@ public class InMemoryPersistedGrantStore : IPersistedGrantStore
         if (filter.ClientIds != null)
         {
             var ids = filter.ClientIds.ToList();
-            if (!String.IsNullOrWhiteSpace(filter.ClientId))
+            if (!string.IsNullOrWhiteSpace(filter.ClientId))
             {
                 ids.Add(filter.ClientId);
             }
             query = query.Where(x => ids.Contains(x.ClientId));
         }
-        else if (!String.IsNullOrWhiteSpace(filter.ClientId))
+        else if (!string.IsNullOrWhiteSpace(filter.ClientId))
         {
             query = query.Where(x => x.ClientId == filter.ClientId);
         }
 
-        if (!String.IsNullOrWhiteSpace(filter.SessionId))
+        if (!string.IsNullOrWhiteSpace(filter.SessionId))
         {
             query = query.Where(x => x.SessionId == filter.SessionId);
         }
-        if (!String.IsNullOrWhiteSpace(filter.SubjectId))
+        if (!string.IsNullOrWhiteSpace(filter.SubjectId))
         {
             query = query.Where(x => x.SubjectId == filter.SubjectId);
         }
@@ -109,13 +109,13 @@ public class InMemoryPersistedGrantStore : IPersistedGrantStore
         if (filter.Types != null)
         {
             var types = filter.Types.ToList();
-            if (!String.IsNullOrWhiteSpace(filter.Type))
+            if (!string.IsNullOrWhiteSpace(filter.Type))
             {
                 types.Add(filter.Type);
             }
             query = query.Where(x => types.Contains(x.Type));
         }
-        else if (!String.IsNullOrWhiteSpace(filter.Type))
+        else if (!string.IsNullOrWhiteSpace(filter.Type))
         {
             query = query.Where(x => x.Type == filter.Type);
         }

--- a/identity-server/src/IdentityServer/Stores/InMemory/InMemoryServerSideSessionStore.cs
+++ b/identity-server/src/IdentityServer/Stores/InMemory/InMemoryServerSideSessionStore.cs
@@ -66,11 +66,11 @@ public class InMemoryServerSideSessionStore : IServerSideSessionStore
         filter.Validate();
 
         var query = _store.Values.AsQueryable();
-        if (!String.IsNullOrWhiteSpace(filter.SubjectId))
+        if (!string.IsNullOrWhiteSpace(filter.SubjectId))
         {
             query = query.Where(x => x.SubjectId == filter.SubjectId);
         }
-        if (!String.IsNullOrWhiteSpace(filter.SessionId))
+        if (!string.IsNullOrWhiteSpace(filter.SessionId))
         {
             query = query.Where(x => x.SessionId == filter.SessionId);
         }
@@ -87,11 +87,11 @@ public class InMemoryServerSideSessionStore : IServerSideSessionStore
         filter.Validate();
 
         var query = _store.Values.AsQueryable();
-        if (!String.IsNullOrWhiteSpace(filter.SubjectId))
+        if (!string.IsNullOrWhiteSpace(filter.SubjectId))
         {
             query = query.Where(x => x.SubjectId == filter.SubjectId);
         }
-        if (!String.IsNullOrWhiteSpace(filter.SessionId))
+        if (!string.IsNullOrWhiteSpace(filter.SessionId))
         {
             query = query.Where(x => x.SessionId == filter.SessionId);
         }
@@ -142,8 +142,8 @@ public class InMemoryServerSideSessionStore : IServerSideSessionStore
 
         // these are the keys of first and last items in the prior results
         // stored as "x,y" in the filter.ResultsToken.
-        var first = String.Empty;
-        var last = String.Empty;
+        var first = string.Empty;
+        var last = string.Empty;
 
         if (filter.ResultsToken != null)
         {
@@ -160,9 +160,9 @@ public class InMemoryServerSideSessionStore : IServerSideSessionStore
 
         var query = _store.Values.AsQueryable();
 
-        if (!String.IsNullOrWhiteSpace(filter.DisplayName) ||
-            !String.IsNullOrWhiteSpace(filter.SubjectId) ||
-            !String.IsNullOrWhiteSpace(filter.SessionId))
+        if (!string.IsNullOrWhiteSpace(filter.DisplayName) ||
+            !string.IsNullOrWhiteSpace(filter.SubjectId) ||
+            !string.IsNullOrWhiteSpace(filter.SessionId))
         {
             query = query.Where(x =>
                 (filter.SubjectId == null || x.SubjectId.Contains(filter.SubjectId)) &&
@@ -184,7 +184,7 @@ public class InMemoryServerSideSessionStore : IServerSideSessionStore
         {
             // sets query at the prior record from the last results, but in reverse order
             items = query.OrderByDescending(x => x.Key)
-                .Where(x => String.Compare(x.Key, first) < 0)
+                .Where(x => string.Compare(x.Key, first) < 0)
                 // and we +1 to see if there's a prev page
                 .Take(countRequested + 1)
                 .ToArray();
@@ -205,7 +205,7 @@ public class InMemoryServerSideSessionStore : IServerSideSessionStore
             if (items.Any())
             {
                 var postCountId = items[items.Length - 1].Key;
-                var postCount = query.Where(x => String.Compare(x.Key, postCountId) > 0).Count();
+                var postCount = query.Where(x => string.Compare(x.Key, postCountId) > 0).Count();
                 hasNext = postCount > 0;
                 currPage = totalPages - (int)Math.Ceiling((1.0 * postCount) / countRequested);
             }
@@ -223,7 +223,7 @@ public class InMemoryServerSideSessionStore : IServerSideSessionStore
         {
             items = query.OrderBy(x => x.Key)
                 // if last is "", then this will just start at beginning
-                .Where(x => String.Compare(x.Key, last) > 0)
+                .Where(x => string.Compare(x.Key, last) > 0)
                 // and we +1 to see if there's a next page
                 .Take(countRequested + 1)
                 .ToArray();
@@ -241,7 +241,7 @@ public class InMemoryServerSideSessionStore : IServerSideSessionStore
             if (items.Any())
             {
                 var priorCountId = items[0].Key;
-                var priorCount = query.Where(x => String.Compare(x.Key, priorCountId) < 0).Count();
+                var priorCount = query.Where(x => string.Compare(x.Key, priorCountId) < 0).Count();
                 hasPrev = priorCount > 0;
                 currPage = 1 + (int)Math.Ceiling((1.0 * priorCount) / countRequested);
             }

--- a/identity-server/src/IdentityServer/Test/TestUserStore.cs
+++ b/identity-server/src/IdentityServer/Test/TestUserStore.cs
@@ -167,11 +167,11 @@ public class TestUserStore
         var sub = CryptoRandom.CreateUniqueId(format: CryptoRandom.OutputFormat.Hex);
 
         var claims = new List<Claim>();
-        if (!String.IsNullOrEmpty(name))
+        if (!string.IsNullOrEmpty(name))
         {
             claims.Add(new Claim(ClaimTypes.Name, name));
         }
-        if (!String.IsNullOrEmpty(email))
+        if (!string.IsNullOrEmpty(email))
         {
             claims.Add(new Claim(ClaimTypes.Email, email));
         }

--- a/identity-server/src/IdentityServer/Validation/Default/BackchannelAuthenticationRequestValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/Default/BackchannelAuthenticationRequestValidator.cs
@@ -200,7 +200,7 @@ internal class BackchannelAuthenticationRequestValidator : IBackchannelAuthentic
                 return Invalid(OidcConstants.BackchannelAuthenticationRequestErrors.InvalidRequest, "Invalid requested_expiry");
             }
 
-            if (Int32.TryParse(requestedExpiry, out var expiryValue) &&
+            if (int.TryParse(requestedExpiry, out var expiryValue) &&
                 expiryValue > 0 &&
                 expiryValue <= requestLifetime)
             {

--- a/identity-server/src/IdentityServer/Validation/Default/DefaultDPoPProofValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/Default/DefaultDPoPProofValidator.cs
@@ -73,7 +73,7 @@ public class DefaultDPoPProofValidator : IDPoPProofValidator
 
         try
         {
-            if (String.IsNullOrEmpty(context?.ProofToken))
+            if (string.IsNullOrEmpty(context?.ProofToken))
             {
                 result.IsError = true;
                 result.ErrorDescription = "Missing DPoP proof value.";
@@ -289,7 +289,7 @@ public class DefaultDPoPProofValidator : IDPoPProofValidator
                 result.AccessTokenHash = ath as string;
             }
 
-            if (String.IsNullOrEmpty(result.AccessTokenHash))
+            if (string.IsNullOrEmpty(result.AccessTokenHash))
             {
                 result.IsError = true;
                 result.ErrorDescription = "Invalid 'ath' value.";
@@ -313,7 +313,7 @@ public class DefaultDPoPProofValidator : IDPoPProofValidator
             result.TokenId = jti as string;
         }
 
-        if (String.IsNullOrEmpty(result.TokenId))
+        if (string.IsNullOrEmpty(result.TokenId))
         {
             result.IsError = true;
             result.ErrorDescription = "Invalid 'jti' value.";
@@ -505,7 +505,7 @@ public class DefaultDPoPProofValidator : IDPoPProofValidator
         try
         {
             var value = DataProtector.Unprotect(result.Nonce);
-            if (Int64.TryParse(value, out long iat))
+            if (long.TryParse(value, out long iat))
             {
                 return ValueTask.FromResult(iat);
             }

--- a/identity-server/src/IdentityServer/Validation/Default/DefaultIdentityProviderConfigurationValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/Default/DefaultIdentityProviderConfigurationValidator.cs
@@ -35,7 +35,7 @@ public class DefaultIdentityProviderConfigurationValidator : IIdentityProviderCo
             return;
         }
 
-        if (String.IsNullOrWhiteSpace(context.IdentityProvider.Scheme))
+        if (string.IsNullOrWhiteSpace(context.IdentityProvider.Scheme))
         {
             context.SetError("Scheme is missing.");
             return;
@@ -61,22 +61,22 @@ public class DefaultIdentityProviderConfigurationValidator : IIdentityProviderCo
     /// <returns>A string that represents the error. Null if there is no error.</returns>
     protected virtual Task ValidateOidcProviderAsync(IdentityProviderConfigurationValidationContext<OidcProvider> context)
     {
-        if (String.IsNullOrWhiteSpace(context.IdentityProvider.Authority))
+        if (string.IsNullOrWhiteSpace(context.IdentityProvider.Authority))
         {
             context.SetError("Authority is missing.");
         }
 
-        if (String.IsNullOrWhiteSpace(context.IdentityProvider.ClientId))
+        if (string.IsNullOrWhiteSpace(context.IdentityProvider.ClientId))
         {
             context.SetError("ClientId is missing.");
         }
 
-        if (String.IsNullOrWhiteSpace(context.IdentityProvider.ResponseType))
+        if (string.IsNullOrWhiteSpace(context.IdentityProvider.ResponseType))
         {
             context.SetError("ResponseType is missing.");
         }
 
-        if (String.IsNullOrWhiteSpace(context.IdentityProvider.Scope))
+        if (string.IsNullOrWhiteSpace(context.IdentityProvider.Scope))
         {
             context.SetError("Scope is missing.");
         }

--- a/identity-server/src/IdentityServer/Validation/Default/JwtRequestValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/Default/JwtRequestValidator.cs
@@ -88,7 +88,7 @@ public class JwtRequestValidator : IJwtRequestValidator
 
         ArgumentNullException.ThrowIfNull(context);
         if (context.Client == null) throw new ArgumentNullException(nameof(context.Client));
-        if (String.IsNullOrWhiteSpace(context.JwtTokenString)) throw new ArgumentNullException(nameof(context.JwtTokenString));
+        if (string.IsNullOrWhiteSpace(context.JwtTokenString)) throw new ArgumentNullException(nameof(context.JwtTokenString));
 
         var fail = new JwtRequestValidationResult { IsError = true };
 

--- a/identity-server/src/IdentityServer/Validation/Default/MutualTlsSecretParser.cs
+++ b/identity-server/src/IdentityServer/Validation/Default/MutualTlsSecretParser.cs
@@ -32,7 +32,7 @@ public class MutualTlsSecretParser : ISecretParser
     /// <summary>
     /// Name of authentication method (blank to suppress in discovery since we do special handling)
     /// </summary>
-    public string AuthenticationMethod => String.Empty;
+    public string AuthenticationMethod => string.Empty;
 
     /// <summary>
     /// Parses the HTTP context
@@ -56,7 +56,7 @@ public class MutualTlsSecretParser : ISecretParser
             var id = body["client_id"].FirstOrDefault();
 
             // client id must be present
-            if (!String.IsNullOrWhiteSpace(id))
+            if (!string.IsNullOrWhiteSpace(id))
             {
                 if (id.Length > _options.InputLengthRestrictions.ClientId)
                 {

--- a/identity-server/src/IdentityServer/Validation/Default/SecretParser.cs
+++ b/identity-server/src/IdentityServer/Validation/Default/SecretParser.cs
@@ -68,6 +68,6 @@ public class SecretParser : ISecretsListParser
     /// <returns></returns>
     public IEnumerable<string> GetAvailableAuthenticationMethods()
     {
-        return _parsers.Select(p => p.AuthenticationMethod).Where(p => !String.IsNullOrWhiteSpace(p));
+        return _parsers.Select(p => p.AuthenticationMethod).Where(p => !string.IsNullOrWhiteSpace(p));
     }
 }

--- a/identity-server/src/IdentityServer/Validation/Default/TokenRequestValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/Default/TokenRequestValidator.cs
@@ -788,7 +788,7 @@ internal class TokenRequestValidator : ITokenRequestValidator
                 return Invalid(OidcConstants.AuthorizeErrors.InvalidTarget, "Resource indicator does not match any resource indicator in the original authorize request.");
             }
         }
-        else if (!String.IsNullOrWhiteSpace(_validatedRequest.RequestedResourceIndicator))
+        else if (!string.IsNullOrWhiteSpace(_validatedRequest.RequestedResourceIndicator))
         {
             resourceIndicators = new[] { _validatedRequest.RequestedResourceIndicator };
         }

--- a/identity-server/src/IdentityServer/Validation/Default/TokenValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/Default/TokenValidator.cs
@@ -422,7 +422,7 @@ internal class TokenValidator : ITokenValidator
                 ClaimValueTypes.Integer64)
         };
 
-        if (!String.IsNullOrEmpty(token.Confirmation))
+        if (!string.IsNullOrEmpty(token.Confirmation))
         {
             claims.Add(new Claim(JwtClaimTypes.Confirmation, token.Confirmation, IdentityServerConstants.ClaimValueTypes.Json));
         }

--- a/identity-server/src/IdentityServer/Validation/Models/BackchannelAuthenticationUserValidationResult.cs
+++ b/identity-server/src/IdentityServer/Validation/Models/BackchannelAuthenticationUserValidationResult.cs
@@ -16,7 +16,7 @@ public class BackchannelAuthenticationUserValidationResult
     /// <summary>
     /// Indicates if this represents an error.
     /// </summary>
-    public bool IsError => !String.IsNullOrWhiteSpace(Error);
+    public bool IsError => !string.IsNullOrWhiteSpace(Error);
 
     /// <summary>
     /// Gets or sets the error.

--- a/identity-server/src/IdentityServer/Validation/Models/ResourceValidationResult.cs
+++ b/identity-server/src/IdentityServer/Validation/Models/ResourceValidationResult.cs
@@ -105,14 +105,14 @@ public class ResourceValidationResult
     public ResourceValidationResult FilterByResourceIndicator(string resourceIndicator)
     {
         // filter ApiResources to only the ones allowed by the resource indicator requested
-        var apiResourcesToKeep = (String.IsNullOrWhiteSpace(resourceIndicator) ?
+        var apiResourcesToKeep = (string.IsNullOrWhiteSpace(resourceIndicator) ?
             Resources.ApiResources.Where(x => !x.RequireResourceIndicator) :
             Resources.ApiResources.Where(x => x.Name == resourceIndicator)).ToArray();
 
         var apiScopesToKeep = Resources.ApiScopes.AsEnumerable();
         var parsedScopesToKeep = ParsedScopes;
 
-        if (!String.IsNullOrWhiteSpace(resourceIndicator))
+        if (!string.IsNullOrWhiteSpace(resourceIndicator))
         {
             // filter ApiScopes to only the ones allowed by the ApiResource requested
             var scopeNamesToKeep = apiResourcesToKeep.SelectMany(x => x.Scopes).ToArray();

--- a/identity-server/src/Storage/Extensions/PersistedGrantFilterExtensions.cs
+++ b/identity-server/src/Storage/Extensions/PersistedGrantFilterExtensions.cs
@@ -19,11 +19,11 @@ public static class PersistedGrantFilterExtensions
     {
         ArgumentNullException.ThrowIfNull(filter);
 
-        if (String.IsNullOrWhiteSpace(filter.ClientId) &&
+        if (string.IsNullOrWhiteSpace(filter.ClientId) &&
             filter.ClientIds == null &&
-            String.IsNullOrWhiteSpace(filter.SessionId) &&
-            String.IsNullOrWhiteSpace(filter.SubjectId) &&
-            String.IsNullOrWhiteSpace(filter.Type) &&
+            string.IsNullOrWhiteSpace(filter.SessionId) &&
+            string.IsNullOrWhiteSpace(filter.SubjectId) &&
+            string.IsNullOrWhiteSpace(filter.Type) &&
             filter.Types == null)
         {
             throw new ArgumentException("No filter values set.", nameof(filter));

--- a/identity-server/src/Storage/Models/Client.cs
+++ b/identity-server/src/Storage/Models/Client.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
-
 #nullable enable
 
 using System.Collections;

--- a/identity-server/src/Storage/Models/RefreshToken.cs
+++ b/identity-server/src/Storage/Models/RefreshToken.cs
@@ -62,7 +62,7 @@ public class RefreshToken
     /// <returns></returns>
     public Token? GetAccessToken(string? resourceIndicator = null)
     {
-        AccessTokens.TryGetValue(resourceIndicator ?? String.Empty, out var token);
+        AccessTokens.TryGetValue(resourceIndicator ?? string.Empty, out var token);
         return token;
     }
 
@@ -74,7 +74,7 @@ public class RefreshToken
     /// <returns></returns>
     public void SetAccessToken(Token token, string? resourceIndicator = null)
     {
-        AccessTokens[resourceIndicator ?? String.Empty] = token;
+        AccessTokens[resourceIndicator ?? string.Empty] = token;
     }
 
     /// <summary>

--- a/identity-server/src/Storage/Models/Secret.cs
+++ b/identity-server/src/Storage/Models/Secret.cs
@@ -96,11 +96,11 @@ public class Secret
     }
 
     /// <summary>
-    /// Determines whether the specified <see cref="System.Object" />, is equal to this instance.
+    /// Determines whether the specified <see cref="object" />, is equal to this instance.
     /// </summary>
-    /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>
+    /// <param name="obj">The <see cref="object" /> to compare with this instance.</param>
     /// <returns>
-    ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
+    ///   <c>true</c> if the specified <see cref="object" /> is equal to this instance; otherwise, <c>false</c>.
     /// </returns>
     public override bool Equals(object? obj)
     {
@@ -109,7 +109,7 @@ public class Secret
         if (other == null) return false;
         if (ReferenceEquals(other, this)) return true;
 
-        return String.Equals(other.Type, Type, StringComparison.Ordinal) &&
-               String.Equals(other.Value, Value, StringComparison.Ordinal);
+        return string.Equals(other.Type, Type, StringComparison.Ordinal) &&
+               string.Equals(other.Value, Value, StringComparison.Ordinal);
     }
 }

--- a/identity-server/src/Storage/Stores/SessionFilter.cs
+++ b/identity-server/src/Storage/Stores/SessionFilter.cs
@@ -26,7 +26,7 @@ public class SessionFilter
     /// </summary>
     public void Validate()
     {
-        if (String.IsNullOrWhiteSpace(SubjectId) && String.IsNullOrWhiteSpace(SessionId))
+        if (string.IsNullOrWhiteSpace(SubjectId) && string.IsNullOrWhiteSpace(SessionId))
         {
             throw new ArgumentNullException("SubjectId or SessionId is required.");
         }

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Account/Login/ViewModel.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Account/Login/ViewModel.cs
@@ -6,7 +6,7 @@ public class ViewModel
     public bool EnableLocalLogin { get; set; } = true;
 
     public IEnumerable<ViewModel.ExternalProvider> ExternalProviders { get; set; } = Enumerable.Empty<ExternalProvider>();
-    public IEnumerable<ViewModel.ExternalProvider> VisibleExternalProviders => ExternalProviders.Where(x => !String.IsNullOrWhiteSpace(x.DisplayName));
+    public IEnumerable<ViewModel.ExternalProvider> VisibleExternalProviders => ExternalProviders.Where(x => !string.IsNullOrWhiteSpace(x.DisplayName));
 
     public bool IsExternalLoginOnly => EnableLocalLogin == false && ExternalProviders?.Count() == 1;
     public string? ExternalLoginScheme => IsExternalLoginOnly ? ExternalProviders?.SingleOrDefault()?.AuthenticationScheme : null;

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Account/Logout/LoggedOut.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Account/Logout/LoggedOut.cshtml.cs
@@ -26,7 +26,7 @@ public class LoggedOut : PageModel
         {
             AutomaticRedirectAfterSignOut = LogoutOptions.AutomaticRedirectAfterSignOut,
             PostLogoutRedirectUri = logout?.PostLogoutRedirectUri,
-            ClientName = String.IsNullOrEmpty(logout?.ClientName) ? logout?.ClientId : logout?.ClientName,
+            ClientName = string.IsNullOrEmpty(logout?.ClientName) ? logout?.ClientId : logout?.ClientName,
             SignOutIframeUrl = logout?.SignOutIFrameUrl
         };
     }

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Ciba/Consent.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Ciba/Consent.cshtml.cs
@@ -194,7 +194,7 @@ public class Consent : PageModel
     private static ScopeViewModel CreateScopeViewModel(ParsedScopeValue parsedScopeValue, ApiScope apiScope, bool check)
     {
         var displayName = apiScope.DisplayName ?? apiScope.Name;
-        if (!String.IsNullOrWhiteSpace(parsedScopeValue.ParsedParameter))
+        if (!string.IsNullOrWhiteSpace(parsedScopeValue.ParsedParameter))
         {
             displayName += ":" + parsedScopeValue.ParsedParameter;
         }

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Consent/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Consent/Index.cshtml.cs
@@ -202,7 +202,7 @@ public class Index : PageModel
     private static ScopeViewModel CreateScopeViewModel(ParsedScopeValue parsedScopeValue, ApiScope apiScope, bool check)
     {
         var displayName = apiScope.DisplayName ?? apiScope.Name;
-        if (!String.IsNullOrWhiteSpace(parsedScopeValue.ParsedParameter))
+        if (!string.IsNullOrWhiteSpace(parsedScopeValue.ParsedParameter))
         {
             displayName += ":" + parsedScopeValue.ParsedParameter;
         }

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Device/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Device/Index.cshtml.cs
@@ -40,7 +40,7 @@ public class Index : PageModel
 
     public async Task<IActionResult> OnGet(string? userCode)
     {
-        if (String.IsNullOrWhiteSpace(userCode))
+        if (string.IsNullOrWhiteSpace(userCode))
         {
             return Page();
         }

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Account/Login/ViewModel.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Account/Login/ViewModel.cs
@@ -6,7 +6,7 @@ public class ViewModel
     public bool EnableLocalLogin { get; set; } = true;
 
     public IEnumerable<ViewModel.ExternalProvider> ExternalProviders { get; set; } = Enumerable.Empty<ExternalProvider>();
-    public IEnumerable<ViewModel.ExternalProvider> VisibleExternalProviders => ExternalProviders.Where(x => !String.IsNullOrWhiteSpace(x.DisplayName));
+    public IEnumerable<ViewModel.ExternalProvider> VisibleExternalProviders => ExternalProviders.Where(x => !string.IsNullOrWhiteSpace(x.DisplayName));
 
     public bool IsExternalLoginOnly => EnableLocalLogin == false && ExternalProviders?.Count() == 1;
     public string? ExternalLoginScheme => IsExternalLoginOnly ? ExternalProviders?.SingleOrDefault()?.AuthenticationScheme : null;

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Account/Logout/LoggedOut.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Account/Logout/LoggedOut.cshtml.cs
@@ -26,7 +26,7 @@ public class LoggedOut : PageModel
         {
             AutomaticRedirectAfterSignOut = LogoutOptions.AutomaticRedirectAfterSignOut,
             PostLogoutRedirectUri = logout?.PostLogoutRedirectUri,
-            ClientName = String.IsNullOrEmpty(logout?.ClientName) ? logout?.ClientId : logout?.ClientName,
+            ClientName = string.IsNullOrEmpty(logout?.ClientName) ? logout?.ClientId : logout?.ClientName,
             SignOutIframeUrl = logout?.SignOutIFrameUrl
         };
     }

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Admin/ApiScopes/ApiScopeRepository.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Admin/ApiScopes/ApiScopeRepository.cs
@@ -34,7 +34,7 @@ public class ApiScopeRepository
             .Include(x => x.UserClaims)
             .AsQueryable();
 
-        if (!String.IsNullOrWhiteSpace(filter))
+        if (!string.IsNullOrWhiteSpace(filter))
         {
             query = query.Where(x => x.Name.Contains(filter) || x.DisplayName.Contains(filter));
         }
@@ -103,7 +103,7 @@ public class ApiScopeRepository
         }
 
         var claims = model.UserClaims?.Split(' ', StringSplitOptions.RemoveEmptyEntries).ToArray() ?? Enumerable.Empty<string>();
-        var currentClaims = (scope.UserClaims.Select(x => x.Type) ?? Enumerable.Empty<String>()).ToArray();
+        var currentClaims = (scope.UserClaims.Select(x => x.Type) ?? Enumerable.Empty<string>()).ToArray();
 
         var claimsToAdd = claims.Except(currentClaims).ToArray();
         var claimsToRemove = currentClaims.Except(claims).ToArray();

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Admin/Clients/ClientRepository.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Admin/Clients/ClientRepository.cs
@@ -73,7 +73,7 @@ public class ClientRepository
             .Include(x => x.AllowedGrantTypes)
             .Where(x => x.AllowedGrantTypes.Count == 1 && x.AllowedGrantTypes.Any(grant => grants.Contains(grant.GrantType)));
 
-        if (!String.IsNullOrWhiteSpace(filter))
+        if (!string.IsNullOrWhiteSpace(filter))
         {
             query = query.Where(x => x.ClientId.Contains(filter) || x.ClientName.Contains(filter));
         }
@@ -161,7 +161,7 @@ public class ClientRepository
         }
 
         var scopes = model.AllowedScopes.Split(' ', StringSplitOptions.RemoveEmptyEntries).ToArray();
-        var currentScopes = (client.AllowedScopes.Select(x => x.Scope) ?? Enumerable.Empty<String>()).ToArray();
+        var currentScopes = (client.AllowedScopes.Select(x => x.Scope) ?? Enumerable.Empty<string>()).ToArray();
 
         var scopesToAdd = scopes.Except(currentScopes).ToArray();
         var scopesToRemove = currentScopes.Except(scopes).ToArray();

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Admin/IdentityScopes/IdentityScopeRepository.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Admin/IdentityScopes/IdentityScopeRepository.cs
@@ -34,7 +34,7 @@ public class IdentityScopeRepository
             .Include(x => x.UserClaims)
             .AsQueryable();
 
-        if (!String.IsNullOrWhiteSpace(filter))
+        if (!string.IsNullOrWhiteSpace(filter))
         {
             query = query.Where(x => x.Name.Contains(filter) || x.DisplayName.Contains(filter));
         }
@@ -102,7 +102,7 @@ public class IdentityScopeRepository
         }
 
         var claims = model.UserClaims?.Split(' ', StringSplitOptions.RemoveEmptyEntries).ToArray() ?? Enumerable.Empty<string>();
-        var currentClaims = (scope.UserClaims.Select(x => x.Type) ?? Enumerable.Empty<String>()).ToArray();
+        var currentClaims = (scope.UserClaims.Select(x => x.Type) ?? Enumerable.Empty<string>()).ToArray();
 
         var claimsToAdd = claims.Except(currentClaims).ToArray();
         var claimsToRemove = currentClaims.Except(claims).ToArray();

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Ciba/Consent.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Ciba/Consent.cshtml.cs
@@ -194,7 +194,7 @@ public class Consent : PageModel
     private static ScopeViewModel CreateScopeViewModel(ParsedScopeValue parsedScopeValue, ApiScope apiScope, bool check)
     {
         var displayName = apiScope.DisplayName ?? apiScope.Name;
-        if (!String.IsNullOrWhiteSpace(parsedScopeValue.ParsedParameter))
+        if (!string.IsNullOrWhiteSpace(parsedScopeValue.ParsedParameter))
         {
             displayName += ":" + parsedScopeValue.ParsedParameter;
         }

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Consent/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Consent/Index.cshtml.cs
@@ -202,7 +202,7 @@ public class Index : PageModel
     private static ScopeViewModel CreateScopeViewModel(ParsedScopeValue parsedScopeValue, ApiScope apiScope, bool check)
     {
         var displayName = apiScope.DisplayName ?? apiScope.Name;
-        if (!String.IsNullOrWhiteSpace(parsedScopeValue.ParsedParameter))
+        if (!string.IsNullOrWhiteSpace(parsedScopeValue.ParsedParameter))
         {
             displayName += ":" + parsedScopeValue.ParsedParameter;
         }

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Device/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Device/Index.cshtml.cs
@@ -40,7 +40,7 @@ public class Index : PageModel
 
     public async Task<IActionResult> OnGet(string? userCode)
     {
-        if (String.IsNullOrWhiteSpace(userCode))
+        if (string.IsNullOrWhiteSpace(userCode))
         {
             return Page();
         }

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Portal/ClientRepository.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Portal/ClientRepository.cs
@@ -24,7 +24,7 @@ public class ClientRepository
         var query = _context.Clients
             .Where(c => c.InitiateLoginUri != null);
 
-        if (!String.IsNullOrWhiteSpace(filter))
+        if (!string.IsNullOrWhiteSpace(filter))
         {
             query = query.Where(x => x.ClientId.Contains(filter) || x.ClientName.Contains(filter));
         }

--- a/identity-server/templates/src/IdentityServerInMem/Pages/Account/Login/ViewModel.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/Account/Login/ViewModel.cs
@@ -6,7 +6,7 @@ public class ViewModel
     public bool EnableLocalLogin { get; set; } = true;
 
     public IEnumerable<ViewModel.ExternalProvider> ExternalProviders { get; set; } = Enumerable.Empty<ExternalProvider>();
-    public IEnumerable<ViewModel.ExternalProvider> VisibleExternalProviders => ExternalProviders.Where(x => !String.IsNullOrWhiteSpace(x.DisplayName));
+    public IEnumerable<ViewModel.ExternalProvider> VisibleExternalProviders => ExternalProviders.Where(x => !string.IsNullOrWhiteSpace(x.DisplayName));
 
     public bool IsExternalLoginOnly => EnableLocalLogin == false && ExternalProviders?.Count() == 1;
     public string? ExternalLoginScheme => IsExternalLoginOnly ? ExternalProviders?.SingleOrDefault()?.AuthenticationScheme : null;

--- a/identity-server/templates/src/IdentityServerInMem/Pages/Account/Logout/LoggedOut.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/Account/Logout/LoggedOut.cshtml.cs
@@ -26,7 +26,7 @@ public class LoggedOut : PageModel
         {
             AutomaticRedirectAfterSignOut = LogoutOptions.AutomaticRedirectAfterSignOut,
             PostLogoutRedirectUri = logout?.PostLogoutRedirectUri,
-            ClientName = String.IsNullOrEmpty(logout?.ClientName) ? logout?.ClientId : logout?.ClientName,
+            ClientName = string.IsNullOrEmpty(logout?.ClientName) ? logout?.ClientId : logout?.ClientName,
             SignOutIframeUrl = logout?.SignOutIFrameUrl
         };
     }

--- a/identity-server/templates/src/IdentityServerInMem/Pages/Ciba/Consent.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/Ciba/Consent.cshtml.cs
@@ -194,7 +194,7 @@ public class Consent : PageModel
     private static ScopeViewModel CreateScopeViewModel(ParsedScopeValue parsedScopeValue, ApiScope apiScope, bool check)
     {
         var displayName = apiScope.DisplayName ?? apiScope.Name;
-        if (!String.IsNullOrWhiteSpace(parsedScopeValue.ParsedParameter))
+        if (!string.IsNullOrWhiteSpace(parsedScopeValue.ParsedParameter))
         {
             displayName += ":" + parsedScopeValue.ParsedParameter;
         }

--- a/identity-server/templates/src/IdentityServerInMem/Pages/Consent/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/Consent/Index.cshtml.cs
@@ -202,7 +202,7 @@ public class Index : PageModel
     private static ScopeViewModel CreateScopeViewModel(ParsedScopeValue parsedScopeValue, ApiScope apiScope, bool check)
     {
         var displayName = apiScope.DisplayName ?? apiScope.Name;
-        if (!String.IsNullOrWhiteSpace(parsedScopeValue.ParsedParameter))
+        if (!string.IsNullOrWhiteSpace(parsedScopeValue.ParsedParameter))
         {
             displayName += ":" + parsedScopeValue.ParsedParameter;
         }

--- a/identity-server/templates/src/IdentityServerInMem/Pages/Device/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/Device/Index.cshtml.cs
@@ -40,7 +40,7 @@ public class Index : PageModel
 
     public async Task<IActionResult> OnGet(string? userCode)
     {
-        if (String.IsNullOrWhiteSpace(userCode))
+        if (string.IsNullOrWhiteSpace(userCode))
         {
             return Page();
         }

--- a/identity-server/test/IdentityServer.IntegrationTests/Common/BrowserHandler.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Common/BrowserHandler.cs
@@ -15,7 +15,7 @@ public class BrowserHandler : DelegatingHandler
     public bool AllowCookies { get; set; } = true;
     public bool AllowAutoRedirect { get; set; } = true;
     public int ErrorRedirectLimit { get; set; } = 20;
-    public int StopRedirectingAfter { get; set; } = Int32.MaxValue;
+    public int StopRedirectingAfter { get; set; } = int.MaxValue;
 
     public BrowserHandler(HttpMessageHandler next)
         : base(next)

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Ciba/CibaTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Ciba/CibaTests.cs
@@ -120,7 +120,7 @@ public class CibaTests
 
         foreach (var item in values)
         {
-            if (!String.IsNullOrWhiteSpace(item.Value))
+            if (!string.IsNullOrWhiteSpace(item.Value))
             {
                 claims.Add(new Claim(item.Key, item.Value));
             }
@@ -1016,7 +1016,7 @@ public class CibaTests
             { "scope", "openid profile scope1 offline_access" },
             { "login_hint", "this means bob" },
             { "binding_message", bindingMessage },
-            { "resource", new String('x', 2000) },
+            { "resource", new string('x', 2000) },
         };
 
         SetValidatedUser();

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Token/DPoPTokenEndpointTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Token/DPoPTokenEndpointTests.cs
@@ -186,7 +186,7 @@ public class DPoPTokenEndpointTests
             if (item.Value.ValueKind == JsonValueKind.String)
             {
                 var val = item.Value.GetString();
-                if (!String.IsNullOrEmpty(val))
+                if (!string.IsNullOrEmpty(val))
                 {
                     jwkValues.Add(item.Name, val);
                 }

--- a/identity-server/test/IdentityServer.IntegrationTests/Hosting/FederatedSignoutTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Hosting/FederatedSignoutTests.cs
@@ -112,7 +112,7 @@ public class FederatedSignoutTests
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
         response.Content.Headers.ContentType.ShouldBeNull();
         var html = await response.Content.ReadAsStringAsync();
-        html.ShouldBe(String.Empty);
+        html.ShouldBe(string.Empty);
     }
 
     [Fact]
@@ -123,7 +123,7 @@ public class FederatedSignoutTests
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
         response.Content.Headers.ContentType.ShouldBeNull();
         var html = await response.Content.ReadAsStringAsync();
-        html.ShouldBe(String.Empty);
+        html.ShouldBe(string.Empty);
     }
 
     [Fact]
@@ -149,7 +149,7 @@ public class FederatedSignoutTests
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
         response.Content.Headers.ContentType.ShouldBeNull();
         var html = await response.Content.ReadAsStringAsync();
-        html.ShouldBe(String.Empty);
+        html.ShouldBe(string.Empty);
     }
 
     [Fact]
@@ -178,6 +178,6 @@ public class FederatedSignoutTests
         response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
         response.Content.Headers.ContentType.ShouldBeNull();
         var html = await response.Content.ReadAsStringAsync();
-        html.ShouldBe(String.Empty);
+        html.ShouldBe(string.Empty);
     }
 }

--- a/identity-server/test/IdentityServer.IntegrationTests/TestFramework/GenericHost.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/TestFramework/GenericHost.cs
@@ -44,7 +44,7 @@ public class GenericHost
 
     public string Url(string path = null)
     {
-        path = path ?? String.Empty;
+        path = path ?? string.Empty;
         if (!path.StartsWith('/')) path = "/" + path;
         return _baseAddress + path;
     }

--- a/identity-server/test/IdentityServer.IntegrationTests/TestFramework/TestBrowserClient.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/TestFramework/TestBrowserClient.cs
@@ -222,7 +222,7 @@ public class TestBrowserClient : HttpClient
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
         await AssertExistsAsync(response, ".error-page");
 
-        if (!String.IsNullOrWhiteSpace(error))
+        if (!string.IsNullOrWhiteSpace(error))
         {
             var errorText = await ReadElementTextAsync(response, ".alert.alert-danger");
             errorText.ShouldContain(error);
@@ -238,7 +238,7 @@ public class TestBrowserClient : HttpClient
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
         await AssertExistsAsync(response, ".validation-summary-errors");
 
-        if (!String.IsNullOrWhiteSpace(error))
+        if (!string.IsNullOrWhiteSpace(error))
         {
             var errorText = await ReadElementTextAsync(response, ".validation-summary-errors");
             errorText.ToLowerInvariant().ShouldContain(error.ToLowerInvariant());

--- a/identity-server/test/IdentityServer.UnitTests/Extensions/IdentityServerBuilderExtensionsCryptoTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Extensions/IdentityServerBuilderExtensionsCryptoTests.cs
@@ -46,7 +46,7 @@ public class IdentityServerBuilderExtensionsCryptoTests
         IServiceCollection services = new ServiceCollection();
         IIdentityServerBuilder identityServerBuilder = new IdentityServerBuilder(services);
 
-        String json =
+        string json =
             """
             {
                 "alg" : "HS256",

--- a/identity-server/test/IdentityServer.UnitTests/Services/Default/DefaultCorsPolicyServiceTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Services/Default/DefaultCorsPolicyServiceTests.cs
@@ -23,7 +23,7 @@ public class DefaultCorsPolicyServiceTests
     public async Task IsOriginAllowed_null_param_ReturnsFalse()
     {
         (await subject.IsOriginAllowedAsync(null)).ShouldBe(false);
-        (await subject.IsOriginAllowedAsync(String.Empty)).ShouldBe(false);
+        (await subject.IsOriginAllowedAsync(string.Empty)).ShouldBe(false);
         (await subject.IsOriginAllowedAsync("    ")).ShouldBe(false);
     }
 

--- a/identity-server/test/IdentityServer.UnitTests/Stores/Default/ServerSideSessionCookieEventsTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Stores/Default/ServerSideSessionCookieEventsTests.cs
@@ -65,7 +65,7 @@ public class ServerSideSessionCookieEventsTests
         };
         if (forceRenew)
         {
-            authProperties.SetString(IdentityServerConstants.ForceCookieRenewalFlag, String.Empty);
+            authProperties.SetString(IdentityServerConstants.ForceCookieRenewalFlag, string.Empty);
         }
 
         var authTicket = new AuthenticationTicket(new ClaimsPrincipal([]), authProperties, "Test")

--- a/identity-server/test/IdentityServer.UnitTests/Validation/ClientConfigurationValidation.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Validation/ClientConfigurationValidation.cs
@@ -460,7 +460,7 @@ public class ClientConfigurationValidation
         var result = await ValidateAsync(client);
         result.IsValid.ShouldBeFalse();
         result.ErrorMessage.ShouldContain("invalid origin");
-        if (!String.IsNullOrWhiteSpace(origin))
+        if (!string.IsNullOrWhiteSpace(origin))
         {
             result.ErrorMessage.ShouldContain(origin);
         }

--- a/identity-server/test/IdentityServer.UnitTests/Validation/DPoPProofValidatorTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Validation/DPoPProofValidatorTests.cs
@@ -87,7 +87,7 @@ public class DPoPProofValidatorTests
             if (item.Value.ValueKind == JsonValueKind.String)
             {
                 var val = item.Value.GetString();
-                if (!String.IsNullOrEmpty(val))
+                if (!string.IsNullOrEmpty(val))
                 {
                     jwkValues.Add(item.Name, val);
                 }


### PR DESCRIPTION
**What issue does this PR address?**

- Enforce using built-in type keywords (e.g., 'string' instead of 'String')
- Applies fixes for rule

Stacked on #1876 will be rebased.

**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
