### PR TITLE
Implement prompt support for login

### DIFF
--- a/bff/src/Bff/Configuration/BffEndpointRouteBuilderExtensions.cs
+++ b/bff/src/Bff/Configuration/BffEndpointRouteBuilderExtensions.cs
@@ -60,7 +60,7 @@ public static class BffEndpointRouteBuilderExtensions
     /// Adds the silent login BFF management endpoints
     /// </summary>
     /// <param name="endpoints"></param>
-    [Obsolete("Silent login is now handled via login=create")]
+    [Obsolete("The silent login endpoint will be removed in a future version. Silent login is now handled by passing the prompt=none parameter to the login endpoint.")]
     public static void MapBffManagementSilentLoginEndpoints(this IEndpointRouteBuilder endpoints)
     {
         endpoints.CheckLicense();

--- a/bff/src/Bff/Configuration/BffEndpointRouteBuilderExtensions.cs
+++ b/bff/src/Bff/Configuration/BffEndpointRouteBuilderExtensions.cs
@@ -32,7 +32,9 @@ public static class BffEndpointRouteBuilderExtensions
     public static void MapBffManagementEndpoints(this IEndpointRouteBuilder endpoints)
     {
         endpoints.MapBffManagementLoginEndpoint();
+#pragma warning disable CS0618 // Type or member is obsolete
         endpoints.MapBffManagementSilentLoginEndpoints();
+#pragma warning restore CS0618 // Type or member is obsolete
         endpoints.MapBffManagementLogoutEndpoint();
         endpoints.MapBffManagementUserEndpoint();
         endpoints.MapBffManagementBackchannelEndpoint();
@@ -58,15 +60,19 @@ public static class BffEndpointRouteBuilderExtensions
     /// Adds the silent login BFF management endpoints
     /// </summary>
     /// <param name="endpoints"></param>
+    [Obsolete("Silent login is now handled via login=create")]
     public static void MapBffManagementSilentLoginEndpoints(this IEndpointRouteBuilder endpoints)
     {
         endpoints.CheckLicense();
 
         var options = endpoints.ServiceProvider.GetRequiredService<IOptions<BffOptions>>().Value;
 
+#pragma warning disable CS0618 // Type or member is obsolete
         endpoints.MapGet(options.SilentLoginPath.Value!, ProcessWith<ISilentLoginService>)
             .WithMetadata(new BffUIEndpointAttribute())
             .AllowAnonymous();
+#pragma warning restore CS0618 // Type or member is obsolete
+
         endpoints.MapGet(options.SilentLoginCallbackPath.Value!, ProcessWith<ISilentLoginCallbackService>)
             .WithMetadata(new BffUIEndpointAttribute())
             .AllowAnonymous();

--- a/bff/src/Bff/Configuration/BffOptions.cs
+++ b/bff/src/Bff/Configuration/BffOptions.cs
@@ -67,7 +67,7 @@ public class BffOptions
     /// <summary>
     /// Silent login endpoint
     /// </summary>
-    [Obsolete("Use Login?prompt=none")]
+    [Obsolete("The silent login endpoint will be removed in a future version. Silent login is now handled by passing the prompt=none parameter to the login endpoint.")]
     public PathString SilentLoginPath => ManagementBasePath.Add(Constants.ManagementEndpoints.SilentLogin);
 
     /// <summary>

--- a/bff/src/Bff/Configuration/BffOptions.cs
+++ b/bff/src/Bff/Configuration/BffOptions.cs
@@ -67,6 +67,7 @@ public class BffOptions
     /// <summary>
     /// Silent login endpoint
     /// </summary>
+    [Obsolete("Use Login?prompt=none")]
     public PathString SilentLoginPath => ManagementBasePath.Add(Constants.ManagementEndpoints.SilentLogin);
 
     /// <summary>

--- a/bff/src/Bff/Configuration/BffServiceCollectionExtensions.cs
+++ b/bff/src/Bff/Configuration/BffServiceCollectionExtensions.cs
@@ -39,7 +39,9 @@ public static class BffServiceCollectionExtensions
 
         // management endpoints
         services.AddTransient<ILoginService, DefaultLoginService>();
+#pragma warning disable CS0618 // Type or member is obsolete
         services.AddTransient<ISilentLoginService, DefaultSilentLoginService>();
+#pragma warning restore CS0618 // Type or member is obsolete
         services.AddTransient<ISilentLoginCallbackService, DefaultSilentLoginCallbackService>();
         services.AddTransient<ILogoutService, DefaultLogoutService>();
         services.AddTransient<IUserService, DefaultUserService>();

--- a/bff/src/Bff/Constants.cs
+++ b/bff/src/Bff/Constants.cs
@@ -65,6 +65,7 @@ public static class Constants
         /// <summary>
         /// Silent login path
         /// </summary>
+        [Obsolete("use /login?prompt=create")]
         public const string SilentLogin = "/silent-login";
 
         /// <summary>
@@ -120,10 +121,6 @@ public static class Constants
     /// </summary>
     public static class BffFlags
     {
-        /// <summary>
-        /// Used to indicate the OIDC request is a silent login
-        /// </summary>
-        public const string SilentLogin = "bff-silent-login";
         public const string Prompt = "bff-prompt";
     }
 }

--- a/bff/src/Bff/Constants.cs
+++ b/bff/src/Bff/Constants.cs
@@ -107,6 +107,11 @@ public static class Constants
         /// Used to pass a return URL to login/logout
         /// </summary>
         public const string ReturnUrl = "returnUrl";
+
+        /// <summary>
+        /// Used to pass a prompt value to login
+        /// </summary>
+        public const string Prompt = "prompt";
     }
 
 
@@ -119,5 +124,6 @@ public static class Constants
         /// Used to indicate the OIDC request is a silent login
         /// </summary>
         public const string SilentLogin = "bff-silent-login";
+        public const string Prompt = "bff-prompt";
     }
 }

