### PR TITLE
Always include displayname in external providers

### DIFF
--- a/identity-server/hosts/AspNetIdentity/Pages/Account/Login/Index.cshtml.cs
+++ b/identity-server/hosts/AspNetIdentity/Pages/Account/Login/Index.cshtml.cs
@@ -158,21 +158,25 @@ public class Index : PageModel
         };
 
         var context = await _interaction.GetAuthorizationContextAsync(returnUrl);
-        if (context?.IdP != null && await _schemeProvider.GetSchemeAsync(context.IdP) != null)
+        if (context?.IdP != null)
         {
-            var local = context.IdP == Duende.IdentityServer.IdentityServerConstants.LocalIdentityProvider;
-
-            // this is meant to short circuit the UI and only trigger the one external IdP
-            View = new ViewModel
+            var scheme = await _schemeProvider.GetSchemeAsync(context.IdP);
+            if (scheme != null)
             {
-                EnableLocalLogin = local,
-            };
+                var local = context.IdP == Duende.IdentityServer.IdentityServerConstants.LocalIdentityProvider;
 
-            Input.Username = context.LoginHint;
+                // this is meant to short circuit the UI and only trigger the one external IdP
+                View = new ViewModel
+                {
+                    EnableLocalLogin = local,
+                };
 
-            if (!local)
-            {
-                View.ExternalProviders = new[] { new ViewModel.ExternalProvider(authenticationScheme: context.IdP) };
+                Input.Username = context.LoginHint;
+
+                if (!local)
+                {
+                    View.ExternalProviders = [new ViewModel.ExternalProvider(authenticationScheme: context.IdP, displayName: scheme.DisplayName)];
+                }
             }
 
             return;

--- a/identity-server/hosts/Configuration/Pages/Account/Login/Index.cshtml.cs
+++ b/identity-server/hosts/Configuration/Pages/Account/Login/Index.cshtml.cs
@@ -164,21 +164,25 @@ public class Index : PageModel
         };
 
         var context = await _interaction.GetAuthorizationContextAsync(returnUrl);
-        if (context?.IdP != null && await _schemeProvider.GetSchemeAsync(context.IdP) != null)
+        if (context?.IdP != null)
         {
-            var local = context.IdP == Duende.IdentityServer.IdentityServerConstants.LocalIdentityProvider;
-
-            // this is meant to short circuit the UI and only trigger the one external IdP
-            View = new ViewModel
+            var scheme = await _schemeProvider.GetSchemeAsync(context.IdP);
+            if (scheme != null)
             {
-                EnableLocalLogin = local,
-            };
+                var local = context.IdP == Duende.IdentityServer.IdentityServerConstants.LocalIdentityProvider;
 
-            Input.Username = context.LoginHint;
+                // this is meant to short circuit the UI and only trigger the one external IdP
+                View = new ViewModel
+                {
+                    EnableLocalLogin = local,
+                };
 
-            if (!local)
-            {
-                View.ExternalProviders = new[] { new ViewModel.ExternalProvider(authenticationScheme: context.IdP) };
+                Input.Username = context.LoginHint;
+
+                if (!local)
+                {
+                    View.ExternalProviders = [new ViewModel.ExternalProvider(authenticationScheme: context.IdP, displayName: scheme.DisplayName)];
+                }
             }
 
             return;

--- a/identity-server/hosts/EntityFramework/Pages/Account/Login/Index.cshtml.cs
+++ b/identity-server/hosts/EntityFramework/Pages/Account/Login/Index.cshtml.cs
@@ -164,21 +164,25 @@ public class Index : PageModel
         };
 
         var context = await _interaction.GetAuthorizationContextAsync(returnUrl);
-        if (context?.IdP != null && await _schemeProvider.GetSchemeAsync(context.IdP) != null)
+        if (context?.IdP != null)
         {
-            var local = context.IdP == Duende.IdentityServer.IdentityServerConstants.LocalIdentityProvider;
-
-            // this is meant to short circuit the UI and only trigger the one external IdP
-            View = new ViewModel
+            var scheme = await _schemeProvider.GetSchemeAsync(context.IdP);
+            if (scheme != null)
             {
-                EnableLocalLogin = local,
-            };
+                var local = context.IdP == Duende.IdentityServer.IdentityServerConstants.LocalIdentityProvider;
 
-            Input.Username = context.LoginHint;
+                // this is meant to short circuit the UI and only trigger the one external IdP
+                View = new ViewModel
+                {
+                    EnableLocalLogin = local,
+                };
 
-            if (!local)
-            {
-                View.ExternalProviders = new[] { new ViewModel.ExternalProvider(authenticationScheme: context.IdP) };
+                Input.Username = context.LoginHint;
+
+                if (!local)
+                {
+                    View.ExternalProviders = [new ViewModel.ExternalProvider(authenticationScheme: context.IdP, displayName: scheme.DisplayName)];
+                }
             }
 
             return;

--- a/identity-server/hosts/main/Pages/Account/Login/Index.cshtml.cs
+++ b/identity-server/hosts/main/Pages/Account/Login/Index.cshtml.cs
@@ -170,21 +170,25 @@ public class Index : PageModel
         };
 
         var context = await _interaction.GetAuthorizationContextAsync(returnUrl);
