### PR TITLE
Don't return redirect URI or response mode on unsafe errors

### DIFF
--- a/identity-server/src/IdentityServer/Endpoints/Results/AuthorizeResult.cs
+++ b/identity-server/src/IdentityServer/Endpoints/Results/AuthorizeResult.cs
@@ -229,13 +229,6 @@ public class AuthorizeHttpWriter : IHttpResponseWriter<AuthorizeResult>
             ClientId = response.Request?.ClientId
         };
 
-        if (response.RedirectUri != null && response.Request?.ResponseMode != null)
-        {
-            // if we have a valid redirect uri, then include it to the error page
-            errorModel.RedirectUri = BuildRedirectUri(response);
-            errorModel.ResponseMode = response.Request.ResponseMode;
-        }
-
         var message = new Message<ErrorMessage>(errorModel, _clock.UtcNow.UtcDateTime);
         var id = await _errorMessageStore.WriteAsync(message);
 

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Authorize/AuthorizeTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Authorize/AuthorizeTests.cs
@@ -814,7 +814,7 @@ public class AuthorizeTests
 
     [Fact]
     [Trait("Category", Category)]
-    public async Task invalid_response_mode_for_flow_should_pass_return_url_to_error_page()
+    public async Task invalid_response_mode_for_flow_should_not_pass_return_url_to_error_page()
     {
         await _mockPipeline.LoginAsync("bob");
 
@@ -829,8 +829,8 @@ public class AuthorizeTests
         await _mockPipeline.BrowserClient.GetAsync(url);
 
         _mockPipeline.ErrorWasCalled.ShouldBeTrue();
-        _mockPipeline.ErrorMessage.RedirectUri.ShouldStartWith("https://client1/callback");
-        _mockPipeline.ErrorMessage.ResponseMode.ShouldBe("fragment");
+        _mockPipeline.ErrorMessage.RedirectUri.ShouldBeNull();
+        _mockPipeline.ErrorMessage.ResponseMode.ShouldBeNull();
     }
 
     [Fact]
@@ -856,7 +856,7 @@ public class AuthorizeTests
 
     [Fact]
     [Trait("Category", Category)]
-    public async Task invalid_response_mode_should_pass_return_url_to_error_page()
+    public async Task invalid_response_mode_should_not_pass_return_url_to_error_page()
     {
         await _mockPipeline.LoginAsync("bob");
 
@@ -871,8 +871,8 @@ public class AuthorizeTests
         await _mockPipeline.BrowserClient.GetAsync(url);
 
         _mockPipeline.ErrorWasCalled.ShouldBeTrue();
-        _mockPipeline.ErrorMessage.RedirectUri.ShouldStartWith("https://client1/callback");
-        _mockPipeline.ErrorMessage.ResponseMode.ShouldBe("fragment");
+        _mockPipeline.ErrorMessage.RedirectUri.ShouldBeNull();
+        _mockPipeline.ErrorMessage.ResponseMode.ShouldBeNull();
     }
 
     [Fact]
@@ -897,7 +897,7 @@ public class AuthorizeTests
 
     [Fact]
     [Trait("Category", Category)]
-    public async Task missing_scope_should_pass_return_url_to_error_page()
+    public async Task missing_scope_should_not_pass_return_url_to_error_page()
     {
         await _mockPipeline.LoginAsync("bob");
 
@@ -911,13 +911,13 @@ public class AuthorizeTests
         await _mockPipeline.BrowserClient.GetAsync(url);
 
         _mockPipeline.ErrorWasCalled.ShouldBeTrue();
-        _mockPipeline.ErrorMessage.RedirectUri.ShouldStartWith("https://client1/callback");
-        _mockPipeline.ErrorMessage.ResponseMode.ShouldBe("fragment");
+        _mockPipeline.ErrorMessage.RedirectUri.ShouldBeNull();
+        _mockPipeline.ErrorMessage.ResponseMode.ShouldBeNull();
     }
 
     [Fact]
     [Trait("Category", Category)]
-    public async Task explicit_response_mode_should_be_passed_to_error_page()
+    public async Task explicit_response_mode_should_not_be_passed_to_error_page()
     {
         await _mockPipeline.LoginAsync("bob");
 
@@ -932,8 +932,8 @@ public class AuthorizeTests
         await _mockPipeline.BrowserClient.GetAsync(url);
 
         _mockPipeline.ErrorWasCalled.ShouldBeTrue();
-        _mockPipeline.ErrorMessage.RedirectUri.ShouldStartWith("https://client1/callback");
-        _mockPipeline.ErrorMessage.ResponseMode.ShouldBe("form_post");
+        _mockPipeline.ErrorMessage.RedirectUri.ShouldBeNull();
+        _mockPipeline.ErrorMessage.ResponseMode.ShouldBeNull();
     }
 
     [Fact]
