### PR TITLE
Align Approach on Check If Request is Remote Amongst Hosts and Templates

### DIFF
--- a/identity-server/hosts/AspNetIdentity/Pages/Diagnostics/Index.cshtml.cs
+++ b/identity-server/hosts/AspNetIdentity/Pages/Diagnostics/Index.cshtml.cs
@@ -16,13 +16,8 @@ public class Index : PageModel
 
     public async Task<IActionResult> OnGet()
     {
-        var localAddresses = new List<string?> { "127.0.0.1", "::1" };
-        if (HttpContext.Connection.LocalIpAddress != null)
-        {
-            localAddresses.Add(HttpContext.Connection.LocalIpAddress.ToString());
-        }
-
-        if (!localAddresses.Contains(HttpContext.Connection.RemoteIpAddress?.ToString()))
+        //Replace with an authorization policy check
+        if (HttpContext.Connection.IsRemote())
         {
             return NotFound();
         }

--- a/identity-server/hosts/AspNetIdentity/Pages/Extensions.cs
+++ b/identity-server/hosts/AspNetIdentity/Pages/Extensions.cs
@@ -39,4 +39,23 @@ public static class Extensions
 
         return page.RedirectToPage("/Redirect/Index", new { RedirectUri = redirectUri });
     }
+
+    /// <summary>
+    /// Check for a remote connection (non-localhost)
+    /// </summary>
+    internal static bool IsRemote(this ConnectionInfo connection)
+    {
+        var localAddresses = new List<string?> { "127.0.0.1", "::1" };
+        if (connection.LocalIpAddress != null)
+        {
+            localAddresses.Add(connection.LocalIpAddress.ToString());
+        }
+
+        if (!localAddresses.Contains(connection.RemoteIpAddress?.ToString()))
+        {
+            return true;
+        }
+
+        return false;
+    }
 }

--- a/identity-server/hosts/AspNetIdentity/Pages/ServerSideSessions/Index.cshtml.cs
+++ b/identity-server/hosts/AspNetIdentity/Pages/ServerSideSessions/Index.cshtml.cs
@@ -35,8 +35,14 @@ public class IndexModel : PageModel
     [BindProperty(SupportsGet = true)]
     public string? Prev { get; set; }
 
-    public async Task OnGet()
+    public async Task<ActionResult> OnGet()
     {
+        //Replace with an authorization policy check
+        if (HttpContext.Connection.IsRemote())
+        {
+            return NotFound();
+        }
+
         if (_sessionManagementService != null)
         {
             UserSessions = await _sessionManagementService.QuerySessionsAsync(new SessionQuery
@@ -48,6 +54,8 @@ public class IndexModel : PageModel
                 SubjectId = SubjectIdFilter
             });
         }
+
+        return Page();
     }
 
     [BindProperty]
@@ -55,12 +63,19 @@ public class IndexModel : PageModel
 
     public async Task<IActionResult> OnPost()
     {
+        //Replace with an authorization policy check
+        if (HttpContext.Connection.IsRemote())
+        {
+            return NotFound();
+        }
+
         ArgumentNullException.ThrowIfNull(_sessionManagementService);
 
         await _sessionManagementService.RemoveSessionsAsync(new RemoveSessionsContext
         {
             SessionId = SessionId,
         });
+
         return RedirectToPage("/ServerSideSessions/Index", new { Token, DisplayNameFilter, SessionIdFilter, SubjectIdFilter, Prev });
     }
 }

--- a/identity-server/hosts/Configuration/Pages/Diagnostics/Index.cshtml.cs
+++ b/identity-server/hosts/Configuration/Pages/Diagnostics/Index.cshtml.cs
@@ -16,13 +16,8 @@ public class Index : PageModel
 
     public async Task<IActionResult> OnGet()
     {
-        var localAddresses = new List<string?> { "127.0.0.1", "::1" };
-        if (HttpContext.Connection.LocalIpAddress != null)
-        {
-            localAddresses.Add(HttpContext.Connection.LocalIpAddress.ToString());
-        }
-
-        if (!localAddresses.Contains(HttpContext.Connection.RemoteIpAddress?.ToString()))
+        //Replace with an authorization policy check
+        if (HttpContext.Connection.IsRemote())
         {
             return NotFound();
         }

--- a/identity-server/hosts/Configuration/Pages/Extensions.cs
+++ b/identity-server/hosts/Configuration/Pages/Extensions.cs
@@ -39,4 +39,23 @@ public static class Extensions
 
         return page.RedirectToPage("/Redirect/Index", new { RedirectUri = redirectUri });
     }