--- a/bff/src/Bff/EndpointServices/Login/DefaultLoginService.cs
+++ b/bff/src/Bff/EndpointServices/Login/DefaultLoginService.cs
@@ -69,7 +69,7 @@ public class DefaultLoginService : ILoginService
 
         var returnUrl = context.Request.Query[Constants.RequestParameters.ReturnUrl].FirstOrDefault();
 
-        var prompt = context.Request.Query["prompt"].FirstOrDefault();
+        var prompt = context.Request.Query[Constants.RequestParameters.Prompt].FirstOrDefault();
 
         var supportedPromptValues = await GetPromptValuesAsync();
         if (prompt != null && !supportedPromptValues.Contains(prompt))

--- a/bff/src/Bff/EndpointServices/Login/DefaultLoginService.cs
+++ b/bff/src/Bff/EndpointServices/Login/DefaultLoginService.cs
@@ -22,11 +22,11 @@ public class DefaultLoginService : ILoginService
     /// <summary>
     /// The OIDC options monitor
     /// </summary>
-    protected readonly IOptionsMonitor<OpenIdConnectOptions> OptionsMonitor;
+    protected readonly IOptionsMonitor<OpenIdConnectOptions> OpenIdConnectOptionsMonitor;
     /// <summary>
     /// The BFF options
     /// </summary>
-    protected readonly BffOptions Options;
+    protected readonly BffOptions BffOptions;
 
     /// <summary>
     /// The return URL validator
@@ -41,21 +41,21 @@ public class DefaultLoginService : ILoginService
     /// <summary>
     /// ctor
     /// </summary>
