### PR TITLE
Added registration of LicenseSummary to all templates

### DIFF
--- a/identity-server/templates/src/IdentityServerAspNetIdentity/HostingExtensions.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/HostingExtensions.cs
@@ -31,7 +31,8 @@ internal static class HostingExtensions
             .AddInMemoryIdentityResources(Config.IdentityResources)
             .AddInMemoryApiScopes(Config.ApiScopes)
             .AddInMemoryClients(Config.Clients)
-            .AddAspNetIdentity<ApplicationUser>();
+            .AddAspNetIdentity<ApplicationUser>()
+            .AddLicenseSummary();
 
         builder.Services.AddAuthentication()
             .AddGoogle(options =>

--- a/identity-server/templates/src/IdentityServerEmpty/HostingExtensions.cs
+++ b/identity-server/templates/src/IdentityServerEmpty/HostingExtensions.cs
@@ -12,7 +12,8 @@ internal static class HostingExtensions
         builder.Services.AddIdentityServer()
             .AddInMemoryIdentityResources(Config.IdentityResources)
             .AddInMemoryApiScopes(Config.ApiScopes)
-            .AddInMemoryClients(Config.Clients);
+            .AddInMemoryClients(Config.Clients)
+            .AddLicenseSummary();
 
         return builder.Build();
     }

--- a/identity-server/templates/src/IdentityServerEntityFramework/HostingExtensions.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/HostingExtensions.cs
@@ -40,7 +40,8 @@ internal static class HostingExtensions
             {
                 options.ConfigureDbContext = b =>
                     b.UseSqlite(connectionString, dbOpts => dbOpts.MigrationsAssembly(typeof(Program).Assembly.FullName));
-            });
+            })
+            .AddLicenseSummary();
 
         builder.Services.AddAuthentication()
             .AddGoogle(options =>

--- a/identity-server/templates/src/IdentityServerInMem/HostingExtensions.cs
+++ b/identity-server/templates/src/IdentityServerInMem/HostingExtensions.cs
@@ -17,7 +17,8 @@ internal static class HostingExtensions
                 options.Events.RaiseFailureEvents = true;
                 options.Events.RaiseSuccessEvents = true;
             })
-            .AddTestUsers(TestUsers.Users);
+            .AddTestUsers(TestUsers.Users)
+            .AddLicenseSummary();
 
         // in-memory, code config
         isBuilder.AddInMemoryIdentityResources(Config.IdentityResources);


### PR DESCRIPTION
**What issue does this PR address?**
The templates were missing the registration of the license usage summary and throwing an exception on shut down rather than printing out the summary.


**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
