### PR TITLE
allow anti-forgery check to be disabled

### DIFF
--- a/bff/src/Bff.Yarp/AntiforgeryMiddleware.cs
+++ b/bff/src/Bff.Yarp/AntiforgeryMiddleware.cs
@@ -38,6 +38,14 @@ public class AntiforgeryMiddleware
     {
         var route = context.GetRouteModel();
 
+        // Check if the request is a WebSocket request
+        if (_options.DisableAntiForgeryCheck(context))
+        {
+            await _next(context);
+            return;
+        }
+
+
         if (route.Config.Metadata != null)
         {
             if (route.Config.Metadata.TryGetValue(Constants.Yarp.AntiforgeryCheckMetadata, out var value))

--- a/bff/src/Bff/Configuration/AnonymousSessionResponse.cs
+++ b/bff/src/Bff/Configuration/AnonymousSessionResponse.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+namespace Bff.Configuration;
+
+/// <summary>
+/// Enum representing the style of response from the ~/bff/user endpoint when the user is anonymous.
+/// </summary>
+public enum AnonymousSessionResponse
+{
+    /// <summary>
+    /// 401 response with empty body
+    /// </summary>
+    Response401,
+    /// <summary>
+    /// 200 response with "null" as the body
+    /// </summary>
+    Response200
+}

--- a/bff/src/Bff/Configuration/AnonymousSessionResponse.cs
+++ b/bff/src/Bff/Configuration/AnonymousSessionResponse.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
-namespace Bff.Configuration;
+namespace Microsoft.AspNetCore.Builder;
 
 /// <summary>
 /// Enum representing the style of response from the ~/bff/user endpoint when the user is anonymous.

--- a/bff/src/Bff/Configuration/BffOptions.cs
+++ b/bff/src/Bff/Configuration/BffOptions.cs
@@ -143,8 +143,8 @@ public class BffOptions
     public bool RemoveSessionAfterRefreshTokenExpiration { get; set; } = true;
 
     /// <summary>
-    /// Implementation that allows you to check if you want to disable the anti-forgery check for a given request.
-    /// Default implementation will disable anti forgery requests for websockets, because websocket requests can't
+    /// A delegate that determines if the anti-forgery check should be disabled for a given request.
+    /// The default is to disable anti forgery checks for websockets, because websocket requests can't
     /// include http headers. 
     /// </summary>
     public DisableAntiForgeryCheck DisableAntiForgeryCheck { get; set; } = (c) =>

--- a/bff/src/Bff/Configuration/BffOptions.cs
+++ b/bff/src/Bff/Configuration/BffOptions.cs
@@ -145,17 +145,8 @@ public class BffOptions
 
     /// <summary>
     /// A delegate that determines if the anti-forgery check should be disabled for a given request.
-    /// The default is to disable anti forgery checks for websockets, because websocket requests can't
-    /// include http headers. 
+    /// The default is not to disable anti-forgery checks.
     /// </summary>
-    public DisableAntiForgeryCheck DisableAntiForgeryCheck { get; set; } = (c) =>
-    {
-        if (c.WebSockets.IsWebSocketRequest)
-        {
-            return true;
-        }
-
-        return false;
-    };
+    public DisableAntiForgeryCheck DisableAntiForgeryCheck { get; set; } = (c) => false;
 
 }

--- a/bff/src/Bff/Configuration/BffOptions.cs
+++ b/bff/src/Bff/Configuration/BffOptions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
+using Bff.Configuration;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Hosting;
 
@@ -140,19 +141,20 @@ public class BffOptions
     /// APIs with TokenType.User or TokenType.UserOrClient. Defaults to True. 
     /// </summary>
     public bool RemoveSessionAfterRefreshTokenExpiration { get; set; } = true;
-}
 
-/// <summary>
-/// Enum representing the style of response from the ~/bff/user endpoint when the user is anonymous.
-/// </summary>
-public enum AnonymousSessionResponse
-{
     /// <summary>
-    /// 401 response with empty body
+    /// Implementation that allows you to check if you want to disable the anti-forgery check for a given request.
+    /// Default implementation will disable anti forgery requests for websockets, because websocket requests can't
+    /// include http headers. 
     /// </summary>
-    Response401,
-    /// <summary>
-    /// 200 response with "null" as the body
-    /// </summary>
-    Response200
+    public DisableAntiForgeryCheck DisableAntiForgeryCheck { get; set; } = (c) =>
+    {
+        if (c.WebSockets.IsWebSocketRequest)
+        {
+            return true;
+        }
+
+        return false;
+    };
+
 }

