### PR TITLE
Don't unnecessarily return scope parameter from authorize endpoint

### DIFF
--- a/identity-server/src/IdentityServer/Extensions/AuthorizeResponseExtensions.cs
+++ b/identity-server/src/IdentityServer/Extensions/AuthorizeResponseExtensions.cs
@@ -43,11 +43,11 @@ internal static class AuthorizeResponseExtensions
                 collection.Add("access_token", response.AccessToken);
                 collection.Add("token_type", "Bearer");
                 collection.Add("expires_in", response.AccessTokenLifetime.ToString());
-            }
 
-            if (response.Scope.IsPresent())
-            {
-                collection.Add("scope", response.Scope);
+                if (response.Scope.IsPresent())
+                {
+                    collection.Add("scope", response.Scope);
+                }
             }
         }
 


### PR DESCRIPTION
**What issue does this PR address?**
This addresses a customer reported bug which was transferred to the internal backlog. The customer reported:
"We’ve noticed that the scope parameter is included in the callback URL after authentication in the authorization code flow, also when using PAR. This behavior seems unexpected, as scope is already handled during the authorization process and doesn’t appear to be required in the callback URL. In particular with PAR, where one of the benefits should be shorter URLs.

Wondering if this is an intentional design choice? If so, what purpose does it serve?"

Per RFC 6749, the only time the authorize endpoint needs to return the scope parameter is during the implicit flow as defined in [section 4.2.2](https://datatracker.ietf.org/doc/html/rfc6749#section-4.2.2). This change prevents the scope parameter from being included in a response from the authorize endpoint unless a token is issued as it the scope parameter will be returned from the token endpoint for other grant types.


**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