-        if (context?.IdP != null && await _schemeProvider.GetSchemeAsync(context.IdP) != null)
+        if (context?.IdP != null)
         {
-            var local = context.IdP == Duende.IdentityServer.IdentityServerConstants.LocalIdentityProvider;
-
-            // this is meant to short circuit the UI and only trigger the one external IdP
-            View = new ViewModel
+            var scheme = await _schemeProvider.GetSchemeAsync(context.IdP);
+            if (scheme != null)
             {
-                EnableLocalLogin = local,
-            };
+                var local = context.IdP == Duende.IdentityServer.IdentityServerConstants.LocalIdentityProvider;
 
-            Input.Username = context.LoginHint;
+                // this is meant to short circuit the UI and only trigger the one external IdP
+                View = new ViewModel
+                {
+                    EnableLocalLogin = local,
+                };
 
-            if (!local)
-            {
-                View.ExternalProviders = new[] { new ViewModel.ExternalProvider(authenticationScheme: context.IdP) };
+                Input.Username = context.LoginHint;
+
+                if (!local)
+                {
+                    View.ExternalProviders = [new ViewModel.ExternalProvider(authenticationScheme: context.IdP, displayName: scheme.DisplayName)];
+                }
             }
 
             return;

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Account/Login/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Account/Login/Index.cshtml.cs
@@ -155,21 +155,25 @@ public class Index : PageModel
         };
 
         var context = await _interaction.GetAuthorizationContextAsync(returnUrl);
-        if (context?.IdP != null && await _schemeProvider.GetSchemeAsync(context.IdP) != null)
+        if (context?.IdP != null)
         {
-            var local = context.IdP == Duende.IdentityServer.IdentityServerConstants.LocalIdentityProvider;
-
-            // this is meant to short circuit the UI and only trigger the one external IdP
-            View = new ViewModel
+            var scheme = await _schemeProvider.GetSchemeAsync(context.IdP);
+            if (scheme != null)
             {
-                EnableLocalLogin = local,
-            };
+                var local = context.IdP == Duende.IdentityServer.IdentityServerConstants.LocalIdentityProvider;
 
-            Input.Username = context.LoginHint;
+                // this is meant to short circuit the UI and only trigger the one external IdP
+                View = new ViewModel
+                {
+                    EnableLocalLogin = local,
+                };
 
-            if (!local)
-            {
-                View.ExternalProviders = new[] { new ViewModel.ExternalProvider(authenticationScheme: context.IdP) };
+                Input.Username = context.LoginHint;
+
+                if (!local)
+                {
+                    View.ExternalProviders = [new ViewModel.ExternalProvider(authenticationScheme: context.IdP, displayName: scheme.DisplayName)];
+                }
             }
 
             return;

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Account/Login/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Account/Login/Index.cshtml.cs
@@ -167,21 +167,25 @@ public class Index : PageModel
         };
 
         var context = await _interaction.GetAuthorizationContextAsync(returnUrl);
-        if (context?.IdP != null && await _schemeProvider.GetSchemeAsync(context.IdP) != null)
+        if (context?.IdP != null)
         {
-            var local = context.IdP == Duende.IdentityServer.IdentityServerConstants.LocalIdentityProvider;
-
-            // this is meant to short circuit the UI and only trigger the one external IdP
-            View = new ViewModel
+            var scheme = await _schemeProvider.GetSchemeAsync(context.IdP);
+            if (scheme != null)
             {
-                EnableLocalLogin = local,
-            };
+                var local = context.IdP == Duende.IdentityServer.IdentityServerConstants.LocalIdentityProvider;
 
-            Input.Username = context.LoginHint;
+                // this is meant to short circuit the UI and only trigger the one external IdP
+                View = new ViewModel
+                {
+                    EnableLocalLogin = local,
+                };
 
-            if (!local)
-            {
-                View.ExternalProviders = new[] { new ViewModel.ExternalProvider(authenticationScheme: context.IdP) };
+                Input.Username = context.LoginHint;
+
+                if (!local)
+                {
+                    View.ExternalProviders = [new ViewModel.ExternalProvider(authenticationScheme: context.IdP, displayName: scheme.DisplayName)];
+                }
             }
 
             return;

--- a/identity-server/templates/src/IdentityServerInMem/Pages/Account/Login/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/Account/Login/Index.cshtml.cs
@@ -167,21 +167,25 @@ public class Index : PageModel
         };
 
         var context = await _interaction.GetAuthorizationContextAsync(returnUrl);
-        if (context?.IdP != null && await _schemeProvider.GetSchemeAsync(context.IdP) != null)
+        if (context?.IdP != null)
         {
-            var local = context.IdP == Duende.IdentityServer.IdentityServerConstants.LocalIdentityProvider;
-
-            // this is meant to short circuit the UI and only trigger the one external IdP
-            View = new ViewModel
+            var scheme = await _schemeProvider.GetSchemeAsync(context.IdP);
+            if (scheme != null)
             {
-                EnableLocalLogin = local,
-            };
+                var local = context.IdP == Duende.IdentityServer.IdentityServerConstants.LocalIdentityProvider;
 
-            Input.Username = context.LoginHint;
+                // this is meant to short circuit the UI and only trigger the one external IdP
+                View = new ViewModel
+                {
+                    EnableLocalLogin = local,
+                };
 
-            if (!local)
-            {
-                View.ExternalProviders = new[] { new ViewModel.ExternalProvider(authenticationScheme: context.IdP) };
+                Input.Username = context.LoginHint;
+
+                if (!local)
+                {
+                    View.ExternalProviders = [new ViewModel.ExternalProvider(authenticationScheme: context.IdP, displayName: scheme.DisplayName)];
+                }
             }
 
             return;


### PR DESCRIPTION
There's an edge case where we don't set the displayname in the ui template for the login page. Normally that doesn't matter because our template would immediately challenge instead of needing to display the external provider. However, some users have run into situations where it caused errors for them. 

My speculation is that there was some additional customization performed, but we'll still apply this change because it doesn't add overhead and makes the template code more robust.

This is a recreation of a community PR to fix that issue. I've rebased onto the latest in main, and applied the fix to all hosts and templates.

Thanks to @stefannikolei for the original contribution!