-    /// <param name="optionsMonitor"></param>
-    /// <param name="options"></param>
+    /// <param name="openIdConnectOptionsMonitor"></param>
+    /// <param name="bffOptions"></param>
     /// <param name="returnUrlValidator"></param>
     /// <param name="logger"></param>
     /// <param name="authenticationSchemeProvider"></param>
     public DefaultLoginService(
         IAuthenticationSchemeProvider authenticationSchemeProvider,
-        IOptionsMonitor<OpenIdConnectOptions> optionsMonitor,
-        IOptions<BffOptions> options,
+        IOptionsMonitor<OpenIdConnectOptions> openIdConnectOptionsMonitor,
+        IOptions<BffOptions> bffOptions,
         IReturnUrlValidator returnUrlValidator,
         ILogger<DefaultLoginService> logger)
     {
-        Options = options.Value;
+        BffOptions = bffOptions.Value;
         AuthenticationSchemeProvider = authenticationSchemeProvider;
-        OptionsMonitor = optionsMonitor;
+        OpenIdConnectOptionsMonitor = openIdConnectOptionsMonitor;
         ReturnUrlValidator = returnUrlValidator;
         Logger = logger;
     }
@@ -65,7 +65,7 @@ public class DefaultLoginService : ILoginService
     {
         Logger.LogDebug("Processing login request");
 
-        context.CheckForBffMiddleware(Options);
+        context.CheckForBffMiddleware(BffOptions);
 
         var returnUrl = context.Request.Query[Constants.RequestParameters.ReturnUrl].FirstOrDefault();
 
@@ -122,7 +122,7 @@ public class DefaultLoginService : ILoginService
             throw new Exception("Failed to obtain default challenge scheme");
         }
 