+
+    /// <summary>
+    /// Check for a remote connection (non-localhost)
+    /// </summary>
+    internal static bool IsRemote(this ConnectionInfo connection)
+    {
+        var localAddresses = new List<string?> { "127.0.0.1", "::1" };
+        if (connection.LocalIpAddress != null)
+        {
+            localAddresses.Add(connection.LocalIpAddress.ToString());
+        }
+
+        if (!localAddresses.Contains(connection.RemoteIpAddress?.ToString()))
+        {
+            return true;
+        }
+
+        return false;
+    }
 }

--- a/identity-server/hosts/Configuration/Pages/ServerSideSessions/Index.cshtml.cs
+++ b/identity-server/hosts/Configuration/Pages/ServerSideSessions/Index.cshtml.cs
@@ -35,8 +35,14 @@ public class IndexModel : PageModel
     [BindProperty(SupportsGet = true)]
     public string? Prev { get; set; }
 
-    public async Task OnGet()
+    public async Task<ActionResult> OnGet()
     {
+        //Replace with an authorization policy check
+        if (HttpContext.Connection.IsRemote())
+        {
+            return NotFound();
+        }
+
         if (_sessionManagementService != null)
         {
             UserSessions = await _sessionManagementService.QuerySessionsAsync(new SessionQuery
@@ -48,6 +54,8 @@ public class IndexModel : PageModel
                 SubjectId = SubjectIdFilter
             });
         }
+
+        return Page();
     }
 
     [BindProperty]
@@ -55,12 +63,19 @@ public class IndexModel : PageModel
 
     public async Task<IActionResult> OnPost()
     {
+        //Replace with an authorization policy check
+        if (HttpContext.Connection.IsRemote())
+        {
+            return NotFound();
+        }
+
         ArgumentNullException.ThrowIfNull(_sessionManagementService);
 
         await _sessionManagementService.RemoveSessionsAsync(new RemoveSessionsContext
         {
             SessionId = SessionId,
         });
+
         return RedirectToPage("/ServerSideSessions/Index", new { Token, DisplayNameFilter, SessionIdFilter, SubjectIdFilter, Prev });
     }
 }

--- a/identity-server/hosts/EntityFramework/Pages/Diagnostics/Index.cshtml.cs
+++ b/identity-server/hosts/EntityFramework/Pages/Diagnostics/Index.cshtml.cs
@@ -16,13 +16,8 @@ public class Index : PageModel
 
     public async Task<IActionResult> OnGet()
     {
-        var localAddresses = new List<string?> { "127.0.0.1", "::1" };
-        if (HttpContext.Connection.LocalIpAddress != null)
-        {
-            localAddresses.Add(HttpContext.Connection.LocalIpAddress.ToString());
-        }
-
-        if (!localAddresses.Contains(HttpContext.Connection.RemoteIpAddress?.ToString()))
+        //Replace with an authorization policy check
+        if (HttpContext.Connection.IsRemote())
         {
             return NotFound();
         }

--- a/identity-server/hosts/EntityFramework/Pages/Extensions.cs
+++ b/identity-server/hosts/EntityFramework/Pages/Extensions.cs
@@ -39,4 +39,23 @@ public static class Extensions
 
         return page.RedirectToPage("/Redirect/Index", new { RedirectUri = redirectUri });
     }
+
+    /// <summary>
+    /// Check for a remote connection (non-localhost)
+    /// </summary>
+    internal static bool IsRemote(this ConnectionInfo connection)
+    {
+        var localAddresses = new List<string?> { "127.0.0.1", "::1" };
+        if (connection.LocalIpAddress != null)
+        {
+            localAddresses.Add(connection.LocalIpAddress.ToString());
+        }
+
+        if (!localAddresses.Contains(connection.RemoteIpAddress?.ToString()))
+        {
+            return true;
+        }
+
+        return false;
+    }
 }

--- a/identity-server/hosts/EntityFramework/Pages/ServerSideSessions/Index.cshtml.cs
+++ b/identity-server/hosts/EntityFramework/Pages/ServerSideSessions/Index.cshtml.cs
@@ -35,8 +35,14 @@ public class IndexModel : PageModel
     [BindProperty(SupportsGet = true)]
     public string? Prev { get; set; }
 
