### PR TITLE
Remove the Experimental flags from the Preview options

### DIFF
--- a/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/PreviewFeatureOptions.cs
+++ b/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/PreviewFeatureOptions.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
-using System.Diagnostics.CodeAnalysis;
 using System;
 
 namespace Duende.IdentityServer.Configuration;
@@ -14,13 +13,11 @@ public class PreviewFeatureOptions
     /// <summary>
     /// Enables Caching of Discovery Document based on ResponseCaching Interval 
     /// </summary>
-    [Experimental("DUENDEPREVIEW001", UrlFormat = "https://duende.link/previewfeatures?id={0}")]
     public bool EnableDiscoveryDocumentCache { get; set; } = false;
 
     /// <summary>
     /// When clients authenticate with private_key_jwt assertions, validate the audience of the assertion strictly: the audience must be this IdentityServer's issuer identifier as a single string.
     /// </summary>
-    [Experimental("DUENDEPREVIEW002", UrlFormat = "https://duende.link/previewfeatures?id={0}")]
     public bool StrictClientAssertionAudienceValidation { get; set; } = false;
 
     /// <summary>

--- a/identity-server/src/IdentityServer/Endpoints/DiscoveryEndpoint.cs
+++ b/identity-server/src/IdentityServer/Endpoints/DiscoveryEndpoint.cs
@@ -69,9 +69,7 @@ internal class DiscoveryEndpoint : IEndpointHandler
         // generate response
         _logger.LogTrace("Calling into discovery response generator: {type}", _responseGenerator.GetType().FullName);
 
-#pragma warning disable DUENDEPREVIEW001
         if (_options.Preview.EnableDiscoveryDocumentCache)
-#pragma warning restore DUENDEPREVIEW001
         {
             var distributedCache = context.RequestServices.GetRequiredService<IDistributedCache>();
             if (distributedCache is not null)

--- a/identity-server/src/IdentityServer/Validation/Default/PrivateKeyJwtSecretValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/Default/PrivateKeyJwtSecretValidator.cs
@@ -1,9 +1,6 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
-// Supress the warning for the preview feature `Preview.StrictClientAssertionAudienceValidation`
-#pragma warning disable DUENDEPREVIEW002
-
 using Duende.IdentityServer.Configuration;
 using Duende.IdentityServer.Extensions;
 using Duende.IdentityServer.Models;

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Discovery/DiscoveryEndpointTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Discovery/DiscoveryEndpointTests.cs
@@ -292,9 +292,8 @@ public class DiscoveryEndpointTests
         IdentityServerPipeline pipeline = new IdentityServerPipeline();
         pipeline.Initialize("/root");
 
-#pragma warning disable DUENDEPREVIEW001
         pipeline.Options.Preview.EnableDiscoveryDocumentCache = true;
-#pragma warning restore DUENDEPREVIEW001
+
         pipeline.Options.Preview.DiscoveryDocumentCacheDuration = TimeSpan.FromSeconds(1);
 
         // cache

--- a/identity-server/test/IdentityServer.UnitTests/Validation/Secrets/PrivateKeyJwtSecretValidation.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Validation/Secrets/PrivateKeyJwtSecretValidation.cs
@@ -1,9 +1,6 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
-// Supress the warning for the preview feature `Preview.StrictClientAssertionAudienceValidation`
-#pragma warning disable DUENDEPREVIEW002
-
 using Duende.IdentityModel;
 using Duende.IdentityServer;
 using Duende.IdentityServer.Configuration;
@@ -17,7 +14,6 @@ using Microsoft.IdentityModel.Tokens;
 using System;
 using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
-using System.Net;
 using System.Security.Claims;
 using System.Text.Json;
 using System.Threading.Tasks;


### PR DESCRIPTION
**What issue does this PR address?**
Based on internal discussions, we are removing the build warnings brought on by using the `Experimental` flags.
The thought process around this is that because the options are explicitly under a "Preview" navigation property, users accessing these options implicitly acknowledge the preview nature of the feature.

**Important: Any code or remarks in your Pull Request are under the following terms:**
If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
