### PR TITLE
example on how to request the email claim

### DIFF
--- a/bff/hosts/Hosts.Bff.InMemory/Extensions.cs
+++ b/bff/hosts/Hosts.Bff.InMemory/Extensions.cs
@@ -76,6 +76,9 @@ internal static class Extensions
                 options.Scope.Add("scope-for-isolated-api");
                 options.Scope.Add("offline_access");
 
+                // 4. The client needs to request the email claim. 
+                options.Scope.Add("email");
+
                 options.Resource = "urn:isolated-api";
             });
         services.AddTransient<ImpersonationAccessTokenRetriever>();

--- a/bff/hosts/Hosts.Bff.InMemory/LocalApiController.cs
+++ b/bff/hosts/Hosts.Bff.InMemory/LocalApiController.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
+using System.IdentityModel.Tokens.Jwt;
 using System.Text.Json;
+using Duende.AccessTokenManagement.OpenIdConnect;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Host8;
@@ -14,12 +16,23 @@ public class LocalApiController : ControllerBase
 
     [Route("self-contained")]
     [HttpGet]
-    public IActionResult SelfContained()
+    public async Task<IActionResult> SelfContained()
     {
+        var ms = HttpContext.RequestServices.GetRequiredService<IUserTokenManagementService>();
+        var token = await ms.GetAccessTokenAsync(User, new UserTokenRequestParameters()
+        {
+
+        });
+
+        var jwt = new JwtSecurityToken(token.AccessToken);
+
         var data = new
         {
             Message = "Hello from self-contained local API",
-            User = User!.FindFirst("name")?.Value ?? User!.FindFirst("sub")!.Value
+            User = User!.FindFirst("name")?.Value ?? User!.FindFirst("sub")!.Value,
+            Email = User.FindFirst("email")?.Value,
+            Token = token,
+            EmailFromToken = jwt.Claims.FirstOrDefault(x => x.Type == "email")?.Value
         };
 
         return Ok(data);

--- a/bff/hosts/Hosts.IdentityServer/Config.cs
+++ b/bff/hosts/Hosts.IdentityServer/Config.cs
@@ -12,11 +12,18 @@ public static class Config
     [
         new IdentityResources.OpenId(),
         new IdentityResources.Profile(),
+
+        // 1. The email resource must be added to the system. 
+        // This maps the email scope to the email claim. 
+        new IdentityResources.Email()
     ];
 
     public static IEnumerable<ApiScope> ApiScopes =>
     [
-        new("api", ["name"]),
+        // 3. The API scope, requested by the BFF needs to also require the email claim. 
+        // Basically, you're telling that, if you want to call this api, it also needs the email claim
+        new("api", ["name", "email"]),
+
         new("scope-for-isolated-api", ["name"]),
     ];
 

--- a/bff/hosts/Hosts.IdentityServer/ServiceDiscoveringClientStore.cs
+++ b/bff/hosts/Hosts.IdentityServer/ServiceDiscoveringClientStore.cs
@@ -56,7 +56,9 @@ public class ServiceDiscoveringClientStore(ServiceEndpointResolver resolver) : I
                     PostLogoutRedirectUris = { $"{bffUrl}signout-callback-oidc" },
 
                     AllowOfflineAccess = true,
-                    AllowedScopes = { "openid", "profile", "api", "scope-for-isolated-api" },
+
+                    // 2. The client needs to be allowed to request the email scope (which maps to the email claim)
+                    AllowedScopes = { "openid", "profile", "api", "scope-for-isolated-api", "email" },
 
                     RefreshTokenExpiration = TokenExpiration.Absolute,
                     AbsoluteRefreshTokenLifetime = 60,


### PR DESCRIPTION
This PR shows an example on how to get the email claim in the access token to a remote api. (Will be closed without merging soon)

To see in action:

a. Start the 'Hosts.AppHost' aspire project.
b. Navigate to the Bff.InMemory project (https://localhost:5002). 
c. Log in (bob/bob)
d. Call the self-contained api
e. Observe that the access token AND the user both contain the email claim. 

If you omit adding the userclaim to the api scope (step 3 in the code changes), then you'll have the email in the User, but not in the access token. 

You can also call the remote api, and use jwt.io to parse the access token and observe the same. 