@@ -954,8 +954,8 @@ public class AuthorizeTests
         _mockPipeline.ErrorWasCalled.ShouldBeTrue();
         _mockPipeline.ErrorMessage.Error.ShouldBe(OidcConstants.AuthorizeErrors.InvalidRequest);
         _mockPipeline.ErrorMessage.ErrorDescription.ShouldContain("scope");
-        _mockPipeline.ErrorMessage.RedirectUri.ShouldStartWith("https://client1/callback");
-        _mockPipeline.ErrorMessage.ResponseMode.ShouldBe("fragment");
+        _mockPipeline.ErrorMessage.RedirectUri.ShouldBeNull();
+        _mockPipeline.ErrorMessage.ResponseMode.ShouldBeNull();
     }
 
     [Fact]
@@ -977,8 +977,8 @@ public class AuthorizeTests
         _mockPipeline.ErrorMessage.Error.ShouldBe(OidcConstants.AuthorizeErrors.InvalidRequest);
         _mockPipeline.ErrorMessage.ErrorDescription.ShouldContain("scope");
         _mockPipeline.ErrorMessage.ErrorDescription.ShouldContain("openid");
-        _mockPipeline.ErrorMessage.RedirectUri.ShouldStartWith("https://client1/callback");
-        _mockPipeline.ErrorMessage.ResponseMode.ShouldBe("fragment");
+        _mockPipeline.ErrorMessage.RedirectUri.ShouldBeNull();
+        _mockPipeline.ErrorMessage.ResponseMode.ShouldBeNull();
     }
 
     [Fact]
@@ -999,8 +999,8 @@ public class AuthorizeTests
         _mockPipeline.ErrorWasCalled.ShouldBeTrue();
         _mockPipeline.ErrorMessage.Error.ShouldBe(OidcConstants.AuthorizeErrors.InvalidScope);
         _mockPipeline.ErrorMessage.ErrorDescription.ShouldContain("scope");
-        _mockPipeline.ErrorMessage.RedirectUri.ShouldStartWith("https://client1/callback");
-        _mockPipeline.ErrorMessage.ResponseMode.ShouldBe("fragment");
+        _mockPipeline.ErrorMessage.RedirectUri.ShouldBeNull();
+        _mockPipeline.ErrorMessage.ResponseMode.ShouldBeNull();
     }
 
     [Fact]
@@ -1022,8 +1022,8 @@ public class AuthorizeTests
         _mockPipeline.ErrorWasCalled.ShouldBeTrue();
         _mockPipeline.ErrorMessage.Error.ShouldBe(OidcConstants.AuthorizeErrors.InvalidRequest);
         _mockPipeline.ErrorMessage.ErrorDescription.ShouldContain("nonce");
-        _mockPipeline.ErrorMessage.RedirectUri.ShouldStartWith("https://client1/callback");
-        _mockPipeline.ErrorMessage.ResponseMode.ShouldBe("fragment");
+        _mockPipeline.ErrorMessage.RedirectUri.ShouldBeNull();
+        _mockPipeline.ErrorMessage.ResponseMode.ShouldBeNull();
     }
 
     [Fact]
@@ -1044,8 +1044,8 @@ public class AuthorizeTests
         _mockPipeline.ErrorWasCalled.ShouldBeTrue();
         _mockPipeline.ErrorMessage.Error.ShouldBe(OidcConstants.AuthorizeErrors.InvalidRequest);
         _mockPipeline.ErrorMessage.ErrorDescription.ShouldContain("nonce");
-        _mockPipeline.ErrorMessage.RedirectUri.ShouldStartWith("https://client1/callback");
-        _mockPipeline.ErrorMessage.ResponseMode.ShouldBe("fragment");
+        _mockPipeline.ErrorMessage.RedirectUri.ShouldBeNull();
+        _mockPipeline.ErrorMessage.ResponseMode.ShouldBeNull();
     }
 
     [Fact]
@@ -1067,8 +1067,8 @@ public class AuthorizeTests
         _mockPipeline.ErrorWasCalled.ShouldBeTrue();
         _mockPipeline.ErrorMessage.Error.ShouldBe(OidcConstants.AuthorizeErrors.InvalidRequest);
         _mockPipeline.ErrorMessage.ErrorDescription.ShouldContain("ui_locales");
-        _mockPipeline.ErrorMessage.RedirectUri.ShouldStartWith("https://client1/callback");
-        _mockPipeline.ErrorMessage.ResponseMode.ShouldBe("fragment");
+        _mockPipeline.ErrorMessage.RedirectUri.ShouldBeNull();
+        _mockPipeline.ErrorMessage.ResponseMode.ShouldBeNull();
     }
 
     [Fact]
