### PR TITLE
Include PAR in mtls aliases

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
 		<PackageVersion Include="Duende.AccessTokenManagement" Version="3.2.0" />
 		<PackageVersion Include="Duende.AccessTokenManagement.OpenIdConnect" Version="3.2.0" />
 		<PackageVersion Include="Duende.AspNetCore.Authentication.JwtBearer" Version="0.1.3" />
-		<PackageVersion Include="Duende.IdentityModel" Version="7.0.0" />
+		<PackageVersion Include="Duende.IdentityModel" Version="7.1.0-preview.1" />
 		<PackageVersion Include="Duende.IdentityModel.OidcClient" Version="6.0.1" />
 		<PackageVersion Include="Duende.IdentityServer" Version="7.1.0" />
 		<PackageVersion Include="IdentityModel.AspNetCore.OAuth2Introspection" Version="6.2.0" />

--- a/identity-server/clients/src/ConsolePrivateKeyJwtClient/Program.cs
+++ b/identity-server/clients/src/ConsolePrivateKeyJwtClient/Program.cs
@@ -133,7 +133,7 @@ static string CreateClientToken(SigningCredentials credential, string clientId, 
         [
             new Claim(JwtClaimTypes.JwtId, Guid.NewGuid().ToString()),
             new Claim(JwtClaimTypes.Subject, clientId),
-            new Claim(JwtClaimTypes.IssuedAt, now.ToEpochTime().ToString(), ClaimValueTypes.Integer64)
+            new Claim(JwtClaimTypes.IssuedAt, ((DateTimeOffset) now).ToUnixTimeSeconds().ToString(), ClaimValueTypes.Integer64)
         ],
         now,
         now.AddMinutes(1),

--- a/identity-server/clients/src/MvcJarJwt/AssertionService.cs
+++ b/identity-server/clients/src/MvcJarJwt/AssertionService.cs
@@ -38,7 +38,7 @@ public class AssertionService(IConfiguration configuration)
             {
                 new Claim(JwtClaimTypes.JwtId, Guid.NewGuid().ToString()),
                 new Claim(JwtClaimTypes.Subject, "mvc.jar.jwt"),
-                new Claim(JwtClaimTypes.IssuedAt, now.ToEpochTime().ToString(), ClaimValueTypes.Integer64)
+                new Claim(JwtClaimTypes.IssuedAt, ((DateTimeOffset) now).ToUnixTimeSeconds().ToString(), ClaimValueTypes.Integer64)
             },
             now,
             now.AddMinutes(1),

--- a/identity-server/clients/src/MvcJarUriJwt/AssertionService.cs
+++ b/identity-server/clients/src/MvcJarUriJwt/AssertionService.cs
@@ -38,7 +38,7 @@ public class AssertionService(IConfiguration configuration)
             {
                 new Claim(JwtClaimTypes.JwtId, Guid.NewGuid().ToString()),
                 new Claim(JwtClaimTypes.Subject, "mvc.jar.jwt"),
-                new Claim(JwtClaimTypes.IssuedAt, now.ToEpochTime().ToString(), ClaimValueTypes.Integer64)
+                new Claim(JwtClaimTypes.IssuedAt, ((DateTimeOffset) now).ToUnixTimeSeconds().ToString(), ClaimValueTypes.Integer64)
             },
             now,
             now.AddMinutes(1),

--- a/identity-server/src/IdentityServer/ResponseHandling/Default/DiscoveryResponseGenerator.cs
+++ b/identity-server/src/IdentityServer/ResponseHandling/Default/DiscoveryResponseGenerator.cs
@@ -184,6 +184,11 @@ public class DiscoveryResponseGenerator : IDiscoveryResponseGenerator
                     mtlsEndpoints.Add(OidcConstants.Discovery.DeviceAuthorizationEndpoint, ConstructMtlsEndpoint(ProtocolRoutePaths.DeviceAuthorization));
                 }
 
+                if (Options.Endpoints.EnablePushedAuthorizationEndpoint)
+                {
+                    mtlsEndpoints.Add(OidcConstants.Discovery.PushedAuthorizationRequestEndpoint, ConstructMtlsEndpoint(ProtocolRoutePaths.PushedAuthorization));
+                }
+
                 if (mtlsEndpoints.Any())
                 {
                     entries.Add(OidcConstants.Discovery.MtlsEndpointAliases, mtlsEndpoints);

--- a/identity-server/src/IdentityServer/Validation/Default/IntrospectionRequestValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/Default/IntrospectionRequestValidator.cs
@@ -185,7 +185,7 @@ internal class IntrospectionRequestValidator : IIntrospectionRequestValidator
         var refreshValidationResult = await _refreshTokenService.ValidateRefreshTokenAsync(token, client);
         if (!refreshValidationResult.IsError)
         {
-            var iat = refreshValidationResult.RefreshToken.CreationTime.ToEpochTime();
+            var iat = ((DateTimeOffset)refreshValidationResult.RefreshToken.CreationTime).ToUnixTimeSeconds();
             var claims = new List<Claim>
             {
                 new Claim("client_id", client.ClientId),

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Discovery/DiscoveryEndpointTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Discovery/DiscoveryEndpointTests.cs
@@ -318,4 +318,18 @@ public class DiscoveryEndpointTests
         Should.Throw<InvalidOperationException>(() =>
             result.Entries.Add("Joe", "Good Stuff"));
     }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task par_is_included_in_mtls_aliases()
+    {
+        var pipeline = new IdentityServerPipeline();
+        pipeline.Initialize();
+
+        pipeline.Options.MutualTls.Enabled = true;
+
+
+        var result = await pipeline.BackChannelClient.GetDiscoveryDocumentAsync("https://server/.well-known/openid-configuration");
+        result.MtlsEndpointAliases.PushedAuthorizationRequestEndpoint.ShouldNotBeNull();
+    }
 }


### PR DESCRIPTION
Adds the PAR endpoint to the discovery doc's mTLS aliases.