-    public async Task OnGet()
+    public async Task<ActionResult> OnGet()
     {
+        //Replace with an authorization policy check
+        if (HttpContext.Connection.IsRemote())
+        {
+            return NotFound();
+        }
+
         if (_sessionManagementService != null)
         {
             UserSessions = await _sessionManagementService.QuerySessionsAsync(new SessionQuery
@@ -48,6 +54,8 @@ public class IndexModel : PageModel
                 SubjectId = SubjectIdFilter
             });
         }
+
+        return Page();
     }
 
     [BindProperty]
@@ -55,12 +63,19 @@ public class IndexModel : PageModel
 
     public async Task<IActionResult> OnPost()
     {
+        //Replace with an authorization policy check
+        if (HttpContext.Connection.IsRemote())
+        {
+            return NotFound();
+        }
+
         ArgumentNullException.ThrowIfNull(_sessionManagementService);
 
         await _sessionManagementService.RemoveSessionsAsync(new RemoveSessionsContext
         {
             SessionId = SessionId,
         });
+
         return RedirectToPage("/ServerSideSessions/Index", new { Token, DisplayNameFilter, SessionIdFilter, SubjectIdFilter, Prev });
     }
 }

--- a/identity-server/hosts/main/Pages/Diagnostics/Index.cshtml.cs
+++ b/identity-server/hosts/main/Pages/Diagnostics/Index.cshtml.cs
@@ -16,13 +16,8 @@ public class Index : PageModel
 
     public async Task<IActionResult> OnGet()
     {
-        var localAddresses = new List<string?> { "127.0.0.1", "::1" };
-        if (HttpContext.Connection.LocalIpAddress != null)
-        {
-            localAddresses.Add(HttpContext.Connection.LocalIpAddress.ToString());
-        }
-
-        if (!localAddresses.Contains(HttpContext.Connection.RemoteIpAddress?.ToString()))
+        //Replace with an authorization policy check
+        if (HttpContext.Connection.IsRemote())
         {
             return NotFound();
         }

--- a/identity-server/hosts/main/Pages/Extensions.cs
+++ b/identity-server/hosts/main/Pages/Extensions.cs
@@ -39,4 +39,23 @@ public static class Extensions
 
         return page.RedirectToPage("/Redirect/Index", new { RedirectUri = redirectUri });
     }
+
+    /// <summary>
+    /// Check for a remote connection (non-localhost)
+    /// </summary>
+    internal static bool IsRemote(this ConnectionInfo connection)
+    {
+        var localAddresses = new List<string?> { "127.0.0.1", "::1" };
+        if (connection.LocalIpAddress != null)
+        {
+            localAddresses.Add(connection.LocalIpAddress.ToString());
+        }
+
+        if (!localAddresses.Contains(connection.RemoteIpAddress?.ToString()))
+        {
+            return true;
+        }
+
+        return false;
+    }
 }

--- a/identity-server/hosts/main/Pages/ServerSideSessions/Index.cshtml.cs
+++ b/identity-server/hosts/main/Pages/ServerSideSessions/Index.cshtml.cs
@@ -35,8 +35,14 @@ public class IndexModel : PageModel
     [BindProperty(SupportsGet = true)]
     public string? Prev { get; set; }
 
-    public async Task OnGet()
+    public async Task<IActionResult> OnGet()
     {
+        //Replace with an authorization policy check
+        if (HttpContext.Connection.IsRemote())
+        {
+            return NotFound();
+        }
+
         if (_sessionManagementService != null)
         {
             UserSessions = await _sessionManagementService.QuerySessionsAsync(new SessionQuery
@@ -48,6 +54,8 @@ public class IndexModel : PageModel
                 SubjectId = SubjectIdFilter
             });
         }
+
+        return Page();
     }
 
     [BindProperty]
