### PR TITLE
Make DPoP authorization scheme case-insensitive

### DIFF
--- a/aspnetcore-authentication-jwtbearer/src/AspNetCore.Authentication.JwtBearer/DPoP/DPoPJwtBearerEvents.cs
+++ b/aspnetcore-authentication-jwtbearer/src/AspNetCore.Authentication.JwtBearer/DPoP/DPoPJwtBearerEvents.cs
@@ -119,7 +119,7 @@ public class DPoPJwtBearerEvents : JwtBearerEvents
     protected static bool IsDPoPAuthorizationScheme(HttpRequest request)
     {
         var authz = request.Headers.Authorization.FirstOrDefault();
-        return authz?.StartsWith(DPoPPrefix, StringComparison.Ordinal) == true;
+        return authz?.StartsWith(DPoPPrefix, StringComparison.OrdinalIgnoreCase) == true;
     }
 
     /// <summary>
@@ -137,7 +137,7 @@ public class DPoPJwtBearerEvents : JwtBearerEvents
             _logger.LogInformation("DPoP proof rejected because it exceeded ProofTokenMaxLength.");
             return false;
         }
-        if (authz?.StartsWith(DPoPPrefix, StringComparison.Ordinal) == true)
+        if (authz?.StartsWith(DPoPPrefix, StringComparison.OrdinalIgnoreCase) == true)
         {
             token = authz[DPoPPrefix.Length..].Trim();
             return true;

--- a/aspnetcore-authentication-jwtbearer/test/AspNetCore.Authentication.JwtBearer.Tests/DPoPIntegrationTests.cs
+++ b/aspnetcore-authentication-jwtbearer/test/AspNetCore.Authentication.JwtBearer.Tests/DPoPIntegrationTests.cs
@@ -57,9 +57,13 @@ public class DPoPIntegrationTests(ITestOutputHelper testOutputHelper)
         result.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
     }
 
-    [Fact]
+    [Theory]
+    [InlineData("DPOP")] // upper
+    [InlineData("dpop")] // lower
+    [InlineData("DPoP")] // mixed, but normal
+    [InlineData("dpOP")] // nonsense
     [Trait("Category", "Integration")]
-    public async Task valid_token_and_proof_succeeds()
+    public async Task valid_token_and_proof_succeeds_with_case_insensitive_http_header_authentication_scheme(string scheme)
     {
         var identityServer = await CreateIdentityServer();
         identityServer.Clients.Add(DPoPOnlyClient);
@@ -77,7 +81,7 @@ public class DPoPIntegrationTests(ITestOutputHelper testOutputHelper)
         token.ShouldNotBeNull();
         token.AccessToken.ShouldNotBeNull();
         token.DPoPJsonWebKey.ShouldNotBeNull();
-        api.HttpClient.SetToken(OidcConstants.AuthenticationSchemes.AuthorizationHeaderDPoP, token.AccessToken);
+        api.HttpClient.SetToken(scheme, token.AccessToken);
 
         // Create proof token for api call
         var dpopService =


### PR DESCRIPTION
As per https://www.rfc-editor.org/rfc/rfc9110#name-authentication-scheme the authentication scheme name must be treated as case insensitive.