### PR TITLE
Add OpenTelemetry tracing and integrate IdentityServer

### DIFF
--- a/identity-server/aspire/aspire.orchestrator/aspire.orchestrator.ServiceDefaults/Extensions.cs
+++ b/identity-server/aspire/aspire.orchestrator/aspire.orchestrator.ServiceDefaults/Extensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
+using Duende.IdentityServer;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.Extensions.DependencyInjection;
@@ -54,7 +55,13 @@ public static class Extensions
             })
             .WithTracing(tracing =>
             {
-                tracing.AddAspNetCoreInstrumentation()
+                tracing
+                    .AddSource(IdentityServerConstants.Tracing.Basic)
+                    .AddSource(IdentityServerConstants.Tracing.Cache)
+                    .AddSource(IdentityServerConstants.Tracing.Services)
+                    .AddSource(IdentityServerConstants.Tracing.Stores)
+                    .AddSource(IdentityServerConstants.Tracing.Validation)
+                    .AddAspNetCoreInstrumentation()
                     // Uncomment the following line to enable gRPC instrumentation (requires the OpenTelemetry.Instrumentation.GrpcNetClient package)
                     //.AddGrpcClientInstrumentation()
                     .AddHttpClientInstrumentation();

--- a/identity-server/aspire/aspire.orchestrator/aspire.orchestrator.ServiceDefaults/aspire.orchestrator.ServiceDefaults.csproj
+++ b/identity-server/aspire/aspire.orchestrator/aspire.orchestrator.ServiceDefaults/aspire.orchestrator.ServiceDefaults.csproj
@@ -19,4 +19,8 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\IdentityServer\Duende.IdentityServer.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/identity-server/hosts/EntityFramework-dotnet9/IdentityServerExtensions.cs
+++ b/identity-server/hosts/EntityFramework-dotnet9/IdentityServerExtensions.cs
@@ -16,14 +16,14 @@ internal static class IdentityServerExtensions
         var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
 
         builder.Services.AddIdentityServer(options =>
-        {
-            options.Authentication.CoordinateClientLifetimesWithUserSession = true;
-            options.ServerSideSessions.UserDisplayNameClaimType = JwtClaimTypes.Name;
-            options.ServerSideSessions.RemoveExpiredSessions = true;
-            options.ServerSideSessions.RemoveExpiredSessionsFrequency = TimeSpan.FromSeconds(10);
-            options.ServerSideSessions.ExpiredSessionsTriggerBackchannelLogout = true;
-            options.Endpoints.EnablePushedAuthorizationEndpoint = true;
-        })
+            {
+                options.Authentication.CoordinateClientLifetimesWithUserSession = true;
+                options.ServerSideSessions.UserDisplayNameClaimType = JwtClaimTypes.Name;
+                options.ServerSideSessions.RemoveExpiredSessions = true;
+                options.ServerSideSessions.RemoveExpiredSessionsFrequency = TimeSpan.FromSeconds(10);
+                options.ServerSideSessions.ExpiredSessionsTriggerBackchannelLogout = true;
+                options.Endpoints.EnablePushedAuthorizationEndpoint = true;
+            })
             .AddTestUsers(TestUsers.Users)
             // this adds the config data from DB (clients, resources, CORS)
             .AddConfigurationStore(options =>
@@ -48,10 +48,12 @@ internal static class IdentityServerExtensions
             ;
 
         builder.Services.AddIdentityServerConfiguration(opt =>
-        {
-            // opt.DynamicClientRegistration.SecretLifetime = TimeSpan.FromHours(1);
-        })
+            {
+                // opt.DynamicClientRegistration.SecretLifetime = TimeSpan.FromHours(1);
+            })
             .AddClientConfigurationStore();
+
+        builder.AddServiceDefaults();
 
         return builder;
     }


### PR DESCRIPTION
Updated tracing to include IdentityServer-specific sources for improved observability. Added a project reference to Duende.IdentityServer and integrated `AddServiceDefaults` to enhance service configuration.

cc @StuFrankish 

![CleanShot 2025-03-28 at 10 11 23@2x](https://github.com/user-attachments/assets/ac3e9ff4-114b-46ce-88e2-62696c43782c)