@@ -55,12 +63,19 @@ public class IndexModel : PageModel
 
     public async Task<IActionResult> OnPost()
     {
+        //Replace with an authorization policy check
+        if (HttpContext.Connection.IsRemote())
+        {
+            return NotFound();
+        }
+
         ArgumentNullException.ThrowIfNull(_sessionManagementService);
 
         await _sessionManagementService.RemoveSessionsAsync(new RemoveSessionsContext
         {
             SessionId = SessionId,
         });
+
         return RedirectToPage("/ServerSideSessions/Index", new { Token, DisplayNameFilter, SessionIdFilter, SubjectIdFilter, Prev });
     }
 }

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Diagnostics/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Diagnostics/Index.cshtml.cs
@@ -13,13 +13,8 @@ public class Index : PageModel
 
     public async Task<IActionResult> OnGet()
     {
-        var localAddresses = new List<string?> { "127.0.0.1", "::1" };
-        if (HttpContext.Connection.LocalIpAddress != null)
-        {
-            localAddresses.Add(HttpContext.Connection.LocalIpAddress.ToString());
-        }
-
-        if (!localAddresses.Contains(HttpContext.Connection.RemoteIpAddress?.ToString()))
+        //Replace with an authorization policy check
+        if (HttpContext.Connection.IsRemote())
         {
             return NotFound();
         }

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Extensions.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/Extensions.cs
@@ -36,4 +36,23 @@ public static class Extensions
 
         return page.RedirectToPage("/Redirect/Index", new { RedirectUri = redirectUri });
     }
+
+    /// <summary>
+    /// Check for a remote connection (non-localhost)
+    /// </summary>
+    internal static bool IsRemote(this ConnectionInfo connection)
+    {
+        var localAddresses = new List<string?> { "127.0.0.1", "::1" };
+        if (connection.LocalIpAddress != null)
+        {
+            localAddresses.Add(connection.LocalIpAddress.ToString());
+        }
+
+        if (!localAddresses.Contains(connection.RemoteIpAddress?.ToString()))
+        {
+            return true;
+        }
+
+        return false;
+    }
 }

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/ServerSideSessions/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/ServerSideSessions/Index.cshtml.cs
@@ -32,8 +32,14 @@ public class IndexModel : PageModel
     [BindProperty(SupportsGet = true)]
     public string? Prev { get; set; }
 
-    public async Task OnGet()
+    public async Task<ActionResult> OnGet()
     {
+        //Replace with an authorization policy check
+        if (HttpContext.Connection.IsRemote())
+        {
+            return NotFound();
+        }
+
         if (_sessionManagementService != null)
         {
             UserSessions = await _sessionManagementService.QuerySessionsAsync(new SessionQuery
@@ -45,6 +51,8 @@ public class IndexModel : PageModel
                 SubjectId = SubjectIdFilter
             });
         }
+
+        return Page();
     }
 
     [BindProperty]
@@ -52,12 +60,19 @@ public class IndexModel : PageModel
 
     public async Task<IActionResult> OnPost()
     {
+        //Replace with an authorization policy check
+        if (HttpContext.Connection.IsRemote())
+        {
+            return NotFound();
+        }
+
         ArgumentNullException.ThrowIfNull(_sessionManagementService);
 
         await _sessionManagementService.RemoveSessionsAsync(new RemoveSessionsContext
         {
             SessionId = SessionId,
         });
+
         return RedirectToPage("/ServerSideSessions/Index", new { Token, DisplayNameFilter, SessionIdFilter, SubjectIdFilter, Prev });
     }
 }

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Diagnostics/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Diagnostics/Index.cshtml.cs
@@ -13,13 +13,8 @@ public class Index : PageModel
 
     public async Task<IActionResult> OnGet()
     {
-        var localAddresses = new List<string?> { "127.0.0.1", "::1" };
-        if (HttpContext.Connection.LocalIpAddress != null)
-        {
-            localAddresses.Add(HttpContext.Connection.LocalIpAddress.ToString());
-        }
-
-        if (!localAddresses.Contains(HttpContext.Connection.RemoteIpAddress?.ToString()))
+        //Replace with an authorization policy check
+        if (HttpContext.Connection.IsRemote())
         {
             return NotFound();
         }

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/Extensions.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/Extensions.cs
@@ -36,4 +36,23 @@ public static class Extensions
 
         return page.RedirectToPage("/Redirect/Index", new { RedirectUri = redirectUri });
     }