--- a/bff/src/Bff/Configuration/BffOptions.cs
+++ b/bff/src/Bff/Configuration/BffOptions.cs
@@ -1,7 +1,8 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
-using Bff.Configuration;
+using Duende.Bff.Configuration;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Hosting;
 

--- a/bff/src/Bff/Configuration/DisableAntiForgeryCheck.cs
+++ b/bff/src/Bff/Configuration/DisableAntiForgeryCheck.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using Microsoft.AspNetCore.Http;
+
+namespace Bff.Configuration;
+
+/// <summary>
+/// Delegate that defines if the default anti forgery check should be disabled for the current request
+/// </summary>
+/// <param name="context"></param>
+/// <returns></returns>
+public delegate bool DisableAntiForgeryCheck(HttpContext context);

--- a/bff/src/Bff/Configuration/DisableAntiForgeryCheck.cs
+++ b/bff/src/Bff/Configuration/DisableAntiForgeryCheck.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNetCore.Http;
 namespace Bff.Configuration;
 
 /// <summary>
-/// Delegate that defines if the default anti forgery check should be disabled for the current request
+/// Delegate that determines if the anti forgery check should be disabled for a request.
 /// </summary>
 /// <param name="context"></param>
 /// <returns></returns>

--- a/bff/src/Bff/Configuration/DisableAntiForgeryCheck.cs
+++ b/bff/src/Bff/Configuration/DisableAntiForgeryCheck.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.AspNetCore.Http;
 
-namespace Bff.Configuration;
+namespace Duende.Bff.Configuration;
 
 /// <summary>
 /// Delegate that determines if the anti forgery check should be disabled for a request.

--- a/bff/src/Bff/EndpointProcessing/BffMiddleware.cs
+++ b/bff/src/Bff/EndpointProcessing/BffMiddleware.cs
@@ -41,6 +41,13 @@ public class BffMiddleware
         // add marker so we can determine if middleware has run later in the pipeline
         context.Items[Constants.BffMiddlewareMarker] = true;
 
+        // Check if the request is a WebSocket request
+        if (_options.DisableAntiForgeryCheck(context))
+        {
+            await _next(context);
+            return;
+        }
+
         // inbound: add CSRF check for local APIs 
 
         var endpoint = context.GetEndpoint();

--- a/bff/src/Bff/EndpointServices/User/DefaultUserService.cs
+++ b/bff/src/Bff/EndpointServices/User/DefaultUserService.cs
@@ -3,10 +3,10 @@
 
 using System.Text;
 using System.Text.Json;
-using Bff.Configuration;
 using Duende.Bff.Logging;
 using Duende.IdentityModel;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;

--- a/bff/src/Bff/EndpointServices/User/DefaultUserService.cs
+++ b/bff/src/Bff/EndpointServices/User/DefaultUserService.cs
@@ -3,6 +3,7 @@
 
 using System.Text;
 using System.Text.Json;
+using Bff.Configuration;
 using Duende.Bff.Logging;
 using Duende.IdentityModel;
 using Microsoft.AspNetCore.Authentication;

--- a/bff/test/Bff.Tests/Endpoints/Management/UserEndpointTests.cs
+++ b/bff/test/Bff.Tests/Endpoints/Management/UserEndpointTests.cs
@@ -3,7 +3,6 @@
 
 using System.Net;
 using System.Security.Claims;
-using Bff.Configuration;
 using Duende.Bff.Tests.TestHosts;
 using Xunit.Abstractions;
 

--- a/bff/test/Bff.Tests/Endpoints/Management/UserEndpointTests.cs
+++ b/bff/test/Bff.Tests/Endpoints/Management/UserEndpointTests.cs
@@ -3,6 +3,7 @@
 
 using System.Net;
 using System.Security.Claims;
+using Bff.Configuration;
 using Duende.Bff.Tests.TestHosts;
 using Xunit.Abstractions;
 

--- a/bff/test/Bff.Tests/Endpoints/RemoteEndpointTests.cs
+++ b/bff/test/Bff.Tests/Endpoints/RemoteEndpointTests.cs
@@ -338,4 +338,14 @@ public class RemoteEndpointTests(ITestOutputHelper output) : BffIntegrationTestB
         response.Content.Headers.Select(x => x.Key).ShouldNotContain("added-by-custom-default-transform",
             "a custom transform doesn't run the defaults");
     }
