### PR TITLE
Implement RFC 9701 to Return JWT Response from Introspection Endpoint

### DIFF
--- a/identity-server/src/IdentityServer/Endpoints/IntrospectionEndpoint.cs
+++ b/identity-server/src/IdentityServer/Endpoints/IntrospectionEndpoint.cs
@@ -155,7 +155,8 @@ internal class IntrospectionEndpoint : IEndpointHandler
 
         // render result
         LogSuccess(validationResult.IsActive, callerName);
-        return new IntrospectionResult(response);
+        return new IntrospectionResult(response, callerName,
+            string.Equals(context.Request.Headers.Accept, $"application/{IdentityServerConstants.TokenTypes.IntrospectionResponseToken}", StringComparison.OrdinalIgnoreCase));
     }
 
     private void LogSuccess(bool tokenActive, string callerName)

--- a/identity-server/src/IdentityServer/Endpoints/Results/IntrospectionResult.cs
+++ b/identity-server/src/IdentityServer/Endpoints/Results/IntrospectionResult.cs
@@ -2,8 +2,11 @@
 // See LICENSE in the project root for license information.
 
 
+using System.Security.Claims;
 using Duende.IdentityServer.Extensions;
 using Duende.IdentityServer.Hosting;
+using Duende.IdentityServer.Models;
+using Duende.IdentityServer.Services;
 using Microsoft.AspNetCore.Http;
 
 namespace Duende.IdentityServer.Endpoints.Results;
@@ -23,22 +26,70 @@ public class IntrospectionResult : EndpointResult<IntrospectionResult>
     public Dictionary<string, object> Entries { get; }
 
     /// <summary>
+    /// Gets the name of the caller.
+    /// </summary>
+    /// <value>
+    /// Identifier of the request caller.
+    /// </value>
+    public string CallerName { get; }
+
+    /// <summary>
+    /// Gets if JWT response was requested.
+    /// </summary>
+    /// <value>
+    /// True if JWT response was requested.
+    /// </value>
+    public bool JwtResponseWasRequested { get; }
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="IntrospectionResult"/> class.
     /// </summary>
     /// <param name="entries">The result.</param>
     /// <exception cref="System.ArgumentNullException">result</exception>
-    public IntrospectionResult(Dictionary<string, object> entries)
+    public IntrospectionResult(Dictionary<string, object> entries) : this(entries, null, false)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IntrospectionResult"/> class.
+    /// </summary>
+    /// <param name="entries">The result.</param>
+    /// <param name="callerName">The identifier of the party making the introspection request.</param>
+    /// <param name="jwtResponseWasRequested">If a JWT response was requested.</param>
+    /// <exception cref="System.ArgumentNullException">result</exception>
+    public IntrospectionResult(Dictionary<string, object> entries, string callerName, bool jwtResponseWasRequested)
     {
         Entries = entries ?? throw new ArgumentNullException(nameof(entries));
+        CallerName = callerName;
+        JwtResponseWasRequested = jwtResponseWasRequested;
     }
 }
 
-internal class IntrospectionHttpWriter : IHttpResponseWriter<IntrospectionResult>
+internal class IntrospectionHttpWriter(IIssuerNameService issuerNameService, ITokenCreationService tokenCreationService)
+    : IHttpResponseWriter<IntrospectionResult>
 {
-    public Task WriteHttpResponse(IntrospectionResult result, HttpContext context)
+    public async Task WriteHttpResponse(IntrospectionResult result, HttpContext context)
     {
         context.Response.SetNoCache();
 
-        return context.Response.WriteJsonAsync(result.Entries);
+        if (result.JwtResponseWasRequested)
+        {
+            context.Response.Headers.ContentType = $"application/{IdentityServerConstants.TokenTypes.IntrospectionResponseToken}";
+            var token = new Token
+            {
+                Type = IdentityServerConstants.TokenTypes.IntrospectionResponseToken,
+                Issuer = await issuerNameService.GetCurrentAsync(),
+                Audiences = [result.CallerName],
+                CreationTime = DateTime.UtcNow,
+                Claims = [new Claim("token_introspection", ObjectSerializer.ToString(result.Entries), IdentityServerConstants.ClaimValueTypes.Json)]
+            };
+            var jwt = await tokenCreationService.CreateTokenAsync(token);
+
+            await context.Response.WriteAsync(jwt);
+        }
+        else
+        {
+            await context.Response.WriteJsonAsync(result.Entries);
+        }
     }
 }

--- a/identity-server/src/IdentityServer/Extensions/TokenExtensions.cs
+++ b/identity-server/src/IdentityServer/Extensions/TokenExtensions.cs
@@ -111,6 +111,13 @@ public static class TokenExtensions
                 }
             }
 
+            if (token.Type == IdentityServerConstants.TokenTypes.IntrospectionResponseToken)
+            {
+                payload.Remove(JwtClaimTypes.Expiration);
+                payload.Remove(JwtClaimTypes.NotBefore);
+                payload.Remove(JwtClaimTypes.Subject);
+            }
+
             return payload;
         }
         catch (Exception ex)

--- a/identity-server/src/IdentityServer/IdentityServerConstants.cs
+++ b/identity-server/src/IdentityServer/IdentityServerConstants.cs
@@ -56,6 +56,7 @@ public static class IdentityServerConstants
         public const string IdentityToken = "id_token";
         public const string AccessToken = "access_token";
         public const string LogoutToken = "logout_token";
+        public const string IntrospectionResponseToken = "token-introspection+jwt";
     }
 
     public static class ClaimValueTypes

--- a/identity-server/src/IdentityServer/Services/Default/DefaultTokenCreationService.cs
+++ b/identity-server/src/IdentityServer/Services/Default/DefaultTokenCreationService.cs
@@ -106,6 +106,10 @@ public class DefaultTokenCreationService : ITokenCreationService
                 additionalHeaderElements.Add("typ", Options.LogoutTokenJwtType);
             }
         }
+        else if (token.Type == IdentityServerConstants.TokenTypes.IntrospectionResponseToken)
+        {
+            additionalHeaderElements.Add("typ", "token-introspection+jwt");
+        }
 
         return Task.FromResult(additionalHeaderElements);
     }


### PR DESCRIPTION
**What issue does this PR address?**
Updates the token introspection endpoint to support the behavior for returning the response as a JWT as defined in [RFC 9701](https://www.rfc-editor.org/rfc/rfc9701.html)


**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