+
+    /// <summary>
+    /// Check for a remote connection (non-localhost)
+    /// </summary>
+    internal static bool IsRemote(this ConnectionInfo connection)
+    {
+        var localAddresses = new List<string?> { "127.0.0.1", "::1" };
+        if (connection.LocalIpAddress != null)
+        {
+            localAddresses.Add(connection.LocalIpAddress.ToString());
+        }
+
+        if (!localAddresses.Contains(connection.RemoteIpAddress?.ToString()))
+        {
+            return true;
+        }
+
+        return false;
+    }
 }

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/ServerSideSessions/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/ServerSideSessions/Index.cshtml.cs
@@ -32,8 +32,14 @@ public class IndexModel : PageModel
     [BindProperty(SupportsGet = true)]
     public string? Prev { get; set; }
 
-    public async Task OnGet()
+    public async Task<ActionResult> OnGet()
     {
+        //Replace with an authorization policy check
+        if (HttpContext.Connection.IsRemote())
+        {
+            return NotFound();
+        }
+
         if (_sessionManagementService != null)
         {
             UserSessions = await _sessionManagementService.QuerySessionsAsync(new SessionQuery
@@ -45,6 +51,8 @@ public class IndexModel : PageModel
                 SubjectId = SubjectIdFilter
             });
         }
+
+        return Page();
     }
 
     [BindProperty]
@@ -52,12 +60,19 @@ public class IndexModel : PageModel
 
     public async Task<IActionResult> OnPost()
     {
+        //Replace with an authorization policy check
+        if (HttpContext.Connection.IsRemote())
+        {
+            return NotFound();
+        }
+
         ArgumentNullException.ThrowIfNull(_sessionManagementService);
 
         await _sessionManagementService.RemoveSessionsAsync(new RemoveSessionsContext
         {
             SessionId = SessionId,
         });
+
         return RedirectToPage("/ServerSideSessions/Index", new { Token, DisplayNameFilter, SessionIdFilter, SubjectIdFilter, Prev });
     }
 }

--- a/identity-server/templates/src/IdentityServerInMem/Pages/Diagnostics/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/Diagnostics/Index.cshtml.cs
@@ -13,13 +13,8 @@ public class Index : PageModel
 
     public async Task<IActionResult> OnGet()
     {
-        var localAddresses = new List<string?> { "127.0.0.1", "::1" };
-        if (HttpContext.Connection.LocalIpAddress != null)
-        {
-            localAddresses.Add(HttpContext.Connection.LocalIpAddress.ToString());
-        }
-
-        if (!localAddresses.Contains(HttpContext.Connection.RemoteIpAddress?.ToString()))
+        //Replace with an authorization policy check
+        if (HttpContext.Connection.IsRemote())
         {
             return NotFound();
         }

--- a/identity-server/templates/src/IdentityServerInMem/Pages/Extensions.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/Extensions.cs
@@ -36,4 +36,23 @@ public static class Extensions
 
         return page.RedirectToPage("/Redirect/Index", new { RedirectUri = redirectUri });
     }
+
+    /// <summary>
+    /// Check for a remote connection (non-localhost)
+    /// </summary>
+    internal static bool IsRemote(this ConnectionInfo connection)
+    {
+        var localAddresses = new List<string?> { "127.0.0.1", "::1" };
+        if (connection.LocalIpAddress != null)
+        {
+            localAddresses.Add(connection.LocalIpAddress.ToString());
+        }
+
+        if (!localAddresses.Contains(connection.RemoteIpAddress?.ToString()))
+        {
+            return true;
+        }
+
+        return false;
+    }
 }

--- a/identity-server/templates/src/IdentityServerInMem/Pages/ServerSideSessions/Index.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/ServerSideSessions/Index.cshtml.cs
@@ -32,8 +32,14 @@ public class IndexModel : PageModel
     [BindProperty(SupportsGet = true)]
     public string? Prev { get; set; }
 
-    public async Task OnGet()
+    public async Task<ActionResult> OnGet()
     {
+        //Replace with an authorization policy check
+        if (HttpContext.Connection.IsRemote())
+        {
+            return NotFound();
+        }
+
         if (_sessionManagementService != null)
         {
             UserSessions = await _sessionManagementService.QuerySessionsAsync(new SessionQuery
@@ -45,6 +51,8 @@ public class IndexModel : PageModel
                 SubjectId = SubjectIdFilter
             });
         }
+
+        return Page();
     }
 
     [BindProperty]