@@ -1090,8 +1090,8 @@ public class AuthorizeTests
         _mockPipeline.ErrorWasCalled.ShouldBeTrue();
         _mockPipeline.ErrorMessage.Error.ShouldBe(OidcConstants.AuthorizeErrors.InvalidRequest);
         _mockPipeline.ErrorMessage.ErrorDescription.ShouldContain("max_age");
-        _mockPipeline.ErrorMessage.RedirectUri.ShouldStartWith("https://client1/callback");
-        _mockPipeline.ErrorMessage.ResponseMode.ShouldBe("fragment");
+        _mockPipeline.ErrorMessage.RedirectUri.ShouldBeNull();
+        _mockPipeline.ErrorMessage.ResponseMode.ShouldBeNull();
     }
 
     [Fact]
@@ -1113,8 +1113,8 @@ public class AuthorizeTests
         _mockPipeline.ErrorWasCalled.ShouldBeTrue();
         _mockPipeline.ErrorMessage.Error.ShouldBe(OidcConstants.AuthorizeErrors.InvalidRequest);
         _mockPipeline.ErrorMessage.ErrorDescription.ShouldContain("max_age");
-        _mockPipeline.ErrorMessage.RedirectUri.ShouldStartWith("https://client1/callback");
-        _mockPipeline.ErrorMessage.ResponseMode.ShouldBe("fragment");
+        _mockPipeline.ErrorMessage.RedirectUri.ShouldBeNull();
+        _mockPipeline.ErrorMessage.ResponseMode.ShouldBeNull();
     }
 
     [Fact]
@@ -1136,8 +1136,8 @@ public class AuthorizeTests
         _mockPipeline.ErrorWasCalled.ShouldBeTrue();
         _mockPipeline.ErrorMessage.Error.ShouldBe(OidcConstants.AuthorizeErrors.InvalidRequest);
         _mockPipeline.ErrorMessage.ErrorDescription.ShouldContain("login_hint");
-        _mockPipeline.ErrorMessage.RedirectUri.ShouldStartWith("https://client1/callback");
-        _mockPipeline.ErrorMessage.ResponseMode.ShouldBe("fragment");
+        _mockPipeline.ErrorMessage.RedirectUri.ShouldBeNull();
+        _mockPipeline.ErrorMessage.ResponseMode.ShouldBeNull();
     }
 
     [Fact]
@@ -1159,8 +1159,8 @@ public class AuthorizeTests
         _mockPipeline.ErrorWasCalled.ShouldBeTrue();
         _mockPipeline.ErrorMessage.Error.ShouldBe(OidcConstants.AuthorizeErrors.InvalidRequest);
         _mockPipeline.ErrorMessage.ErrorDescription.ShouldContain("acr_values");
-        _mockPipeline.ErrorMessage.RedirectUri.ShouldStartWith("https://client1/callback");
-        _mockPipeline.ErrorMessage.ResponseMode.ShouldBe("fragment");
+        _mockPipeline.ErrorMessage.RedirectUri.ShouldBeNull();
+        _mockPipeline.ErrorMessage.ResponseMode.ShouldBeNull();
     }
 
     [Fact]

--- a/identity-server/test/IdentityServer.UnitTests/Endpoints/Results/AuthorizeResultTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Endpoints/Results/AuthorizeResultTests.cs
@@ -301,7 +301,7 @@ public class AuthorizeResultTests
     [InlineData(OidcConstants.AuthorizeErrors.RegistrationNotSupported)]
     [InlineData(OidcConstants.AuthorizeErrors.InvalidTarget)]
     [Theory]
-    public async Task error_resulting_in_error_page_should_attach_fragment_to_error_model_redirect_uri(string error)
+    public async Task error_resulting_in_error_page_should_not_set_redirect_uri_or_response_mode(string error)
     {
         _response.Error = error;
         _response.Request = new ValidatedAuthorizeRequest
@@ -321,6 +321,7 @@ public class AuthorizeResultTests
         var queryParams = QueryHelpers.ParseQuery(queryString);
         var errorId = queryParams.First(kvp => kvp.Key == _options.UserInteraction.ErrorIdParameter).Value;
         var errorMessage = await _mockErrorMessageStore.ReadAsync(errorId);
-        errorMessage.Data.RedirectUri.ShouldContain("#_");
+        errorMessage.Data.RedirectUri.ShouldBeNull();
+        errorMessage.Data.ResponseMode.ShouldBeNull();
     }
 }


### PR DESCRIPTION
**What issue does this PR address?**
Stop setting redirect URI and response mode on unsafe errors. The errors have been deemed unsafe to redirect so we should not enable them being presented to users.


**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