+    [Fact]
+    public async Task can_disable_anti_forgery_check()
+    {
+        BffHost.BffOptions.DisableAntiForgeryCheck = (c) => true;
+
+        var req = new HttpRequestMessage(HttpMethod.Get, BffHost.Url("/api_user_or_anon/test"));
+        var response = await BffHost.BrowserClient.SendAsync(req);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
 }

--- a/bff/test/Bff.Tests/Endpoints/YarpRemoteEndpointTests.cs
+++ b/bff/test/Bff.Tests/Endpoints/YarpRemoteEndpointTests.cs
@@ -27,7 +27,16 @@ public class YarpRemoteEndpointTests(ITestOutputHelper output) : YarpBffIntegrat
 
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
     }
+    [Fact]
+    public async Task can_disable_anti_forgery_check()
+    {
+        YarpBasedBffHost.BffOptions.DisableAntiForgeryCheck = (c) => true;
 
+        var req = new HttpRequestMessage(HttpMethod.Get, YarpBasedBffHost.Url("/api_anon/test"));
+        var response = await YarpBasedBffHost.BrowserClient.SendAsync(req);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
 
     [Fact]
     public async Task anonymous_call_to_no_token_requirement_route_should_succeed()

--- a/bff/test/Bff.Tests/PublicApiVerificationTests.VerifyPublicApi_Bff.verified.txt
+++ b/bff/test/Bff.Tests/PublicApiVerificationTests.VerifyPublicApi_Bff.verified.txt
@@ -27,11 +27,6 @@
         public AccessTokenRetrievalError(string error) { }
         public string Error { get; set; }
     }
-    public enum AnonymousSessionResponse
-    {
-        Response401 = 0,
-        Response200 = 1,
-    }
     public static class AuthenticationPropertiesExtensions
     {
         public static bool IsSilentLogin(this Microsoft.AspNetCore.Authentication.AuthenticationProperties props) { }
@@ -86,7 +81,7 @@
     public class BffOptions
     {
         public BffOptions() { }
-        public Duende.Bff.AnonymousSessionResponse AnonymousSessionResponse { get; set; }
+        public Microsoft.AspNetCore.Builder.AnonymousSessionResponse AnonymousSessionResponse { get; set; }
         public string AntiForgeryHeaderName { get; set; }
         public string AntiForgeryHeaderValue { get; set; }
         public Microsoft.AspNetCore.Http.PathString BackChannelLogoutPath { get; }
@@ -94,6 +89,7 @@
         public string? DPoPJsonWebKey { get; set; }
         public System.Collections.Generic.ICollection<string> DiagnosticsEnvironments { get; set; }
         public Microsoft.AspNetCore.Http.PathString DiagnosticsPath { get; }
+        public Duende.Bff.Configuration.DisableAntiForgeryCheck DisableAntiForgeryCheck { get; set; }
         public bool EnableSessionCleanup { get; set; }
         public bool EnforceBffMiddleware { get; set; }
         public string? LicenseKey { get; set; }
@@ -403,6 +399,10 @@
         public string? SubjectId { get; init; }
         public void Validate() { }
     }
+}
+namespace Duende.Bff.Configuration
+{
+    public delegate bool DisableAntiForgeryCheck(Microsoft.AspNetCore.Http.HttpContext context);
 }
 namespace Duende.Bff.Endpoints
 {

--- a/bff/test/Bff.Tests/TestHosts/YarpBffHost.cs
+++ b/bff/test/Bff.Tests/TestHosts/YarpBffHost.cs
@@ -51,7 +51,10 @@ public class YarpBffHost : GenericHost
         services.AddRouting();
         services.AddAuthorization();
 
-        var bff = services.AddBff(options => { BffOptions = options; });
+        var bff = services.AddBff(options =>
+        {
+            BffOptions = options;
+        });
 
         services.AddSingleton<IForwarderHttpClientFactory>(
             new CallbackForwarderHttpClientFactory(


### PR DESCRIPTION
**What issue does this PR address?**
The anti-forgery check can be disabled by changing the **BffOptions.DisableAntiForgeryRequest** method. 

fixes: https://github.com/DuendeSoftware/products/issues/1732

**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