@@ -52,12 +60,19 @@ public class IndexModel : PageModel
 
     public async Task<IActionResult> OnPost()
     {
+        //Replace with an authorization policy check
+        if (HttpContext.Connection.IsRemote())
+        {
+            return NotFound();
+        }
+
         ArgumentNullException.ThrowIfNull(_sessionManagementService);
 
         await _sessionManagementService.RemoveSessionsAsync(new RemoveSessionsContext
         {
             SessionId = SessionId,
         });
+
         return RedirectToPage("/ServerSideSessions/Index", new { Token, DisplayNameFilter, SessionIdFilter, SubjectIdFilter, Prev });
     }
 }

--- a/identity-server/templates/src/UI/Pages/Diagnostics/Index.cshtml.cs
+++ b/identity-server/templates/src/UI/Pages/Diagnostics/Index.cshtml.cs
@@ -15,7 +15,9 @@ public class Index : PageModel
     {
         //Replace with an authorization policy check
         if (HttpContext.Connection.IsRemote())
+        {
             return NotFound();
+        }
 
         View = new ViewModel(await HttpContext.AuthenticateAsync());
 

--- a/identity-server/templates/src/UI/Pages/Extensions.cs
+++ b/identity-server/templates/src/UI/Pages/Extensions.cs
@@ -52,6 +52,7 @@ public static class Extensions
         {
             return true;
         }
+
         return false;
     }
 }

--- a/identity-server/templates/src/UI/Pages/ServerSideSessions/Index.cshtml.cs
+++ b/identity-server/templates/src/UI/Pages/ServerSideSessions/Index.cshtml.cs
@@ -32,41 +32,48 @@ public class IndexModel : PageModel
     [BindProperty(SupportsGet = true)]
     public string? Prev { get; set; }
 
-        public async Task<ActionResult> OnGet()
+    public async Task<ActionResult> OnGet()
+    {
+        //Replace with an authorization policy check
+        if (HttpContext.Connection.IsRemote())
         {
-            //Replace with an authorization policy check
-            if (HttpContext.Connection.IsRemote())
-                return NotFound();
+            return NotFound();
+        }
 
-            if (_sessionManagementService != null)
+        if (_sessionManagementService != null)
+        {
+            UserSessions = await _sessionManagementService.QuerySessionsAsync(new SessionQuery
             {
-                UserSessions = await _sessionManagementService.QuerySessionsAsync(new SessionQuery
-                {
-                    ResultsToken = Token,
-                    RequestPriorResults = Prev == "true",
-                    DisplayName = DisplayNameFilter,
-                    SessionId = SessionIdFilter,
-                    SubjectId = SubjectIdFilter
-                });
-            }
-            return Page();
-        }
-
-        [BindProperty]
-        public string? SessionId { get; set; }
-
-        public async Task<IActionResult> OnPost()
-        {
-            //Replace with an authorization policy check
-            if (HttpContext.Connection.IsRemote())
-                return NotFound();
-
-            ArgumentNullException.ThrowIfNull(_sessionManagementService);
-
-            await _sessionManagementService.RemoveSessionsAsync(new RemoveSessionsContext { 
-                SessionId = SessionId,
+                ResultsToken = Token,
+                RequestPriorResults = Prev == "true",
+                DisplayName = DisplayNameFilter,
+                SessionId = SessionIdFilter,
+                SubjectId = SubjectIdFilter
             });
-            return RedirectToPage("/ServerSideSessions/Index", new { Token, DisplayNameFilter, SessionIdFilter, SubjectIdFilter, Prev });
         }
+
+        return Page();
+        return Page();
+    }
+
+    [BindProperty]
+    public string? SessionId { get; set; }
+
+    public async Task<IActionResult> OnPost()
+    {
+        //Replace with an authorization policy check
+        if (HttpContext.Connection.IsRemote())
+        {
+            return NotFound();
+        }
+
+        ArgumentNullException.ThrowIfNull(_sessionManagementService);
+
+        await _sessionManagementService.RemoveSessionsAsync(new RemoveSessionsContext
+        {
+            SessionId = SessionId,
+        });
+
+        return RedirectToPage("/ServerSideSessions/Index", new { Token, DisplayNameFilter, SessionIdFilter, SubjectIdFilter, Prev });
     }
 }


### PR DESCRIPTION
**What issue does this PR address?**
Takes extension method used in UI template for checking if connection is local and uses it across all templates and hosts. Also ensure that method is being applied appropriately in the server side session pages.


**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