-        var options = OptionsMonitor.Get(scheme.Name);
+        var options = OpenIdConnectOptionsMonitor.Get(scheme.Name);
         if (options == null)
         {
             throw new Exception("Failed to obtain OIDC options for default challenge scheme");

--- a/bff/src/Bff/EndpointServices/SilentLogin/BffOpenIdConnectEvents.cs
+++ b/bff/src/Bff/EndpointServices/SilentLogin/BffOpenIdConnectEvents.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Duende.Bff;
 
@@ -16,13 +17,17 @@ public class BffOpenIdConnectEvents : OpenIdConnectEvents
     /// </summary>
     protected readonly ILogger<BffOpenIdConnectEvents> Logger;
 
+    private readonly IOptions<BffOptions> _options;
+
     /// <summary>
     /// ctor
     /// </summary>
     /// <param name="logger"></param>
-    public BffOpenIdConnectEvents(ILogger<BffOpenIdConnectEvents> logger)
+    /// <param name="options"></param>
+    public BffOpenIdConnectEvents(ILogger<BffOpenIdConnectEvents> logger, IOptions<BffOptions> options)
     {
         Logger = logger;
+        _options = options;
     }
 
     /// <inheritdoc/>
@@ -41,12 +46,16 @@ public class BffOpenIdConnectEvents : OpenIdConnectEvents
     {
         if (context.Properties?.IsSilentLogin() == true)
         {
+            var pathBase = context.Request.PathBase;
+            var redirectPath = pathBase + _options.Value.SilentLoginCallbackPath;
+
+            context.Properties.RedirectUri = redirectPath;
             Logger.LogDebug("Setting OIDC ProtocolMessage.Prompt to 'none' for BFF silent login");
             context.ProtocolMessage.Prompt = "none";
         }
-        else if (context.Properties.TryGetPrompt(out var prompt))
+        else if (context.Properties?.TryGetPrompt(out var prompt) == true)
         {
-            Logger.LogDebug("Setting OIDC ProtocolMessage.Prompt to 'none' for BFF silent login");
+            Logger.LogDebug("Setting OIDC ProtocolMessage.Prompt to {prompt} for BFF silent login", prompt);
             context.ProtocolMessage.Prompt = prompt;
         }
 
@@ -71,7 +80,7 @@ public class BffOpenIdConnectEvents : OpenIdConnectEvents
         if (context.Properties?.IsSilentLogin() == true &&
             context.Properties?.RedirectUri != null)
         {
-            context.HttpContext.Items[Constants.BffFlags.SilentLogin] = context.Properties.RedirectUri;
+            context.HttpContext.Items["silent"] = context.Properties.RedirectUri;
 
             if (context.ProtocolMessage.Error != null)
             {
@@ -85,7 +94,7 @@ public class BffOpenIdConnectEvents : OpenIdConnectEvents
         else if (context.Properties?.TryGetPrompt(out var prompt) == true &&
                  context.Properties?.RedirectUri != null)
         {
-            context.HttpContext.Items[Constants.BffFlags.SilentLogin] = context.Properties.RedirectUri;
+            context.HttpContext.Items["silent"] = context.Properties.RedirectUri;
 
             if (context.ProtocolMessage.Error != null)
             {
@@ -115,12 +124,12 @@ public class BffOpenIdConnectEvents : OpenIdConnectEvents
     /// </summary>
     public virtual Task<bool> ProcessAuthenticationFailedAsync(AuthenticationFailedContext context)
     {
-        if (context.HttpContext.Items.ContainsKey(Constants.BffFlags.SilentLogin))
+        if (context.HttpContext.Items.ContainsKey("silent"))
         {
             Logger.LogDebug("Handling failed response from OIDC provider for BFF silent login.");
 
             context.HandleResponse();
-            context.Response.Redirect(context.HttpContext.Items[Constants.BffFlags.SilentLogin]!.ToString()!);
+            context.Response.Redirect(context.HttpContext.Items["silent"]!.ToString()!);
 
             return Task.FromResult(true);
         }

--- a/bff/src/Bff/EndpointServices/SilentLogin/DefaultSilentLoginService.cs
+++ b/bff/src/Bff/EndpointServices/SilentLogin/DefaultSilentLoginService.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -35,15 +36,23 @@ public class DefaultSilentLoginService : ISilentLoginService
     }
 
     /// <inheritdoc />
-    public virtual Task ProcessRequestAsync(HttpContext context)
+    public virtual async Task ProcessRequestAsync(HttpContext context)
     {
-        var query = context.Request.QueryString;
-        if (!string.IsNullOrEmpty(query.Value))
-        {
-            query = query.Add(Constants.RequestParameters.Prompt, "none");
-        }
+        Logger.LogDebug("Processing silent login request");
 
-        context.Response.Redirect($"{Options.LoginPath}?{query}");
-        return Task.CompletedTask;
+        context.CheckForBffMiddleware(Options);
+
+        var props = new AuthenticationProperties
+        {
+            Items =
+            {
+                { Constants.BffFlags.Prompt, "none" }
+            },
+        };
+
+        Logger.LogWarning("Using deprecated silentlogin endpoint. This endpoint will be removed in future versions. Consider calling the BFF Login endpoint with prompt=none.");
+
+        await context.ChallengeAsync(props);
+
     }
 }

--- a/bff/src/Bff/EndpointServices/SilentLogin/PostConfigureOidcOptionsForSilentLogin.cs
+++ b/bff/src/Bff/EndpointServices/SilentLogin/PostConfigureOidcOptionsForSilentLogin.cs
@@ -19,10 +19,10 @@ public class PostConfigureOidcOptionsForSilentLogin : IPostConfigureOptions<Open
     /// <summary>
     /// ctor
     /// </summary>
-    public PostConfigureOidcOptionsForSilentLogin(IOptions<AuthenticationOptions> options, ILoggerFactory logger)
+    public PostConfigureOidcOptionsForSilentLogin(IOptions<BffOptions> bffOptions, IOptions<AuthenticationOptions> options, ILoggerFactory logger)
     {
         _scheme = options.Value.DefaultChallengeScheme;
-        _events = new BffOpenIdConnectEvents(logger.CreateLogger<BffOpenIdConnectEvents>());
+        _events = new BffOpenIdConnectEvents(logger.CreateLogger<BffOpenIdConnectEvents>(), bffOptions);
     }
 
     /// <inheritdoc />

--- a/bff/src/Bff/EndpointServices/SilentLogin/PostConfigureOidcOptionsForSilentLogin.cs
+++ b/bff/src/Bff/EndpointServices/SilentLogin/PostConfigureOidcOptionsForSilentLogin.cs
@@ -19,9 +19,12 @@ public class PostConfigureOidcOptionsForSilentLogin : IPostConfigureOptions<Open
     /// <summary>
     /// ctor
     /// </summary>
-    public PostConfigureOidcOptionsForSilentLogin(IOptions<BffOptions> bffOptions, IOptions<AuthenticationOptions> options, ILoggerFactory logger)
+    public PostConfigureOidcOptionsForSilentLogin(
+        IOptions<BffOptions> bffOptions,
+        IOptions<AuthenticationOptions> authenticationOptions,
+        ILoggerFactory logger)
     {
-        _scheme = options.Value.DefaultChallengeScheme;
+        _scheme = authenticationOptions.Value.DefaultChallengeScheme;
         _events = new BffOpenIdConnectEvents(logger.CreateLogger<BffOpenIdConnectEvents>(), bffOptions);
     }
 

--- a/bff/src/Bff/Extensions/AuthenticationPropertiesExtensions.cs
+++ b/bff/src/Bff/Extensions/AuthenticationPropertiesExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Authentication;
 
 namespace Duende.Bff;
@@ -15,10 +16,10 @@ public static class AuthenticationPropertiesExtensions
     /// </summary>
     public static bool IsSilentLogin(this AuthenticationProperties props)
     {
-        return props.Items.ContainsKey(Constants.BffFlags.SilentLogin);
+        return props.TryGetPrompt(out var prompt) && prompt == "none";
     }
 
-    public static bool TryGetPrompt(this AuthenticationProperties props, out string prompt)
+    public static bool TryGetPrompt(this AuthenticationProperties props, [NotNullWhen(true)] out string? prompt)
     {
         return props.Items.TryGetValue(Constants.BffFlags.Prompt, out prompt);
     }

--- a/bff/src/Bff/Extensions/AuthenticationPropertiesExtensions.cs
+++ b/bff/src/Bff/Extensions/AuthenticationPropertiesExtensions.cs
@@ -17,4 +17,9 @@ public static class AuthenticationPropertiesExtensions
     {
         return props.Items.ContainsKey(Constants.BffFlags.SilentLogin);
     }
+
+    public static bool TryGetPrompt(this AuthenticationProperties props, out string prompt)
+    {
+        return props.Items.TryGetValue(Constants.BffFlags.Prompt, out prompt);
+    }
 }

--- a/bff/src/Bff/Extensions/HttpContextExtensions.cs
+++ b/bff/src/Bff/Extensions/HttpContextExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
+using System.Net;
 using Duende.AccessTokenManagement;
 using Duende.AccessTokenManagement.OpenIdConnect;
 using Duende.IdentityModel;
@@ -11,6 +12,20 @@ namespace Duende.Bff;
 
 internal static class HttpContextExtensions
 {
+    public static void ReturnHttpProblem(this HttpContext context, string title, params (string key, string[] values)[] errors)
+    {
+        var problem = new HttpValidationProblemDetails()
+        {
+            Status = (int)HttpStatusCode.BadRequest,
+            Title = title,
+            Errors = errors.ToDictionary()
+        };
+        context.Response.StatusCode = problem.Status.Value;
+        context.Response.ContentType = "application/problem+json";
+        context.Response.WriteAsJsonAsync(problem);
+
+    }
+
     public static void CheckForBffMiddleware(this HttpContext context, BffOptions options)
     {
         if (options.EnforceBffMiddleware)

--- a/bff/test/Bff.Tests/Bff.Tests.net8.0.v3.ncrunchproject
+++ b/bff/test/Bff.Tests/Bff.Tests.net8.0.v3.ncrunchproject
@@ -1,5 +1,6 @@
 ﻿<ProjectConfiguration>
   <Settings>
+    <EnableRDI>True</EnableRDI>
     <HiddenComponentWarnings>
       <Value>AspNetTestHostCompatibility</Value>
     </HiddenComponentWarnings>

--- a/bff/test/Bff.Tests/Endpoints/Management/LoginEndpointTests.cs
+++ b/bff/test/Bff.Tests/Endpoints/Management/LoginEndpointTests.cs
@@ -71,7 +71,7 @@ public class LoginEndpointTests(ITestOutputHelper output) : BffIntegrationTestBa
     [Fact]
     public async Task login_with_unsupported_prompt_is_rejected()
     {
-        var response = await BffHost.BrowserClient.GetAsync(BffHost.Url("/bff/login?prompt=not_supported_prompt")); 
+        var response = await BffHost.BrowserClient.GetAsync(BffHost.Url("/bff/login?prompt=not_supported_prompt"));
         response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
 
         var problem = await response.Content.ReadFromJsonAsync<HttpValidationProblemDetails>();

--- a/bff/test/Bff.Tests/Endpoints/Management/LoginEndpointTests.cs
+++ b/bff/test/Bff.Tests/Endpoints/Management/LoginEndpointTests.cs
@@ -32,9 +32,18 @@ public class LoginEndpointTests(ITestOutputHelper output) : BffIntegrationTestBa
     public async Task silent_login_should_challenge_and_redirect_to_root()
     {
         var response = await BffHost.BrowserClient.GetAsync(BffHost.Url("/bff/silent-login?redirectUri=/"));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+        response.Headers.Location!.ToString().ShouldStartWith("/bff/login");
+        response.Headers.Location!.ToString().ShouldContain("redirectUri=/");
+        response.Headers.Location!.ToString().ShouldNotContain("error");
+
+        response = await BffHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
+
         response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
         response.Headers.Location!.ToString().ShouldStartWith(IdentityServerHost.Url("/connect/authorize"));
         response.Headers.Location!.ToString().ShouldNotContain("error");
+
 
         await IdentityServerHost.IssueSessionCookieAsync("alice");
         response = await IdentityServerHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
@@ -63,7 +72,7 @@ public class LoginEndpointTests(ITestOutputHelper output) : BffIntegrationTestBa
 
         response = await BffHost.BrowserClient.GetAsync(response.Headers.Location.ToString());
         response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
-        response.Headers.Location!.ToString().ShouldBe("/");
+        response.Headers.Location!.ToString().ShouldBe("/bff/silent-login-callback");
     }
 
     [Fact]

--- a/bff/test/Bff.Tests/Endpoints/Management/ManagementBasePathTests.cs
+++ b/bff/test/Bff.Tests/Endpoints/Management/ManagementBasePathTests.cs
@@ -12,7 +12,9 @@ public class ManagementBasePathTests(ITestOutputHelper output) : BffIntegrationT
     [Theory]
     [InlineData(Constants.ManagementEndpoints.Login)]
     [InlineData(Constants.ManagementEndpoints.Logout)]
+#pragma warning disable CS0618 // Type or member is obsolete
     [InlineData(Constants.ManagementEndpoints.SilentLogin)]
+#pragma warning restore CS0618 // Type or member is obsolete
     [InlineData(Constants.ManagementEndpoints.SilentLoginCallback)]
     [InlineData(Constants.ManagementEndpoints.User)]
     public async Task custom_ManagementBasePath_should_affect_basepath(string path)

--- a/bff/test/Bff.Tests/TestHosts/IdentityServerHost.cs
+++ b/bff/test/Bff.Tests/TestHosts/IdentityServerHost.cs
@@ -43,6 +43,7 @@ public class IdentityServerHost : GenericHost
         services.AddIdentityServer(options =>
         {
             options.EmitStaticAudienceClaim = true;
+            options.UserInteraction.CreateAccountUrl = "/account/create";
         })
             .AddInMemoryClients(Clients)
             .AddInMemoryIdentityResources(IdentityResources)
@@ -58,6 +59,11 @@ public class IdentityServerHost : GenericHost
 
         app.UseEndpoints(endpoints =>
         {
+            endpoints.MapGet("/account/create", context =>
+            {
+                return Task.CompletedTask;
+            });
+
             endpoints.MapGet("/account/login", context =>
             {
                 return Task.CompletedTask;


### PR DESCRIPTION
**What issue does this PR address?**
The login endpoint now supports prompt=create (for silent login) and other prompts such as select. 

The existing silent-login endpoint now redirects to the login endpoint with prompt=none. 

This is a breaking change because some of the public constructors have changed.

fixes #https://github.com/DuendeSoftware/products/issues/1701

**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
