### PR TITLE
Fix typo in workflow name

### DIFF
--- a/.github/workflows/practices-check-pr.yml
+++ b/.github/workflows/practices-check-pr.yml
@@ -1,4 +1,4 @@
-name: practices\check-pr
+name: practices/check-pr
 
 on:
   pull_request:


### PR DESCRIPTION
All the other workflows use the other slash in their names.