### PR TITLE
Support binding of authorization codes to dpop proof key via dpop header

### DIFF
--- a/identity-server/src/IdentityServer/Endpoints/PushedAuthorizationEndpoint.cs
+++ b/identity-server/src/IdentityServer/Endpoints/PushedAuthorizationEndpoint.cs
@@ -101,7 +101,7 @@ internal class PushedAuthorizationEndpoint : IEndpointHandler
         }
 
         // This "can't happen", because PAR validation results don't have a constructor that
-        // allows you to create a successful result with a validated request, but static analysis
+        // allows you to create a successful result without a validated request, but static analysis
         // doesn't know that.
         if (parValidationResult.ValidatedRequest is null)
         {

--- a/identity-server/src/IdentityServer/Endpoints/PushedAuthorizationEndpoint.cs
+++ b/identity-server/src/IdentityServer/Endpoints/PushedAuthorizationEndpoint.cs
@@ -142,11 +142,11 @@ internal class PushedAuthorizationEndpoint : IEndpointHandler
             _logger.LogInformation("{@validationDetails}", details);
         }
 
-        //INFO: this is expected case in the normal DPoP flow and is not a real failure event.
-        //Keeping a debug log to help with troubleshooting in the case of a buggy client.
+        // Note: this is an expected case in the normal DPoP flow and is not a real failure event.
+        // Keeping a debug log to help with troubleshooting in the case of a buggy client.
         if (serverNonce != null)
         {
-            _logger.LogDebug("Token request validation failed with: {tokenFailureReason}", OidcConstants.TokenErrors.UseDPoPNonce);
+            _logger.LogDebug("Pushed authorization request returned an error with a server issued nonce. This is an expected event when using DPoP server nonces.");
         }
         else
         {

--- a/identity-server/src/IdentityServer/Endpoints/Results/PushedAuthorizationErrorResult.cs
+++ b/identity-server/src/IdentityServer/Endpoints/Results/PushedAuthorizationErrorResult.cs
@@ -3,6 +3,7 @@
 
 
 using System.Net;
+using Duende.IdentityModel;
 using Duende.IdentityServer.Extensions;
 using Duende.IdentityServer.Hosting;
 using Duende.IdentityServer.ResponseHandling;
@@ -34,6 +35,12 @@ internal class PushedAuthorizationErrorHttpWriter : IHttpResponseWriter<PushedAu
     {
         context.Response.SetNoCache();
         context.Response.StatusCode = (int)HttpStatusCode.BadRequest;
+
+        if (result.Response.DPoPNonce.IsPresent())
+        {
+            context.Response.Headers.Append(OidcConstants.HttpHeaders.DPoPNonce, result.Response.DPoPNonce);
+        }
+
         var dto = new ResultDto
         {
             error = result.Response.Error,

--- a/identity-server/src/IdentityServer/Endpoints/TokenEndpoint.cs
+++ b/identity-server/src/IdentityServer/Endpoints/TokenEndpoint.cs
@@ -116,11 +116,11 @@ internal class TokenEndpoint : IEndpointHandler
         var requestResult = await _requestValidator.ValidateRequestAsync(requestContext);
         if (requestResult.IsError)
         {
-            //INFO: this is expected case in the normal DPoP flow and is not a real failure event.
-            //Keeping a debug log to help with troubleshooting in the case of a buggy client.
+            // Note: this is an expected case in the normal DPoP flow and is not a real failure event.
+            // Keeping a debug log to help with troubleshooting in the case of a buggy client.
             if (requestResult.Error == OidcConstants.TokenErrors.UseDPoPNonce)
             {
-                _logger.LogDebug("Token request validation failed with: {tokenFailureReason}", OidcConstants.TokenErrors.UseDPoPNonce);
+                _logger.LogDebug("Token request returned an error with a server issued nonce. This is an expected event when using DPoP server nonces.");
             }
             else
             {

--- a/identity-server/src/IdentityServer/ResponseHandling/Models/PushedAuthorizationResponse.cs
+++ b/identity-server/src/IdentityServer/ResponseHandling/Models/PushedAuthorizationResponse.cs
@@ -26,6 +26,11 @@ public class PushedAuthorizationFailure : PushedAuthorizationResponse
     /// understanding the error that occurred."
     /// </summary>
     public required string ErrorDescription { get; set; }
+
+    /// <summary>
+    /// The DPoP nonce header to emit, or null if no nonce is to be emitted.
+    /// </summary>
+    public string DPoPNonce { get; set; }
 }
 
 /// <summary>

--- a/identity-server/src/IdentityServer/Validation/Contexts/PushedAuthorizationRequestValidationContext.cs
+++ b/identity-server/src/IdentityServer/Validation/Contexts/PushedAuthorizationRequestValidationContext.cs
@@ -22,6 +22,7 @@ public class PushedAuthorizationRequestValidationContext
         RequestParameters = requestParameters;
         Client = client;
     }
+
     /// <summary>
     /// The request form parameters
     /// </summary>
@@ -31,4 +32,9 @@ public class PushedAuthorizationRequestValidationContext
     /// The validation result of client authentication
     /// </summary>
     public Client Client { get; set; }
+
+    /// <summary>
+    /// The DPoP proof token sent to the endpoint, if any
+    /// </summary>
+    public string DPoPProofToken { get; set; }
 }

--- a/identity-server/src/IdentityServer/Validation/Default/AuthorizeRequestValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/Default/AuthorizeRequestValidator.cs
@@ -783,21 +783,32 @@ internal class AuthorizeRequestValidator : IAuthorizeRequestValidator
         //////////////////////////////////////////////////////////
         // DPoP
         //////////////////////////////////////////////////////////
+        if (!ValidateDpopThumprint(request))
+        {
+            return Invalid(request, description: "Invalid dpop_jwt");
+        }
+
+        return Valid(request);
+    }
+
+
+    private bool ValidateDpopThumprint(ValidatedAuthorizeRequest request)
+    {
         var dpop_jkt = request.Raw.Get(OidcConstants.AuthorizeRequest.DPoPKeyThumbprint);
         if (dpop_jkt.IsPresent())
         {
             if (dpop_jkt.Length > _options.InputLengthRestrictions.DPoPKeyThumbprint)
             {
                 LogError("dpop_jwt value too long", request);
-                return Invalid(request, description: "Invalid dpop_jwt");
+                return false;
             }
 
             request.DPoPKeyThumbprint = dpop_jkt;
         }
 
-        return Valid(request);
+        return true;
     }
-
+    
     private AuthorizeRequestValidationResult Invalid(ValidatedAuthorizeRequest request, string error = OidcConstants.AuthorizeErrors.InvalidRequest, string description = null) => new AuthorizeRequestValidationResult(request, error, description);
 
     private AuthorizeRequestValidationResult Valid(ValidatedAuthorizeRequest request) => new AuthorizeRequestValidationResult(request);

--- a/identity-server/src/IdentityServer/Validation/Default/AuthorizeRequestValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/Default/AuthorizeRequestValidator.cs
@@ -783,16 +783,16 @@ internal class AuthorizeRequestValidator : IAuthorizeRequestValidator
         //////////////////////////////////////////////////////////
         // DPoP
         //////////////////////////////////////////////////////////
-        var dpop_jwt = request.Raw.Get(OidcConstants.AuthorizeRequest.DPoPKeyThumbprint);
-        if (dpop_jwt.IsPresent())
+        var dpop_jkt = request.Raw.Get(OidcConstants.AuthorizeRequest.DPoPKeyThumbprint);
+        if (dpop_jkt.IsPresent())
         {
-            if (dpop_jwt.Length > _options.InputLengthRestrictions.DPoPKeyThumbprint)
+            if (dpop_jkt.Length > _options.InputLengthRestrictions.DPoPKeyThumbprint)
             {
                 LogError("dpop_jwt value too long", request);
                 return Invalid(request, description: "Invalid dpop_jwt");
             }
 
-            request.DPoPKeyThumbprint = dpop_jwt;
+            request.DPoPKeyThumbprint = dpop_jkt;
         }
 
         return Valid(request);

--- a/identity-server/src/IdentityServer/Validation/Default/AuthorizeRequestValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/Default/AuthorizeRequestValidator.cs
@@ -783,16 +783,16 @@ internal class AuthorizeRequestValidator : IAuthorizeRequestValidator
         //////////////////////////////////////////////////////////
         // DPoP
         //////////////////////////////////////////////////////////
-        if (!ValidateDpopThumprint(request))
+        if (!ValidateDpopThumbprint(request))
         {
-            return Invalid(request, description: "Invalid dpop_jwt");
+            return Invalid(request, description: "Invalid dpop_jkt");
         }
 
         return Valid(request);
     }
 
 
-    private bool ValidateDpopThumprint(ValidatedAuthorizeRequest request)
+    private bool ValidateDpopThumbprint(ValidatedAuthorizeRequest request)
     {
         var dpop_jkt = request.Raw.Get(OidcConstants.AuthorizeRequest.DPoPKeyThumbprint);
         if (dpop_jkt.IsPresent())
@@ -808,7 +808,7 @@ internal class AuthorizeRequestValidator : IAuthorizeRequestValidator
 
         return true;
     }
-    
+
     private AuthorizeRequestValidationResult Invalid(ValidatedAuthorizeRequest request, string error = OidcConstants.AuthorizeErrors.InvalidRequest, string description = null) => new AuthorizeRequestValidationResult(request, error, description);
 
     private AuthorizeRequestValidationResult Valid(ValidatedAuthorizeRequest request) => new AuthorizeRequestValidationResult(request);

--- a/identity-server/src/IdentityServer/Validation/Default/DefaultDPoPProofValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/Default/DefaultDPoPProofValidator.cs
@@ -470,6 +470,7 @@ public class DefaultDPoPProofValidator : IDPoPProofValidator
             Logger.LogDebug("Invalid time value read from the 'nonce' value");
 
             result.IsError = true;
+            result.Error = OidcConstants.TokenErrors.UseDPoPNonce;
             result.ErrorDescription = "Invalid 'nonce' value.";
             result.ServerIssuedNonce = CreateNonce(context, result);
             return;
@@ -480,6 +481,7 @@ public class DefaultDPoPProofValidator : IDPoPProofValidator
             Logger.LogDebug("DPoP 'nonce' expiration failed. It's possible that the server farm clocks might not be closely synchronized, so consider setting the ServerClockSkew on the DPoPOptions on the IdentityServerOptions.");
 
             result.IsError = true;
+            result.Error = OidcConstants.TokenErrors.UseDPoPNonce;
             result.ErrorDescription = "Invalid 'nonce' value.";
             result.ServerIssuedNonce = CreateNonce(context, result);
             return;

--- a/identity-server/src/IdentityServer/Validation/Default/PushedAuthorizationRequestValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/Default/PushedAuthorizationRequestValidator.cs
@@ -5,8 +5,12 @@
 #nullable enable
 
 using Duende.IdentityModel;
+using Duende.IdentityServer.Configuration;
 using Duende.IdentityServer.Extensions;
 using Duende.IdentityServer.Licensing.V2;
+using Duende.IdentityServer.Services;
+using Microsoft.Extensions.Logging;
+using static Duende.IdentityServer.IdentityServerConstants;
 
 namespace Duende.IdentityServer.Validation;
 
@@ -16,38 +20,111 @@ namespace Duende.IdentityServer.Validation;
 /// cref="IAuthorizeRequestValidator"/> to validate the pushed parameters as if
 /// they had been sent to the authorize endpoint directly. 
 /// </summary>
-internal class PushedAuthorizationRequestValidator : IPushedAuthorizationRequestValidator
+/// <remarks>
+/// Initializes a new instance of the <see
+/// cref="PushedAuthorizationRequestValidator"/> class. 
+/// </remarks>
+/// <param name="authorizeRequestValidator">The authorize request validator,
+/// used to validate the pushed authorization parameters as if they were
+/// used directly at the authorize endpoint.</param>
+/// <param name="dpopProofValidator">The dpop proof validator, used to
+/// validate DPoP proofs that are sent to bind authorization codes
+/// to a proof key.</param>
+/// <param name="serverUrls">The server urls service</param>
+/// <param name="licenseUsage">The feature manager</param>
+/// <param name="options">The IdentityServer Options</param>
+/// <param name="logger">The logger</param>
+internal class PushedAuthorizationRequestValidator(
+    IAuthorizeRequestValidator authorizeRequestValidator,
+    IDPoPProofValidator dpopProofValidator,
+    IServerUrls serverUrls,
+    LicenseUsageTracker licenseUsage,
+    IdentityServerOptions options,
+    ILogger<PushedAuthorizationRequestValidator> logger) : IPushedAuthorizationRequestValidator
 {
-
-    private readonly LicenseUsageTracker _features;
-    private readonly IAuthorizeRequestValidator _authorizeRequestValidator;
-
-    /// <summary>
-    /// Initializes a new instance of the <see
-    /// cref="PushedAuthorizationRequestValidator"/> class. 
-    /// </summary>
-    /// <param name="authorizeRequestValidator">The authorize request validator,
-    /// used to validate the pushed authorization parameters as if they were
-    /// used directly at the authorize endpoint.</param>
-    /// <param name="features">The feature manager</param>
-    public PushedAuthorizationRequestValidator(IAuthorizeRequestValidator authorizeRequestValidator, LicenseUsageTracker features)
-    {
-        _authorizeRequestValidator = authorizeRequestValidator;
-        _features = features;
-    }
-
-    /// <inheritdoc />
     public async Task<PushedAuthorizationValidationResult> ValidateAsync(PushedAuthorizationRequestValidationContext context)
     {
-        _features.FeatureUsed(LicenseFeature.PAR);
+        // Licensing
+        licenseUsage.FeatureUsed(LicenseFeature.PAR);
         IdentityServerLicenseValidator.Instance.ValidatePar();
+
+        // -- Request URI validation --
         var validatedRequest = await ValidateRequestUriAsync(context);
         if (validatedRequest.IsError)
         {
             return validatedRequest;
         }
 
-        var authorizeRequestValidation = await _authorizeRequestValidator.ValidateAsync(context.RequestParameters,
+        // -- DPoP Header Validation --
+        // The client can send the public key of its DPoP proof key to us. We
+        // then bind its authorization code to the proof key and check for a 
+        // proof token signed with the key at the token endpoint.
+        //  
+        // There are two ways for the client to send its DPoP proof key public 
+        // key material to us:
+        // 1. pass the dpop_jkt parameter with a JWK thumbprint (RFC 7638)
+        // 2. send a DPoP proof (which contains the public key as a JWK) in the 
+        //    DPoP http header
+        //
+        // If a proof is passed, then we validate it, compute the thumbprint of 
+        // the key within, and treat that as if it were passed as the dpop_jkt 
+        // parameter.
+        //
+        // If a proof and a dpop_jkt are both passed, its an error if they don't
+        // agree.
+        if (context.DPoPProofToken.IsPresent())
+        {
+            // bail out if unreasonably large
+            if (context.DPoPProofToken.Length > options.InputLengthRestrictions.DPoPProofToken)
+            {
+                logger.LogError("DPoP proof token is too long");
+                return new PushedAuthorizationValidationResult(
+                    "invalid_dpop_proof",
+                    "DPoP proof token is too long");
+            }
+
+            // validate proof token
+            var parUrl = serverUrls.BaseUrl.EnsureTrailingSlash() + ProtocolRoutePaths.PushedAuthorization;
+            var dpopContext = new DPoPProofValidatonContext
+            {
+                ProofToken = context.DPoPProofToken,
+                ExpirationValidationMode = context.Client.DPoPValidationMode,
+                ClientClockSkew = context.Client.DPoPClockSkew,
+                ValidateAccessToken = false,
+                Method = "POST",
+                Url = parUrl
+            };
+            var dpopValidationResult = await dpopProofValidator.ValidateAsync(dpopContext);
+            if (dpopValidationResult.Error != null)
+            {
+                return new PushedAuthorizationValidationResult(
+                    dpopValidationResult.Error,
+                    dpopValidationResult.ErrorDescription ?? "Invalid DPoP Proof");
+            }
+
+            // if dpop_jkt was also passed, make sure they are consistent
+            var dpopThumbprintParameter = context.RequestParameters.Get(OidcConstants.AuthorizeRequest.DPoPKeyThumbprint);
+            if (dpopThumbprintParameter != null)
+            {
+                if (dpopThumbprintParameter != dpopValidationResult.JsonWebKeyThumbprint)
+                {
+                    return new PushedAuthorizationValidationResult(
+                        OidcConstants.AuthorizeErrors.InvalidRequest,
+                        "Mismatch between thumbprint of JWK in DPoP HTTP header and dpop_jkt parameter");
+                }
+                // dpop_jkt and dpop header match, and the request parameters already include dpop_jkt,
+                // so the code will be bound to the client's key without us doing anything more.
+            }
+            else
+            {
+                // Since dpop_jkt wasn't passed, copy the thumbprint we derived from the proof token
+                // into the request parameters so that the auth code will be bound to it.
+                context.RequestParameters.Add(OidcConstants.AuthorizeRequest.DPoPKeyThumbprint, dpopValidationResult.JsonWebKeyThumbprint);
+            }
+        }
+
+        // -- Authorization Parameter Validation --
+        var authorizeRequestValidation = await authorizeRequestValidator.ValidateAsync(context.RequestParameters,
             authorizeRequestType: AuthorizeRequestType.PushedAuthorization);
         if (authorizeRequestValidation.IsError)
         {

--- a/identity-server/src/IdentityServer/Validation/Default/PushedAuthorizationRequestValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/Default/PushedAuthorizationRequestValidator.cs
@@ -95,6 +95,11 @@ internal class PushedAuthorizationRequestValidator(
                 Url = parUrl
             };
             var dpopValidationResult = await dpopProofValidator.ValidateAsync(dpopContext);
+            if (dpopValidationResult.ServerIssuedNonce != null)
+            {
+                return PushedAuthorizationValidationResult.CreateServerNonceResult(dpopValidationResult.ServerIssuedNonce);
+            }
+
             if (dpopValidationResult.Error != null)
             {
                 return new PushedAuthorizationValidationResult(

--- a/identity-server/src/IdentityServer/Validation/Models/PushedAuthorizationValidationResult.cs
+++ b/identity-server/src/IdentityServer/Validation/Models/PushedAuthorizationValidationResult.cs
@@ -74,7 +74,7 @@ public class PushedAuthorizationValidationResult : ValidationResult
     }
 
     public static PushedAuthorizationValidationResult CreateServerNonceResult(string nonce) =>
-        new(OidcConstants.TokenErrors.UseDPoPNonce, null)
+        new(OidcConstants.TokenErrors.UseDPoPNonce, "")
         {
             ServerIssuedNonce = nonce
         };

--- a/identity-server/src/IdentityServer/Validation/Models/PushedAuthorizationValidationResult.cs
+++ b/identity-server/src/IdentityServer/Validation/Models/PushedAuthorizationValidationResult.cs
@@ -4,6 +4,8 @@
 
 #nullable enable
 
+using Duende.IdentityModel;
+
 namespace Duende.IdentityServer.Validation;
 
 /// <summary>
@@ -71,6 +73,13 @@ public class PushedAuthorizationValidationResult : ValidationResult
         PartiallyValidatedAuthorizeRequest = authorizeRequest;
     }
 
+    public static PushedAuthorizationValidationResult CreateServerNonceResult(string nonce) =>
+        new(OidcConstants.TokenErrors.UseDPoPNonce, null)
+        {
+            ServerIssuedNonce = nonce
+        };
+
+
     /// <summary>
     /// The validated pushed authorization request, or null if a validation error occurred. 
     /// </summary>
@@ -88,4 +97,6 @@ public class PushedAuthorizationValidationResult : ValidationResult
     /// </para>
     /// </summary>
     public ValidatedAuthorizeRequest? PartiallyValidatedAuthorizeRequest { get; set; }
+
+    public string? ServerIssuedNonce { get; set; }
 }

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Authorize/PushedAuthorizationTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Authorize/PushedAuthorizationTests.cs
@@ -230,6 +230,17 @@ public class PushedAuthorizationTests
         authorizeCallbackResponse.Headers.Location!.ToString().ShouldStartWith(expectedCallback);
     }
 
+    [Fact]
+    public async Task multiple_dpop_headers_sent_to_the_par_endpoint_fails()
+    {
+        _mockPipeline.BackChannelClient.DefaultRequestHeaders.Add("DPoP", "first");
+        _mockPipeline.BackChannelClient.DefaultRequestHeaders.Add("DPoP", "second");
+        var (parJson, statusCode) = await _mockPipeline.PushAuthorizationRequestAsync();
+        statusCode.ShouldBe(HttpStatusCode.BadRequest);
+        parJson.RootElement.GetProperty("error").GetString()
+            .ShouldBe(OidcConstants.AuthorizeErrors.InvalidRequest);
+    }
+
     private void ConfigureScopesAndResources()
     {
         _mockPipeline.IdentityScopes.AddRange(new IdentityResource[] {

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Authorize/PushedAuthorizationTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Authorize/PushedAuthorizationTests.cs
@@ -11,7 +11,6 @@ using IntegrationTests.Common;
 
 namespace IntegrationTests.Endpoints.Authorize;
 
-
 public class PushedAuthorizationTests
 {
     private readonly IdentityServerPipeline _mockPipeline = new();
@@ -284,6 +283,4 @@ public class PushedAuthorizationTests
                 RedirectUris = new List<string> { "https://client1/callback" },
             },
         });
-
-
 }

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Authorize/PushedAuthorizationTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Authorize/PushedAuthorizationTests.cs
@@ -230,17 +230,6 @@ public class PushedAuthorizationTests
         authorizeCallbackResponse.Headers.Location!.ToString().ShouldStartWith(expectedCallback);
     }
 
-    [Fact]
-    public async Task multiple_dpop_headers_sent_to_the_par_endpoint_fails()
-    {
-        _mockPipeline.BackChannelClient.DefaultRequestHeaders.Add("DPoP", "first");
-        _mockPipeline.BackChannelClient.DefaultRequestHeaders.Add("DPoP", "second");
-        var (parJson, statusCode) = await _mockPipeline.PushAuthorizationRequestAsync();
-        statusCode.ShouldBe(HttpStatusCode.BadRequest);
-        parJson.RootElement.GetProperty("error").GetString()
-            .ShouldBe(OidcConstants.AuthorizeErrors.InvalidRequest);
-    }
-
     private void ConfigureScopesAndResources()
     {
         _mockPipeline.IdentityScopes.AddRange(new IdentityResource[] {

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Token/DPoPEndpointTestBase.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Token/DPoPEndpointTestBase.cs
@@ -1,0 +1,286 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text.Json;
+using Duende.IdentityModel;
+using Duende.IdentityModel.Client;
+using Duende.IdentityServer.Configuration;
+using Duende.IdentityServer.Models;
+using Duende.IdentityServer.Test;
+using IntegrationTests.Common;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+
+namespace IntegrationTests.Endpoints.Token;
+
+[ShouldlyMethods]
+public static class DPoPAssertions
+{
+    private static string GetJKTFromAccessToken(TokenResponse tokenResponse)
+    {
+        var claims = ParseAccessTokenClaims(tokenResponse);
+        return GetJKTFromCnfClaim(claims);
+    }
+
+    private static IEnumerable<Claim> ParseAccessTokenClaims(TokenResponse tokenResponse)
+    {
+        tokenResponse.IsError.ShouldBeFalse(tokenResponse.Error);
+
+        var handler = new JwtSecurityTokenHandler();
+        var token = handler.ReadJwtToken(tokenResponse.AccessToken);
+        return token.Claims;
+    }
+
+    private static string GetJKTFromCnfClaim(IEnumerable<Claim> claims)
+    {
+        var cnf = claims.SingleOrDefault(x => x.Type == "cnf")?.Value;
+        if (cnf != null)
+        {
+            var json = JsonSerializer.Deserialize<JsonElement>(cnf);
+            return json.GetString("jkt");
+        }
+        return null;
+    }
+
+
+    public static void ShouldHaveDPoPThumbprint(this TokenResponse token, string jkt)
+    {
+        token.IsError.ShouldBeFalse();
+        token.TokenType.ShouldBe(OidcConstants.TokenResponse.DPoPTokenType);
+        GetJKTFromAccessToken(token).ShouldBe(jkt);
+    }
+}
+
+public abstract class DPoPEndpointTestBase
+{
+    protected IdentityServerPipeline Pipeline = new IdentityServerPipeline();
+
+    protected Client ConfidentialClient;
+
+    protected Client PublicClient;
+
+    protected DateTime Now = new DateTime(2020, 3, 10, 9, 0, 0, DateTimeKind.Utc);
+    protected DateTime UtcNow
+    {
+        get
+        {
+            if (Now > DateTime.MinValue) return Now;
+            return DateTime.UtcNow;
+        }
+    }
+
+    protected Dictionary<string, object> Header;
+    protected Dictionary<string, object> Payload;
+    protected string PrivateJWK = "{\"Crv\":null,\"D\":\"QeBWodq0hSYjfAxxo0VZleXLqwwZZeNWvvFfES4WyItao_-OJv1wKA7zfkZxbWkpK5iRbKrl2AMJ52AtUo5JJ6QZ7IjAQlgM0lBg3ltjb1aA0gBsK5XbiXcsV8DiAnRuy6-XgjAKPR8Lo-wZl_fdPbVoAmpSdmfn_6QXXPBai5i7FiyDbQa16pI6DL-5SCj7F78QDTRiJOqn5ElNvtoJEfJBm13giRdqeriFi3pCWo7H3QBgTEWtDNk509z4w4t64B2HTXnM0xj9zLnS42l7YplJC7MRibD4nVBMtzfwtGRKLj8beuDgtW9pDlQqf7RVWX5pHQgiHAZmUi85TEbYdQ\",\"DP\":\"h2F54OMaC9qq1yqR2b55QNNaChyGtvmTHSdqZJ8lJFqvUorlz-Uocj2BTowWQnaMd8zRKMdKlSeUuSv4Z6WmjSxSsNbonI6_II5XlZLWYqFdmqDS-xCmJY32voT5Wn7OwB9xj1msDqrFPg-PqSBOh5OppjCqXqDFcNvSkQSajXc\",\"DQ\":\"VABdS20Nxkmq6JWLQj7OjRxVJuYsHrfmWJmDA7_SYtlXaPUcg-GiHGQtzdDWEeEi0dlJjv9I3FdjKGC7CGwqtVygW38DzVYJsV2EmRNJc1-j-1dRs_pK9GWR4NYm0mVz_IhS8etIf9cfRJk90xU3AL3_J6p5WNF7I5ctkLpnt8M\",\"E\":\"AQAB\",\"K\":null,\"KeyOps\":[],\"Kty\":\"RSA\",\"N\":\"yWWAOSV3Z_BW9rJEFvbZyeU-q2mJWC0l8WiHNqwVVf7qXYgm9hJC0j1aPHku_Wpl38DpK3Xu3LjWOFG9OrCqga5Pzce3DDJKI903GNqz5wphJFqweoBFKOjj1wegymvySsLoPqqDNVYTKp4nVnECZS4axZJoNt2l1S1bC8JryaNze2stjW60QT-mIAGq9konKKN3URQ12dr478m0Oh-4WWOiY4HrXoSOklFmzK-aQx1JV_SZ04eIGfSw1pZZyqTaB1BwBotiy-QA03IRxwIXQ7BSx5EaxC5uMCMbzmbvJqjt-q8Y1wyl-UQjRucgp7hkfHSE1QT3zEex2Q3NFux7SQ\",\"Oth\":null,\"P\":\"_T7MTkeOh5QyqlYCtLQ2RWf2dAJ9i3wrCx4nEDm1c1biijhtVTL7uJTLxwQIM9O2PvOi5Dq-UiGy6rhHZqf5akWTeHtaNyI-2XslQfaS3ctRgmGtRQL_VihK-R9AQtDx4eWL4h-bDJxPaxby_cVo_j2MX5AeoC1kNmcCdDf_X0M\",\"Q\":\"y5ZSThaGLjaPj8Mk2nuD8TiC-sb4aAZVh9K-W4kwaWKfDNoPcNb_dephBNMnOp9M1br6rDbyG7P-Sy_LOOsKg3Q0wHqv4hnzGaOQFeMJH4HkXYdENC7B5JG9PefbC6zwcgZWiBnsxgKpScNWuzGF8x2CC-MdsQ1bkQeTPbJklIM\",\"QI\":\"i716Vt9II_Rt6qnjsEhfE4bej52QFG9a1hSnx5PDNvRrNqR_RpTA0lO9qeXSZYGHTW_b6ZXdh_0EUwRDEDHmaxjkIcTADq6JLuDltOhZuhLUSc5NCKLAVCZlPcaSzv8-bZm57mVcIpx0KyFHxvk50___Jgx1qyzwLX03mPGUbDQ\",\"Use\":null,\"X\":null,\"X5c\":[],\"X5t\":null,\"X5tS256\":null,\"X5u\":null,\"Y\":null,\"KeySize\":2048,\"HasPrivateKey\":true,\"CryptoProviderFactory\":{\"CryptoProviderCache\":{},\"CustomCryptoProvider\":null,\"CacheSignatureProviders\":true,\"SignatureProviderObjectPoolCacheSize\":80}}";
+    protected string PublicJWK = "{\"kty\":\"RSA\",\"use\":\"sig\",\"x5t\":null,\"e\":\"AQAB\",\"n\":\"yWWAOSV3Z_BW9rJEFvbZyeU-q2mJWC0l8WiHNqwVVf7qXYgm9hJC0j1aPHku_Wpl38DpK3Xu3LjWOFG9OrCqga5Pzce3DDJKI903GNqz5wphJFqweoBFKOjj1wegymvySsLoPqqDNVYTKp4nVnECZS4axZJoNt2l1S1bC8JryaNze2stjW60QT-mIAGq9konKKN3URQ12dr478m0Oh-4WWOiY4HrXoSOklFmzK-aQx1JV_SZ04eIGfSw1pZZyqTaB1BwBotiy-QA03IRxwIXQ7BSx5EaxC5uMCMbzmbvJqjt-q8Y1wyl-UQjRucgp7hkfHSE1QT3zEex2Q3NFux7SQ\",\"x5c\":null,\"x\":null,\"y\":null,\"crv\":null}";
+    protected string JKT = "JGSVlE73oKtQQI1dypYg8_JNat0xJjsQNyOI5oxaZf4";
+
+    public DPoPEndpointTestBase()
+    {
+        Pipeline.OnPostConfigureServices += services =>
+        {
+        };
+
+        Pipeline.Clients.AddRange([
+            ConfidentialClient = new Client
+            {
+                ClientId = "client1",
+                AllowedGrantTypes = GrantTypes.CodeAndClientCredentials,
+                ClientSecrets =
+                {
+                    new Secret("secret".Sha256()),
+                },
+                RedirectUris = { "https://client1/callback" },
+                RequirePkce = false,
+                AllowOfflineAccess = true,
+                RefreshTokenUsage = TokenUsage.ReUse,
+                AllowedScopes = new List<string> { "openid", "profile", "scope1" },
+            },
+            PublicClient = new Client
+            {
+                ClientId = "client2",
+                AllowedGrantTypes = GrantTypes.Code,
+                RequireClientSecret = false,
+                RequirePkce = false,
+                RedirectUris = { "https://client2/callback" },
+                AllowOfflineAccess = true,
+                RefreshTokenUsage = TokenUsage.ReUse,
+                AllowedScopes = new List<string> { "openid", "profile", "scope2" },
+            }
+        ]);
+
+        Pipeline.Users.Add(new TestUser
+        {
+            SubjectId = "bob",
+            Username = "bob",
+            Password = "bob",
+            Claims =
+            [
+                new Claim("name", "Bob Loblaw"),
+                new Claim("email", "bob@loblaw.com"),
+                new Claim("role", "Attorney")
+            ]
+        });
+
+        Pipeline.IdentityScopes.AddRange([
+            new IdentityResources.OpenId(),
+            new IdentityResources.Profile(),
+            new IdentityResources.Email()
+        ]);
+        Pipeline.ApiResources.AddRange(
+        [
+            new ApiResource("api1")
+            {
+                Scopes = { "scope1" },
+                ApiSecrets =
+                {
+                    new Secret("secret".Sha256())
+                }
+            },
+            new ApiResource("api2")
+            {
+                Scopes = { "scope2" },
+                ApiSecrets =
+                {
+                    new Secret("secret".Sha256())
+                }
+            }
+        ]);
+        Pipeline.ApiScopes.AddRange([
+            new ApiScope
+            {
+                Name = "scope1"
+            },
+            new ApiScope
+            {
+                Name = "scope2"
+            }
+        ]);
+
+        Pipeline.Initialize();
+
+        Payload = new Dictionary<string, object>
+        {
+            //{ "jti", CryptoRandom.CreateUniqueId() }, // added dynamically below in CreateDPoPProofToken
+            //{ "iat", DateTimeOffset.UtcNow.ToUnixTimeSeconds() }, // added dynamically below in CreateDPoPProofToken
+            { "htm", "POST" },
+            { "htu", IdentityServerPipeline.TokenEndpoint },
+        };
+
+        CreateHeaderValuesFromPublicKey();
+    }
+
+    protected void CreateNewRSAKey()
+    {
+        var key = CryptoHelper.CreateRsaSecurityKey();
+        var jwk = JsonWebKeyConverter.ConvertFromRSASecurityKey(key);
+        JKT = Base64UrlEncoder.Encode(key.ComputeJwkThumbprint());
+        PrivateJWK = JsonSerializer.Serialize(jwk);
+        PublicJWK = JsonSerializer.Serialize(new
+        {
+            kty = jwk.Kty,
+            e = jwk.E,
+            n = jwk.N,
+        });
+
+        CreateHeaderValuesFromPublicKey();
+    }
+
+    protected void CreateNewECKey()
+    {
+        var key = CryptoHelper.CreateECDsaSecurityKey();
+        var jwk = JsonWebKeyConverter.ConvertFromECDsaSecurityKey(key);
+        JKT = Base64UrlEncoder.Encode(key.ComputeJwkThumbprint());
+        PrivateJWK = JsonSerializer.Serialize(jwk);
+        PublicJWK = JsonSerializer.Serialize(new
+        {
+            kty = jwk.Kty,
+            x = jwk.X,
+            y = jwk.Y,
+            crv = jwk.Crv
+        });
+
+        CreateHeaderValuesFromPublicKey();
+    }
+
+    protected void CreateHeaderValuesFromPublicKey(string publicJwk = null)
+    {
+        var jwk = JsonSerializer.Deserialize<JsonElement>(publicJwk ?? PublicJWK);
+        var jwkValues = new Dictionary<string, object>();
+        foreach (var item in jwk.EnumerateObject())
+        {
+            if (item.Value.ValueKind == JsonValueKind.String)
+            {
+                var val = item.Value.GetString();
+                if (!string.IsNullOrEmpty(val))
+                {
+                    jwkValues.Add(item.Name, val);
+                }
+            }
+            if (item.Value.ValueKind == JsonValueKind.False)
+            {
+                jwkValues.Add(item.Name, false);
+            }
+            if (item.Value.ValueKind == JsonValueKind.True)
+            {
+                jwkValues.Add(item.Name, true);
+            }
+            if (item.Value.ValueKind == JsonValueKind.Number)
+            {
+                jwkValues.Add(item.Name, item.Value.GetInt64());
+            }
+        }
+        Header = new Dictionary<string, object>()
+        {
+            //{ "alg", "RS265" }, // JsonWebTokenHandler requires adding this itself
+            { "typ", "dpop+jwt" },
+            { "jwk", jwkValues },
+        };
+    }
+
+    protected string CreateDPoPProofToken(string alg = "RS256", SecurityKey key = null)
+    {
+        var payload = new Dictionary<string, object>(Payload);
+        if (!payload.ContainsKey("jti"))
+        {
+            payload.Add("jti", CryptoRandom.CreateUniqueId());
+        }
+        if (!payload.ContainsKey("iat"))
+        {
+            payload.Add("iat", DateTimeOffset.UtcNow.ToUnixTimeSeconds());
+        }
+
+        key ??= new Microsoft.IdentityModel.Tokens.JsonWebKey(PrivateJWK);
+        var handler = new JsonWebTokenHandler() { SetDefaultTimesOnTokenCreation = false };
+        var token = handler.CreateToken(JsonSerializer.Serialize(payload), new SigningCredentials(key, alg), Header);
+        return token;
+    }
+
+    protected IEnumerable<Claim> ParseAccessTokenClaims(TokenResponse tokenResponse)
+    {
+        tokenResponse.IsError.ShouldBeFalse(tokenResponse.Error);
+
+        var handler = new JwtSecurityTokenHandler();
+        var token = handler.ReadJwtToken(tokenResponse.AccessToken);
+        return token.Claims;
+    }
+    protected string GetJKTFromAccessToken(TokenResponse tokenResponse)
+    {
+        var claims = ParseAccessTokenClaims(tokenResponse);
+        return GetJKTFromCnfClaim(claims);
+    }
+    protected string GetJKTFromCnfClaim(IEnumerable<Claim> claims)
+    {
+        var cnf = claims.SingleOrDefault(x => x.Type == "cnf")?.Value;
+        if (cnf != null)
+        {
+            var json = JsonSerializer.Deserialize<JsonElement>(cnf);
+            return json.GetString("jkt");
+        }
+        return null;
+    }
+}

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Token/DPoPEndpointTestBase.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Token/DPoPEndpointTestBase.cs
@@ -3,6 +3,7 @@
 
 
 using System.IdentityModel.Tokens.Jwt;
+using System.Net;
 using System.Security.Claims;
 using System.Text.Json;
 using Duende.IdentityModel;
@@ -74,9 +75,28 @@ public abstract class DPoPEndpointTestBase
     }
 
     protected Dictionary<string, object> Header;
-    protected Dictionary<string, object> Payload;
-    protected string PrivateJWK = "{\"Crv\":null,\"D\":\"QeBWodq0hSYjfAxxo0VZleXLqwwZZeNWvvFfES4WyItao_-OJv1wKA7zfkZxbWkpK5iRbKrl2AMJ52AtUo5JJ6QZ7IjAQlgM0lBg3ltjb1aA0gBsK5XbiXcsV8DiAnRuy6-XgjAKPR8Lo-wZl_fdPbVoAmpSdmfn_6QXXPBai5i7FiyDbQa16pI6DL-5SCj7F78QDTRiJOqn5ElNvtoJEfJBm13giRdqeriFi3pCWo7H3QBgTEWtDNk509z4w4t64B2HTXnM0xj9zLnS42l7YplJC7MRibD4nVBMtzfwtGRKLj8beuDgtW9pDlQqf7RVWX5pHQgiHAZmUi85TEbYdQ\",\"DP\":\"h2F54OMaC9qq1yqR2b55QNNaChyGtvmTHSdqZJ8lJFqvUorlz-Uocj2BTowWQnaMd8zRKMdKlSeUuSv4Z6WmjSxSsNbonI6_II5XlZLWYqFdmqDS-xCmJY32voT5Wn7OwB9xj1msDqrFPg-PqSBOh5OppjCqXqDFcNvSkQSajXc\",\"DQ\":\"VABdS20Nxkmq6JWLQj7OjRxVJuYsHrfmWJmDA7_SYtlXaPUcg-GiHGQtzdDWEeEi0dlJjv9I3FdjKGC7CGwqtVygW38DzVYJsV2EmRNJc1-j-1dRs_pK9GWR4NYm0mVz_IhS8etIf9cfRJk90xU3AL3_J6p5WNF7I5ctkLpnt8M\",\"E\":\"AQAB\",\"K\":null,\"KeyOps\":[],\"Kty\":\"RSA\",\"N\":\"yWWAOSV3Z_BW9rJEFvbZyeU-q2mJWC0l8WiHNqwVVf7qXYgm9hJC0j1aPHku_Wpl38DpK3Xu3LjWOFG9OrCqga5Pzce3DDJKI903GNqz5wphJFqweoBFKOjj1wegymvySsLoPqqDNVYTKp4nVnECZS4axZJoNt2l1S1bC8JryaNze2stjW60QT-mIAGq9konKKN3URQ12dr478m0Oh-4WWOiY4HrXoSOklFmzK-aQx1JV_SZ04eIGfSw1pZZyqTaB1BwBotiy-QA03IRxwIXQ7BSx5EaxC5uMCMbzmbvJqjt-q8Y1wyl-UQjRucgp7hkfHSE1QT3zEex2Q3NFux7SQ\",\"Oth\":null,\"P\":\"_T7MTkeOh5QyqlYCtLQ2RWf2dAJ9i3wrCx4nEDm1c1biijhtVTL7uJTLxwQIM9O2PvOi5Dq-UiGy6rhHZqf5akWTeHtaNyI-2XslQfaS3ctRgmGtRQL_VihK-R9AQtDx4eWL4h-bDJxPaxby_cVo_j2MX5AeoC1kNmcCdDf_X0M\",\"Q\":\"y5ZSThaGLjaPj8Mk2nuD8TiC-sb4aAZVh9K-W4kwaWKfDNoPcNb_dephBNMnOp9M1br6rDbyG7P-Sy_LOOsKg3Q0wHqv4hnzGaOQFeMJH4HkXYdENC7B5JG9PefbC6zwcgZWiBnsxgKpScNWuzGF8x2CC-MdsQ1bkQeTPbJklIM\",\"QI\":\"i716Vt9II_Rt6qnjsEhfE4bej52QFG9a1hSnx5PDNvRrNqR_RpTA0lO9qeXSZYGHTW_b6ZXdh_0EUwRDEDHmaxjkIcTADq6JLuDltOhZuhLUSc5NCKLAVCZlPcaSzv8-bZm57mVcIpx0KyFHxvk50___Jgx1qyzwLX03mPGUbDQ\",\"Use\":null,\"X\":null,\"X5c\":[],\"X5t\":null,\"X5tS256\":null,\"X5u\":null,\"Y\":null,\"KeySize\":2048,\"HasPrivateKey\":true,\"CryptoProviderFactory\":{\"CryptoProviderCache\":{},\"CustomCryptoProvider\":null,\"CacheSignatureProviders\":true,\"SignatureProviderObjectPoolCacheSize\":80}}";
-    protected string PublicJWK = "{\"kty\":\"RSA\",\"use\":\"sig\",\"x5t\":null,\"e\":\"AQAB\",\"n\":\"yWWAOSV3Z_BW9rJEFvbZyeU-q2mJWC0l8WiHNqwVVf7qXYgm9hJC0j1aPHku_Wpl38DpK3Xu3LjWOFG9OrCqga5Pzce3DDJKI903GNqz5wphJFqweoBFKOjj1wegymvySsLoPqqDNVYTKp4nVnECZS4axZJoNt2l1S1bC8JryaNze2stjW60QT-mIAGq9konKKN3URQ12dr478m0Oh-4WWOiY4HrXoSOklFmzK-aQx1JV_SZ04eIGfSw1pZZyqTaB1BwBotiy-QA03IRxwIXQ7BSx5EaxC5uMCMbzmbvJqjt-q8Y1wyl-UQjRucgp7hkfHSE1QT3zEex2Q3NFux7SQ\",\"x5c\":null,\"x\":null,\"y\":null,\"crv\":null}";
+    protected Dictionary<string, object> Payload = new();
+
+    protected string PrivateJWK =
+        """
+        {
+            "kty":"RSA",
+            "d": "QeBWodq0hSYjfAxxo0VZleXLqwwZZeNWvvFfES4WyItao_-OJv1wKA7zfkZxbWkpK5iRbKrl2AMJ52AtUo5JJ6QZ7IjAQlgM0lBg3ltjb1aA0gBsK5XbiXcsV8DiAnRuy6-XgjAKPR8Lo-wZl_fdPbVoAmpSdmfn_6QXXPBai5i7FiyDbQa16pI6DL-5SCj7F78QDTRiJOqn5ElNvtoJEfJBm13giRdqeriFi3pCWo7H3QBgTEWtDNk509z4w4t64B2HTXnM0xj9zLnS42l7YplJC7MRibD4nVBMtzfwtGRKLj8beuDgtW9pDlQqf7RVWX5pHQgiHAZmUi85TEbYdQ","DP":"h2F54OMaC9qq1yqR2b55QNNaChyGtvmTHSdqZJ8lJFqvUorlz-Uocj2BTowWQnaMd8zRKMdKlSeUuSv4Z6WmjSxSsNbonI6_II5XlZLWYqFdmqDS-xCmJY32voT5Wn7OwB9xj1msDqrFPg-PqSBOh5OppjCqXqDFcNvSkQSajXc",
+            "dq":"VABdS20Nxkmq6JWLQj7OjRxVJuYsHrfmWJmDA7_SYtlXaPUcg-GiHGQtzdDWEeEi0dlJjv9I3FdjKGC7CGwqtVygW38DzVYJsV2EmRNJc1-j-1dRs_pK9GWR4NYm0mVz_IhS8etIf9cfRJk90xU3AL3_J6p5WNF7I5ctkLpnt8M",
+            "e":"AQAB",
+            "n":"yWWAOSV3Z_BW9rJEFvbZyeU-q2mJWC0l8WiHNqwVVf7qXYgm9hJC0j1aPHku_Wpl38DpK3Xu3LjWOFG9OrCqga5Pzce3DDJKI903GNqz5wphJFqweoBFKOjj1wegymvySsLoPqqDNVYTKp4nVnECZS4axZJoNt2l1S1bC8JryaNze2stjW60QT-mIAGq9konKKN3URQ12dr478m0Oh-4WWOiY4HrXoSOklFmzK-aQx1JV_SZ04eIGfSw1pZZyqTaB1BwBotiy-QA03IRxwIXQ7BSx5EaxC5uMCMbzmbvJqjt-q8Y1wyl-UQjRucgp7hkfHSE1QT3zEex2Q3NFux7SQ","Oth":null,"P":"_T7MTkeOh5QyqlYCtLQ2RWf2dAJ9i3wrCx4nEDm1c1biijhtVTL7uJTLxwQIM9O2PvOi5Dq-UiGy6rhHZqf5akWTeHtaNyI-2XslQfaS3ctRgmGtRQL_VihK-R9AQtDx4eWL4h-bDJxPaxby_cVo_j2MX5AeoC1kNmcCdDf_X0M","Q":"y5ZSThaGLjaPj8Mk2nuD8TiC-sb4aAZVh9K-W4kwaWKfDNoPcNb_dephBNMnOp9M1br6rDbyG7P-Sy_LOOsKg3Q0wHqv4hnzGaOQFeMJH4HkXYdENC7B5JG9PefbC6zwcgZWiBnsxgKpScNWuzGF8x2CC-MdsQ1bkQeTPbJklIM","QI":"i716Vt9II_Rt6qnjsEhfE4bej52QFG9a1hSnx5PDNvRrNqR_RpTA0lO9qeXSZYGHTW_b6ZXdh_0EUwRDEDHmaxjkIcTADq6JLuDltOhZuhLUSc5NCKLAVCZlPcaSzv8-bZm57mVcIpx0KyFHxvk50___Jgx1qyzwLX03mPGUbDQ"
+        }
+        """;
+
+    protected string PublicJWK =
+        """
+        {
+            "kty":"RSA",
+            "use":"sig",
+            "e":"AQAB",
+            "n":"yWWAOSV3Z_BW9rJEFvbZyeU-q2mJWC0l8WiHNqwVVf7qXYgm9hJC0j1aPHku_Wpl38DpK3Xu3LjWOFG9OrCqga5Pzce3DDJKI903GNqz5wphJFqweoBFKOjj1wegymvySsLoPqqDNVYTKp4nVnECZS4axZJoNt2l1S1bC8JryaNze2stjW60QT-mIAGq9konKKN3URQ12dr478m0Oh-4WWOiY4HrXoSOklFmzK-aQx1JV_SZ04eIGfSw1pZZyqTaB1BwBotiy-QA03IRxwIXQ7BSx5EaxC5uMCMbzmbvJqjt-q8Y1wyl-UQjRucgp7hkfHSE1QT3zEex2Q3NFux7SQ"
+        }
+        """;
     protected string JKT = "JGSVlE73oKtQQI1dypYg8_JNat0xJjsQNyOI5oxaZf4";
 
     public DPoPEndpointTestBase()
@@ -163,14 +183,6 @@ public abstract class DPoPEndpointTestBase
 
         Pipeline.Initialize();
 
-        Payload = new Dictionary<string, object>
-        {
-            //{ "jti", CryptoRandom.CreateUniqueId() }, // added dynamically below in CreateDPoPProofToken
-            //{ "iat", DateTimeOffset.UtcNow.ToUnixTimeSeconds() }, // added dynamically below in CreateDPoPProofToken
-            { "htm", "POST" },
-            { "htu", IdentityServerPipeline.TokenEndpoint },
-        };
-
         CreateHeaderValuesFromPublicKey();
     }
 
@@ -242,17 +254,15 @@ public abstract class DPoPEndpointTestBase
         };
     }
 
-    protected string CreateDPoPProofToken(string alg = "RS256", SecurityKey key = null)
+    protected string CreateDPoPProofToken(string alg = "RS256", SecurityKey key = null, string htu = IdentityServerPipeline.TokenEndpoint, string htm = "POST")
     {
-        var payload = new Dictionary<string, object>(Payload);
-        if (!payload.ContainsKey("jti"))
+        var payload = new Dictionary<string, object>(Payload)
         {
-            payload.Add("jti", CryptoRandom.CreateUniqueId());
-        }
-        if (!payload.ContainsKey("iat"))
-        {
-            payload.Add("iat", DateTimeOffset.UtcNow.ToUnixTimeSeconds());
-        }
+            { "jti", CryptoRandom.CreateUniqueId() },
+            { "iat", DateTimeOffset.UtcNow.ToUnixTimeSeconds() },
+            { "htm", htm },
+            { "htu", htu }
+        };
 
         key ??= new Microsoft.IdentityModel.Tokens.JsonWebKey(PrivateJWK);
         var handler = new JsonWebTokenHandler() { SetDefaultTimesOnTokenCreation = false };
@@ -283,4 +293,86 @@ public abstract class DPoPEndpointTestBase
         }
         return null;
     }
+
+    protected async Task<AuthorizationCodeTokenRequest> CreateAuthCodeTokenRequestAsync(
+        string clientId = "client1",
+        bool omitDPoPProofAtTokenEndpoint = false,
+        string dpopJkt = null,
+        string dpopProof = null,
+        ParMode parMode = ParMode.Unused)
+    {
+
+        await Pipeline.LoginAsync("bob");
+
+        Pipeline.BrowserClient.AllowAutoRedirect = false;
+
+        var scope = clientId == "client1" ? "scope1" : "scope2";
+
+        string url;
+
+        if (parMode != ParMode.Unused)
+        {
+            var parRequest = new Duende.IdentityModel.Client.PushedAuthorizationRequest
+            {
+                Address = IdentityServerPipeline.ParEndpoint,
+                ClientId = clientId,
+                ClientSecret = "secret",
+                Scope = $"openid {scope} offline_access",
+                ResponseType = OidcConstants.ResponseTypes.Code,
+                ResponseMode = OidcConstants.ResponseModes.Query,
+                RedirectUri = $"https://{clientId}/callback",
+                DPoPKeyThumbprint = dpopJkt ?? (parMode is ParMode.Both or ParMode.DpopJktParameter ? JKT : null)
+            };
+            if (parMode is ParMode.Both or ParMode.DpopHeader)
+            {
+                parRequest.Headers.Add("DPoP", dpopProof ?? CreateDPoPProofToken(htu: IdentityServerPipeline.ParEndpoint));
+            }
+            var parResponse = await Pipeline.BackChannelClient.PushAuthorizationAsync(parRequest);
+            parResponse.IsError.ShouldBeFalse($"Error from PAR request: {parResponse.Error}");
+            url = Pipeline.CreateAuthorizeUrl(
+                clientId: clientId,
+                requestUri: parResponse.RequestUri);
+        }
+        else
+        {
+            url = Pipeline.CreateAuthorizeUrl(
+                clientId: clientId,
+                responseType: OidcConstants.ResponseTypes.Code,
+                responseMode: OidcConstants.ResponseModes.Query,
+                scope: $"openid {scope} offline_access",
+                redirectUri: $"https://{clientId}/callback",
+                extra: new { dpop_jkt = dpopJkt });
+        }
+        var response = await Pipeline.BrowserClient.GetAsync(url);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+        response.Headers.Location.ToString().ShouldStartWith($"https://{clientId}/callback");
+
+        var authorization = new AuthorizeResponse(response.Headers.Location.ToString());
+        authorization.IsError.ShouldBeFalse();
+
+        var codeRequest = new AuthorizationCodeTokenRequest
+        {
+            Address = IdentityServerPipeline.TokenEndpoint,
+            ClientId = clientId,
+            ClientSecret = "secret",
+            Code = authorization.Code,
+            RedirectUri = $"https://{clientId}/callback",
+        };
+        if (!omitDPoPProofAtTokenEndpoint)
+        {
+            codeRequest.Headers.Add("DPoP", CreateDPoPProofToken());
+        }
+        return codeRequest;
+    }
+}
+
+public enum ParMode
+{
+    Unused,
+    NoBinding,
+    DpopJktParameter,
+    DpopHeader,
+    Both
+
 }

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Token/DPoPPushedAuthorizationEndpointTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Token/DPoPPushedAuthorizationEndpointTests.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+
+using System.Net;
+using Duende.IdentityModel;
+using Duende.IdentityModel.Client;
+using IntegrationTests.Common;
+using IntegrationTests.Endpoints.Token;
+
+namespace IntegrationTests.Endpoints.PushedAuthorization;
+
+public class DPoPPushedAuthorizationEndpointTests : DPoPEndpointTestBase
+{
+    protected const string Category = "DPoP PAR endpoint";
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task invalid_dpop_request_should_fail()
+    {
+        var request = new PushedAuthorizationRequest
+        {
+            Address = IdentityServerPipeline.ParEndpoint,
+            ClientId = "client1",
+            ClientSecret = "secret",
+            Scope = "scope1",
+            ResponseType = OidcConstants.ResponseTypes.Code
+        };
+        request.Headers.Add("DPoP", "malformed");
+
+        var response = await Pipeline.BackChannelClient.PushAuthorizationAsync(request);
+        response.IsError.ShouldBeTrue();
+        response.Error.ShouldBe("invalid_request");
+    }
+
+    [Fact]
+    public async Task multiple_dpop_headers_sent_to_the_par_endpoint_fails()
+    {
+        Pipeline.BackChannelClient.DefaultRequestHeaders.Add("DPoP", "first");
+        Pipeline.BackChannelClient.DefaultRequestHeaders.Add("DPoP", "second");
+        var (parJson, statusCode) = await Pipeline.PushAuthorizationRequestAsync();
+        statusCode.ShouldBe(HttpStatusCode.BadRequest);
+        parJson.RootElement.GetProperty("error").GetString()
+            .ShouldBe(OidcConstants.AuthorizeErrors.InvalidRequest);
+    }
+}

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Token/DPoPPushedAuthorizationEndpointTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Token/DPoPPushedAuthorizationEndpointTests.cs
@@ -2,7 +2,6 @@
 // See LICENSE in the project root for license information.
 
 
-using System.Net;
 using Duende.IdentityModel;
 using Duende.IdentityModel.Client;
 using IntegrationTests.Common;
@@ -10,13 +9,18 @@ using IntegrationTests.Endpoints.Token;
 
 namespace IntegrationTests.Endpoints.PushedAuthorization;
 
+/// <summary>
+/// This class contains tests of the DPoP support at the PAR endpoint, exercising behavior that is specific to PAR.
+/// Many more tests in DPoPTokenEndpointTests exercise the code flow and are parameterized to test both with and without
+/// pushed authorization.
+/// </summary>
 public class DPoPPushedAuthorizationEndpointTests : DPoPEndpointTestBase
 {
     protected const string Category = "DPoP PAR endpoint";
 
-    [Fact]
-    [Trait("Category", Category)]
-    public async Task invalid_dpop_request_should_fail()
+    private PushedAuthorizationRequest CreatePushedAuthorizationRequest(
+        string proofToken = null, bool omitDPoPProof = false, string dpopKeyThumprint = null
+    )
     {
         var request = new PushedAuthorizationRequest
         {
@@ -24,23 +28,83 @@ public class DPoPPushedAuthorizationEndpointTests : DPoPEndpointTestBase
             ClientId = "client1",
             ClientSecret = "secret",
             Scope = "scope1",
-            ResponseType = OidcConstants.ResponseTypes.Code
+            ResponseType = OidcConstants.ResponseTypes.Code,
+            RedirectUri = "https://client1/callback",
+            DPoPKeyThumbprint = dpopKeyThumprint
         };
-        request.Headers.Add("DPoP", "malformed");
-
-        var response = await Pipeline.BackChannelClient.PushAuthorizationAsync(request);
-        response.IsError.ShouldBeTrue();
-        response.Error.ShouldBe("invalid_request");
+        if (!omitDPoPProof)
+        {
+            proofToken ??= CreateDPoPProofToken(htu: IdentityServerPipeline.ParEndpoint);
+            request.Headers.Add("DPoP", proofToken);
+        }
+        return request;
     }
 
     [Fact]
-    public async Task multiple_dpop_headers_sent_to_the_par_endpoint_fails()
+    [Trait("Category", Category)]
+    public async Task dpop_proof_token_too_long_should_fail()
     {
-        Pipeline.BackChannelClient.DefaultRequestHeaders.Add("DPoP", "first");
-        Pipeline.BackChannelClient.DefaultRequestHeaders.Add("DPoP", "second");
-        var (parJson, statusCode) = await Pipeline.PushAuthorizationRequestAsync();
-        statusCode.ShouldBe(HttpStatusCode.BadRequest);
-        parJson.RootElement.GetProperty("error").GetString()
-            .ShouldBe(OidcConstants.AuthorizeErrors.InvalidRequest);
+        Payload.Add("foo", new string('x', 3000));
+        var request = CreatePushedAuthorizationRequest();
+        var response = await Pipeline.BackChannelClient.PushAuthorizationAsync(request);
+        response.IsError.ShouldBeTrue();
+        response.Error.ShouldBe("invalid_dpop_proof");
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task replayed_dpop_token_should_fail()
+    {
+        // Shared proof used throughout
+        var dpopToken = CreateDPoPProofToken(htu: IdentityServerPipeline.ParEndpoint);
+
+        // Initial request succeeds
+        var firstRequest = CreatePushedAuthorizationRequest(dpopToken);
+        var firstResponse = await Pipeline.BackChannelClient.PushAuthorizationAsync(firstRequest);
+        firstResponse.IsError.ShouldBeFalse();
+
+        // Second request fails
+        var secondRequest = CreatePushedAuthorizationRequest(dpopToken);
+        var secondResponse = await Pipeline.BackChannelClient.PushAuthorizationAsync(secondRequest);
+        secondResponse.IsError.ShouldBeTrue();
+        secondResponse.Error.ShouldBe("invalid_dpop_proof");
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task invalid_dpop_request_should_fail()
+    {
+        var request = CreatePushedAuthorizationRequest(proofToken: "malformed");
+        var response = await Pipeline.BackChannelClient.PushAuthorizationAsync(request);
+        response.IsError.ShouldBeTrue();
+        response.Error.ShouldBe("invalid_dpop_proof");
+    }
+
+    [Fact]
+    public async Task multiple_dpop_headers_should_fail()
+    {
+        var request = CreatePushedAuthorizationRequest(omitDPoPProof: true);
+        var dpopToken = CreateDPoPProofToken();
+        request.Headers.Add("DPoP", dpopToken);
+        request.Headers.Add("DPoP", dpopToken);
+
+        var response = await Pipeline.BackChannelClient.PushAuthorizationAsync(request);
+
+        response.IsError.ShouldBeTrue();
+        response.Error.ShouldBe(OidcConstants.AuthorizeErrors.InvalidRequest);
+    }
+
+    [Fact]
+    public async Task mismatch_between_header_and_thumbprint_should_fail()
+    {
+        var oldThumbprint = JKT;
+        CreateNewRSAKey();
+        oldThumbprint.ShouldNotBe(JKT);
+        var request = CreatePushedAuthorizationRequest(dpopKeyThumprint: oldThumbprint);
+
+        var response = await Pipeline.BackChannelClient.PushAuthorizationAsync(request);
+
+        response.IsError.ShouldBeTrue();
+        response.Error.ShouldBe(OidcConstants.AuthorizeErrors.InvalidRequest);
     }
 }

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Token/DPoPTokenEndpointTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Token/DPoPTokenEndpointTests.cs
@@ -2,278 +2,113 @@
 // See LICENSE in the project root for license information.
 
 
-using System.IdentityModel.Tokens.Jwt;
 using System.Net;
-using System.Security.Claims;
-using System.Text.Json;
-using Duende.IdentityModel;
 using Duende.IdentityModel.Client;
 using Duende.IdentityServer;
 using Duende.IdentityServer.Configuration;
 using Duende.IdentityServer.Extensions;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services;
-using Duende.IdentityServer.Test;
 using Duende.IdentityServer.Validation;
 using IntegrationTests.Common;
-using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.IdentityModel.JsonWebTokens;
-using Microsoft.IdentityModel.Tokens;
 
 namespace IntegrationTests.Endpoints.Token;
 
-public class DPoPTokenEndpointTests
+public class DPoPTokenEndpointTests : DPoPEndpointTestBase
 {
-    private const string Category = "DPoP Token endpoint";
+    protected const string Category = "DPoP Token endpoint";
 
-    private IdentityServerPipeline _mockPipeline = new IdentityServerPipeline();
-
-    private Client _dpopConfidentialClient;
-
-    private Client _dpopPublicClient;
-
-    private DateTime _now = new DateTime(2020, 3, 10, 9, 0, 0, DateTimeKind.Utc);
-    public DateTime UtcNow
+    private ClientCredentialsTokenRequest CreateClientCredentialsTokenRequest(
+        string proofToken = null, bool omitDPoPProof = false)
     {
-        get
-        {
-            if (_now > DateTime.MinValue) return _now;
-            return DateTime.UtcNow;
-        }
-    }
-
-    private Dictionary<string, object> _header;
-    private Dictionary<string, object> _payload;
-    private string _privateJWK = "{\"Crv\":null,\"D\":\"QeBWodq0hSYjfAxxo0VZleXLqwwZZeNWvvFfES4WyItao_-OJv1wKA7zfkZxbWkpK5iRbKrl2AMJ52AtUo5JJ6QZ7IjAQlgM0lBg3ltjb1aA0gBsK5XbiXcsV8DiAnRuy6-XgjAKPR8Lo-wZl_fdPbVoAmpSdmfn_6QXXPBai5i7FiyDbQa16pI6DL-5SCj7F78QDTRiJOqn5ElNvtoJEfJBm13giRdqeriFi3pCWo7H3QBgTEWtDNk509z4w4t64B2HTXnM0xj9zLnS42l7YplJC7MRibD4nVBMtzfwtGRKLj8beuDgtW9pDlQqf7RVWX5pHQgiHAZmUi85TEbYdQ\",\"DP\":\"h2F54OMaC9qq1yqR2b55QNNaChyGtvmTHSdqZJ8lJFqvUorlz-Uocj2BTowWQnaMd8zRKMdKlSeUuSv4Z6WmjSxSsNbonI6_II5XlZLWYqFdmqDS-xCmJY32voT5Wn7OwB9xj1msDqrFPg-PqSBOh5OppjCqXqDFcNvSkQSajXc\",\"DQ\":\"VABdS20Nxkmq6JWLQj7OjRxVJuYsHrfmWJmDA7_SYtlXaPUcg-GiHGQtzdDWEeEi0dlJjv9I3FdjKGC7CGwqtVygW38DzVYJsV2EmRNJc1-j-1dRs_pK9GWR4NYm0mVz_IhS8etIf9cfRJk90xU3AL3_J6p5WNF7I5ctkLpnt8M\",\"E\":\"AQAB\",\"K\":null,\"KeyOps\":[],\"Kty\":\"RSA\",\"N\":\"yWWAOSV3Z_BW9rJEFvbZyeU-q2mJWC0l8WiHNqwVVf7qXYgm9hJC0j1aPHku_Wpl38DpK3Xu3LjWOFG9OrCqga5Pzce3DDJKI903GNqz5wphJFqweoBFKOjj1wegymvySsLoPqqDNVYTKp4nVnECZS4axZJoNt2l1S1bC8JryaNze2stjW60QT-mIAGq9konKKN3URQ12dr478m0Oh-4WWOiY4HrXoSOklFmzK-aQx1JV_SZ04eIGfSw1pZZyqTaB1BwBotiy-QA03IRxwIXQ7BSx5EaxC5uMCMbzmbvJqjt-q8Y1wyl-UQjRucgp7hkfHSE1QT3zEex2Q3NFux7SQ\",\"Oth\":null,\"P\":\"_T7MTkeOh5QyqlYCtLQ2RWf2dAJ9i3wrCx4nEDm1c1biijhtVTL7uJTLxwQIM9O2PvOi5Dq-UiGy6rhHZqf5akWTeHtaNyI-2XslQfaS3ctRgmGtRQL_VihK-R9AQtDx4eWL4h-bDJxPaxby_cVo_j2MX5AeoC1kNmcCdDf_X0M\",\"Q\":\"y5ZSThaGLjaPj8Mk2nuD8TiC-sb4aAZVh9K-W4kwaWKfDNoPcNb_dephBNMnOp9M1br6rDbyG7P-Sy_LOOsKg3Q0wHqv4hnzGaOQFeMJH4HkXYdENC7B5JG9PefbC6zwcgZWiBnsxgKpScNWuzGF8x2CC-MdsQ1bkQeTPbJklIM\",\"QI\":\"i716Vt9II_Rt6qnjsEhfE4bej52QFG9a1hSnx5PDNvRrNqR_RpTA0lO9qeXSZYGHTW_b6ZXdh_0EUwRDEDHmaxjkIcTADq6JLuDltOhZuhLUSc5NCKLAVCZlPcaSzv8-bZm57mVcIpx0KyFHxvk50___Jgx1qyzwLX03mPGUbDQ\",\"Use\":null,\"X\":null,\"X5c\":[],\"X5t\":null,\"X5tS256\":null,\"X5u\":null,\"Y\":null,\"KeySize\":2048,\"HasPrivateKey\":true,\"CryptoProviderFactory\":{\"CryptoProviderCache\":{},\"CustomCryptoProvider\":null,\"CacheSignatureProviders\":true,\"SignatureProviderObjectPoolCacheSize\":80}}";
-    private string _publicJWK = "{\"kty\":\"RSA\",\"use\":\"sig\",\"x5t\":null,\"e\":\"AQAB\",\"n\":\"yWWAOSV3Z_BW9rJEFvbZyeU-q2mJWC0l8WiHNqwVVf7qXYgm9hJC0j1aPHku_Wpl38DpK3Xu3LjWOFG9OrCqga5Pzce3DDJKI903GNqz5wphJFqweoBFKOjj1wegymvySsLoPqqDNVYTKp4nVnECZS4axZJoNt2l1S1bC8JryaNze2stjW60QT-mIAGq9konKKN3URQ12dr478m0Oh-4WWOiY4HrXoSOklFmzK-aQx1JV_SZ04eIGfSw1pZZyqTaB1BwBotiy-QA03IRxwIXQ7BSx5EaxC5uMCMbzmbvJqjt-q8Y1wyl-UQjRucgp7hkfHSE1QT3zEex2Q3NFux7SQ\",\"x5c\":null,\"x\":null,\"y\":null,\"crv\":null}";
-    private string _JKT = "JGSVlE73oKtQQI1dypYg8_JNat0xJjsQNyOI5oxaZf4";
-
-    public DPoPTokenEndpointTests()
-    {
-        _mockPipeline.OnPostConfigureServices += services =>
-        {
-        };
-
-        _mockPipeline.Clients.AddRange(new Client[] {
-            _dpopConfidentialClient = new Client
-            {
-                ClientId = "client1",
-                AllowedGrantTypes = GrantTypes.CodeAndClientCredentials,
-                ClientSecrets =
-                {
-                    new Secret("secret".Sha256()),
-                },
-                RedirectUris = { "https://client1/callback" },
-                RequirePkce = false,
-                AllowOfflineAccess = true,
-                RefreshTokenUsage = TokenUsage.ReUse,
-                AllowedScopes = new List<string> { "openid", "profile", "scope1" },
-            },
-            _dpopPublicClient = new Client
-            {
-                ClientId = "client2",
-                AllowedGrantTypes = GrantTypes.Code,
-                RequireClientSecret = false,
-                RequirePkce = false,
-                RedirectUris = { "https://client2/callback" },
-                AllowOfflineAccess = true,
-                RefreshTokenUsage = TokenUsage.ReUse,
-                AllowedScopes = new List<string> { "openid", "profile", "scope2" },
-            }
-        });
-
-        _mockPipeline.Users.Add(new TestUser
-        {
-            SubjectId = "bob",
-            Username = "bob",
-            Password = "bob",
-            Claims = new Claim[]
-            {
-                new Claim("name", "Bob Loblaw"),
-                new Claim("email", "bob@loblaw.com"),
-                new Claim("role", "Attorney")
-            }
-        });
-
-        _mockPipeline.IdentityScopes.AddRange(new IdentityResource[] {
-            new IdentityResources.OpenId(),
-            new IdentityResources.Profile(),
-            new IdentityResources.Email()
-        });
-        _mockPipeline.ApiResources.AddRange(new[]
-        {
-            new ApiResource("api1")
-            {
-                Scopes = { "scope1" },
-                ApiSecrets =
-                {
-                    new Secret("secret".Sha256())
-                }
-            },
-            new ApiResource("api2")
-            {
-                Scopes = { "scope2" },
-                ApiSecrets =
-                {
-                    new Secret("secret".Sha256())
-                }
-            }
-        });
-        _mockPipeline.ApiScopes.AddRange(new ApiScope[] {
-            new ApiScope
-            {
-                Name = "scope1"
-            },
-            new ApiScope
-            {
-                Name = "scope2"
-            }
-        });
-
-        _mockPipeline.Initialize();
-
-        _payload = new Dictionary<string, object>
-        {
-            //{ "jti", CryptoRandom.CreateUniqueId() }, // added dynamically below in CreateDPoPProofToken
-            //{ "iat", DateTimeOffset.UtcNow.ToUnixTimeSeconds() }, // added dynamically below in CreateDPoPProofToken
-            { "htm", "POST" },
-            { "htu", IdentityServerPipeline.TokenEndpoint },
-        };
-
-        CreateHeaderValuesFromPublicKey();
-    }
-
-    private void CreateNewRSAKey()
-    {
-        var key = CryptoHelper.CreateRsaSecurityKey();
-        var jwk = JsonWebKeyConverter.ConvertFromRSASecurityKey(key);
-        _JKT = Base64UrlEncoder.Encode(key.ComputeJwkThumbprint());
-        _privateJWK = JsonSerializer.Serialize(jwk);
-        _publicJWK = JsonSerializer.Serialize(new
-        {
-            kty = jwk.Kty,
-            e = jwk.E,
-            n = jwk.N,
-        });
-
-        CreateHeaderValuesFromPublicKey();
-    }
-
-    private void CreateNewECKey()
-    {
-        var key = CryptoHelper.CreateECDsaSecurityKey();
-        var jwk = JsonWebKeyConverter.ConvertFromECDsaSecurityKey(key);
-        _JKT = Base64UrlEncoder.Encode(key.ComputeJwkThumbprint());
-        _privateJWK = JsonSerializer.Serialize(jwk);
-        _publicJWK = JsonSerializer.Serialize(new
-        {
-            kty = jwk.Kty,
-            x = jwk.X,
-            y = jwk.Y,
-            crv = jwk.Crv
-        });
-
-        CreateHeaderValuesFromPublicKey();
-    }
-
-    private void CreateHeaderValuesFromPublicKey(string publicJwk = null)
-    {
-        var jwk = JsonSerializer.Deserialize<JsonElement>(publicJwk ?? _publicJWK);
-        var jwkValues = new Dictionary<string, object>();
-        foreach (var item in jwk.EnumerateObject())
-        {
-            if (item.Value.ValueKind == JsonValueKind.String)
-            {
-                var val = item.Value.GetString();
-                if (!string.IsNullOrEmpty(val))
-                {
-                    jwkValues.Add(item.Name, val);
-                }
-            }
-            if (item.Value.ValueKind == JsonValueKind.False)
-            {
-                jwkValues.Add(item.Name, false);
-            }
-            if (item.Value.ValueKind == JsonValueKind.True)
-            {
-                jwkValues.Add(item.Name, true);
-            }
-            if (item.Value.ValueKind == JsonValueKind.Number)
-            {
-                jwkValues.Add(item.Name, item.Value.GetInt64());
-            }
-        }
-        _header = new Dictionary<string, object>()
-        {
-            //{ "alg", "RS265" }, // JsonWebTokenHandler requires adding this itself
-            { "typ", "dpop+jwt" },
-            { "jwk", jwkValues },
-        };
-    }
-
-    private string CreateDPoPProofToken(string alg = "RS256", SecurityKey key = null)
-    {
-        var payload = new Dictionary<string, object>(_payload);
-        if (!payload.ContainsKey("jti"))
-        {
-            payload.Add("jti", CryptoRandom.CreateUniqueId());
-        }
-        if (!payload.ContainsKey("iat"))
-        {
-            payload.Add("iat", DateTimeOffset.UtcNow.ToUnixTimeSeconds());
-        }
-
-        key ??= new Microsoft.IdentityModel.Tokens.JsonWebKey(_privateJWK);
-        var handler = new JsonWebTokenHandler() { SetDefaultTimesOnTokenCreation = false };
-        var token = handler.CreateToken(JsonSerializer.Serialize(payload), new SigningCredentials(key, alg), _header);
-        return token;
-    }
-
-    private IEnumerable<Claim> ParseAccessTokenClaims(TokenResponse tokenResponse)
-    {
-        tokenResponse.IsError.ShouldBeFalse(tokenResponse.Error);
-
-        var handler = new JwtSecurityTokenHandler();
-        var token = handler.ReadJwtToken(tokenResponse.AccessToken);
-        return token.Claims;
-    }
-    private string GetJKTFromAccessToken(TokenResponse tokenResponse)
-    {
-        var claims = ParseAccessTokenClaims(tokenResponse);
-        return GetJKTFromCnfClaim(claims);
-    }
-    private string GetJKTFromCnfClaim(IEnumerable<Claim> claims)
-    {
-        var cnf = claims.SingleOrDefault(x => x.Type == "cnf")?.Value;
-        if (cnf != null)
-        {
-            var json = JsonSerializer.Deserialize<JsonElement>(cnf);
-            return json.GetString("jkt");
-        }
-        return null;
-    }
-
-    [Fact]
-    [Trait("Category", Category)]
-    public async Task valid_dpop_request_should_return_bound_access_token()
-    {
-        var dpopToken = CreateDPoPProofToken();
-        var request = new ClientCredentialsTokenRequest
+        var request = new ClientCredentialsTokenRequest()
         {
             Address = IdentityServerPipeline.TokenEndpoint,
             ClientId = "client1",
             ClientSecret = "secret",
             Scope = "scope1",
         };
-        request.Headers.Add("DPoP", dpopToken);
+        if (!omitDPoPProof)
+        {
+            proofToken ??= CreateDPoPProofToken();
+            request.Headers.Add("DPoP", proofToken);
+        }
+        return request;
+    }
 
-        var response = await _mockPipeline.BackChannelClient.RequestClientCredentialsTokenAsync(request);
+    private async Task<AuthorizationCodeTokenRequest> CreateAuthCodeTokenRequestAsync(
+        string clientId = "client1", bool omitDPoPProof = false, string dpopJkt = null)
+    {
+        await Pipeline.LoginAsync("bob");
+
+        Pipeline.BrowserClient.AllowAutoRedirect = false;
+
+        var scope = clientId == "client1" ? "scope1" : "scope2";
+
+        var url = Pipeline.CreateAuthorizeUrl(
+            clientId: clientId,
+            responseType: "code",
+            responseMode: "query",
+            scope: $"openid {scope} offline_access",
+            redirectUri: $"https://{clientId}/callback",
+            extra: dpopJkt != null ? new
+            {
+                dpop_jkt = dpopJkt
+            } : null);
+        var response = await Pipeline.BrowserClient.GetAsync(url);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+        response.Headers.Location.ToString().ShouldStartWith($"https://{clientId}/callback");
+
+        var authorization = new AuthorizeResponse(response.Headers.Location.ToString());
+        authorization.IsError.ShouldBeFalse();
+
+        var codeRequest = new AuthorizationCodeTokenRequest
+        {
+            Address = IdentityServerPipeline.TokenEndpoint,
+            ClientId = clientId,
+            ClientSecret = "secret",
+            Code = authorization.Code,
+            RedirectUri = $"https://{clientId}/callback",
+        };
+        if (!omitDPoPProof)
+        {
+            codeRequest.Headers.Add("DPoP", CreateDPoPProofToken());
+        }
+        return codeRequest;
+    }
+
+    private RefreshTokenRequest CreateRefreshTokenRequest(
+        TokenResponse codeResponse, string clientId = "client1", bool omitDPoPProof = false)
+    {
+        var rtRequest = new RefreshTokenRequest
+        {
+            Address = IdentityServerPipeline.TokenEndpoint,
+            ClientId = clientId,
+            ClientSecret = "secret",
+            RefreshToken = codeResponse.RefreshToken
+        };
+        if (!omitDPoPProof)
+        {
+            rtRequest.Headers.Add("DPoP", CreateDPoPProofToken());
+        }
+        return rtRequest;
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task valid_dpop_request_should_return_bound_access_token()
+    {
+        var request = CreateClientCredentialsTokenRequest();
+
+        var response = await Pipeline.BackChannelClient.RequestClientCredentialsTokenAsync(request);
+
         response.IsError.ShouldBeFalse();
         response.TokenType.ShouldBe("DPoP");
         var jkt = GetJKTFromAccessToken(response);
-        jkt.ShouldBe(_JKT);
+        jkt.ShouldBe(JKT);
     }
 
     [Fact]
@@ -282,42 +117,26 @@ public class DPoPTokenEndpointTests
     {
         // The point here is to have an array in the payload, to exercise 
         // the json serialization
-        _payload.Add("key_ops", new string[] { "sign", "verify" });
+        Payload.Add("key_ops", new string[] { "sign", "verify" });
+        var request = CreateClientCredentialsTokenRequest();
 
-        var dpopToken = CreateDPoPProofToken();
-        var request = new ClientCredentialsTokenRequest
-        {
-            Address = IdentityServerPipeline.TokenEndpoint,
-            ClientId = "client1",
-            ClientSecret = "secret",
-            Scope = "scope1",
-        };
-        request.Headers.Add("DPoP", dpopToken);
+        var response = await Pipeline.BackChannelClient.RequestClientCredentialsTokenAsync(request);
 
-        var response = await _mockPipeline.BackChannelClient.RequestClientCredentialsTokenAsync(request);
         response.IsError.ShouldBeFalse();
         response.TokenType.ShouldBe("DPoP");
         var jkt = GetJKTFromAccessToken(response);
-        jkt.ShouldBe(_JKT);
+        jkt.ShouldBe(JKT);
     }
 
     [Fact]
     [Trait("Category", Category)]
     public async Task dpop_proof_token_too_long_should_fail()
     {
-        _payload.Add("foo", new string('x', 3000));
+        Payload.Add("foo", new string('x', 3000));
+        var request = CreateClientCredentialsTokenRequest();
 
-        var dpopToken = CreateDPoPProofToken();
-        var request = new ClientCredentialsTokenRequest
-        {
-            Address = IdentityServerPipeline.TokenEndpoint,
-            ClientId = "client1",
-            ClientSecret = "secret",
-            Scope = "scope1",
-        };
-        request.Headers.Add("DPoP", dpopToken);
+        var response = await Pipeline.BackChannelClient.RequestClientCredentialsTokenAsync(request);
 
-        var response = await _mockPipeline.BackChannelClient.RequestClientCredentialsTokenAsync(request);
         response.IsError.ShouldBeTrue();
     }
 
@@ -325,54 +144,32 @@ public class DPoPTokenEndpointTests
     [Trait("Category", Category)]
     public async Task replayed_dpop_token_should_fail()
     {
+        // Shared proof used throughout
         var dpopToken = CreateDPoPProofToken();
 
-        {
-            var request = new ClientCredentialsTokenRequest
-            {
-                Address = IdentityServerPipeline.TokenEndpoint,
-                ClientId = "client1",
-                ClientSecret = "secret",
-                Scope = "scope1",
-            };
-            request.Headers.Add("DPoP", dpopToken);
+        // Initial request succeeds
+        var firstRequest = CreateClientCredentialsTokenRequest(dpopToken);
+        var firstResponse = await Pipeline.BackChannelClient.RequestClientCredentialsTokenAsync(firstRequest);
+        firstResponse.IsError.ShouldBeFalse();
+        firstResponse.TokenType.ShouldBe("DPoP");
+        var jkt = GetJKTFromAccessToken(firstResponse);
+        jkt.ShouldBe(JKT);
 
-            var response = await _mockPipeline.BackChannelClient.RequestClientCredentialsTokenAsync(request);
-            response.IsError.ShouldBeFalse();
-            response.TokenType.ShouldBe("DPoP");
-            var jkt = GetJKTFromAccessToken(response);
-            jkt.ShouldBe(_JKT);
-        }
-
-        {
-            var request = new ClientCredentialsTokenRequest
-            {
-                Address = IdentityServerPipeline.TokenEndpoint,
-                ClientId = "client1",
-                ClientSecret = "secret",
-                Scope = "scope1",
-            };
-            request.Headers.Add("DPoP", dpopToken);
-
-            var response = await _mockPipeline.BackChannelClient.RequestClientCredentialsTokenAsync(request);
-            response.IsError.ShouldBeTrue();
-        }
+        // Second request fails
+        var secondRequest = CreateClientCredentialsTokenRequest(dpopToken);
+        secondRequest.Headers.Add("DPoP", dpopToken);
+        var secondResponse = await Pipeline.BackChannelClient.RequestClientCredentialsTokenAsync(secondRequest);
+        secondResponse.IsError.ShouldBeTrue();
     }
 
     [Fact]
     [Trait("Category", Category)]
     public async Task invalid_dpop_request_should_fail()
     {
-        var request = new ClientCredentialsTokenRequest
-        {
-            Address = IdentityServerPipeline.TokenEndpoint,
-            ClientId = "client1",
-            ClientSecret = "secret",
-            Scope = "scope1",
-        };
-        request.Headers.Add("DPoP", "malformed");
+        var request = CreateClientCredentialsTokenRequest(proofToken: "malformed");
 
-        var response = await _mockPipeline.BackChannelClient.RequestClientCredentialsTokenAsync(request);
+        var response = await Pipeline.BackChannelClient.RequestClientCredentialsTokenAsync(request);
+
         response.IsError.ShouldBeTrue();
         response.Error.ShouldBe("invalid_dpop_proof");
     }
@@ -381,17 +178,11 @@ public class DPoPTokenEndpointTests
     [Trait("Category", Category)]
     public async Task missing_dpop_token_when_required_should_fail()
     {
-        _dpopConfidentialClient.RequireDPoP = true;
+        ConfidentialClient.RequireDPoP = true;
+        var request = CreateClientCredentialsTokenRequest(omitDPoPProof: true);
 
-        var request = new ClientCredentialsTokenRequest
-        {
-            Address = IdentityServerPipeline.TokenEndpoint,
-            ClientId = "client1",
-            ClientSecret = "secret",
-            Scope = "scope1",
-        };
+        var response = await Pipeline.BackChannelClient.RequestClientCredentialsTokenAsync(request);
 
-        var response = await _mockPipeline.BackChannelClient.RequestClientCredentialsTokenAsync(request);
         response.IsError.ShouldBeTrue();
         response.Error.ShouldBe("invalid_dpop_proof");
     }
@@ -400,18 +191,13 @@ public class DPoPTokenEndpointTests
     [Trait("Category", Category)]
     public async Task multiple_dpop_tokens_should_fail()
     {
+        var request = CreateClientCredentialsTokenRequest(omitDPoPProof: true);
         var dpopToken = CreateDPoPProofToken();
-        var request = new ClientCredentialsTokenRequest
-        {
-            Address = IdentityServerPipeline.TokenEndpoint,
-            ClientId = "client1",
-            ClientSecret = "secret",
-            Scope = "scope1",
-        };
         request.Headers.Add("DPoP", dpopToken);
         request.Headers.Add("DPoP", dpopToken);
 
-        var response = await _mockPipeline.BackChannelClient.RequestClientCredentialsTokenAsync(request);
+        var response = await Pipeline.BackChannelClient.RequestClientCredentialsTokenAsync(request);
+
         response.IsError.ShouldBeTrue();
         response.Error.ShouldBe("invalid_dpop_proof");
     }
@@ -420,101 +206,25 @@ public class DPoPTokenEndpointTests
     [Trait("Category", Category)]
     public async Task valid_dpop_request_should_return_bound_refresh_token()
     {
-        await _mockPipeline.LoginAsync("bob");
+        var codeRequest = await CreateAuthCodeTokenRequestAsync();
+        var codeResponse = await Pipeline.BackChannelClient.RequestAuthorizationCodeTokenAsync(codeRequest);
+        codeResponse.ShouldHaveDPoPThumbprint(JKT);
 
-        _mockPipeline.BrowserClient.AllowAutoRedirect = false;
-
-        var url = _mockPipeline.CreateAuthorizeUrl(
-            clientId: "client1",
-            responseType: "code",
-            responseMode: "query",
-            scope: "openid scope1 offline_access",
-            redirectUri: "https://client1/callback");
-        var response = await _mockPipeline.BrowserClient.GetAsync(url);
-
-        response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
-        response.Headers.Location.ToString().ShouldStartWith("https://client1/callback");
-
-        var authorization = new AuthorizeResponse(response.Headers.Location.ToString());
-        authorization.IsError.ShouldBeFalse();
-
-        var codeRequest = new AuthorizationCodeTokenRequest
-        {
-            Address = IdentityServerPipeline.TokenEndpoint,
-            ClientId = "client1",
-            ClientSecret = "secret",
-            Code = authorization.Code,
-            RedirectUri = "https://client1/callback",
-        };
-        codeRequest.Headers.Add("DPoP", CreateDPoPProofToken());
-
-        var codeResponse = await _mockPipeline.BackChannelClient.RequestAuthorizationCodeTokenAsync(codeRequest);
-        codeResponse.IsError.ShouldBeFalse();
-        codeResponse.TokenType.ShouldBe("DPoP");
-        GetJKTFromAccessToken(codeResponse).ShouldBe(_JKT);
-
-        var rtRequest = new RefreshTokenRequest
-        {
-            Address = IdentityServerPipeline.TokenEndpoint,
-            ClientId = "client1",
-            ClientSecret = "secret",
-            RefreshToken = codeResponse.RefreshToken
-        };
-        rtRequest.Headers.Add("DPoP", CreateDPoPProofToken());
-
-        var rtResponse = await _mockPipeline.BackChannelClient.RequestRefreshTokenAsync(rtRequest);
-        rtResponse.IsError.ShouldBeFalse();
-        rtResponse.TokenType.ShouldBe("DPoP");
-        GetJKTFromAccessToken(rtResponse).ShouldBe(_JKT);
+        var rtRequest = CreateRefreshTokenRequest(codeResponse);
+        var rtResponse = await Pipeline.BackChannelClient.RequestRefreshTokenAsync(rtRequest);
+        rtResponse.ShouldHaveDPoPThumbprint(JKT);
     }
 
     [Fact]
     [Trait("Category", Category)]
     public async Task confidential_client_dpop_proof_should_be_required_on_renewal()
     {
-        await _mockPipeline.LoginAsync("bob");
+        var codeRequest = await CreateAuthCodeTokenRequestAsync();
+        var codeResponse = await Pipeline.BackChannelClient.RequestAuthorizationCodeTokenAsync(codeRequest);
+        codeResponse.ShouldHaveDPoPThumbprint(JKT);
 
-        _mockPipeline.BrowserClient.AllowAutoRedirect = false;
-
-        var url = _mockPipeline.CreateAuthorizeUrl(
-            clientId: "client1",
-            responseType: "code",
-            responseMode: "query",
-            scope: "openid scope1 offline_access",
-            redirectUri: "https://client1/callback");
-        var response = await _mockPipeline.BrowserClient.GetAsync(url);
-
-        response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
-        response.Headers.Location.ToString().ShouldStartWith("https://client1/callback");
-
-        var authorization = new AuthorizeResponse(response.Headers.Location.ToString());
-        authorization.IsError.ShouldBeFalse();
-
-        var codeRequest = new AuthorizationCodeTokenRequest
-        {
-            Address = IdentityServerPipeline.TokenEndpoint,
-            ClientId = "client1",
-            ClientSecret = "secret",
-            Code = authorization.Code,
-            RedirectUri = "https://client1/callback",
-        };
-        codeRequest.Headers.Add("DPoP", CreateDPoPProofToken());
-
-        var codeResponse = await _mockPipeline.BackChannelClient.RequestAuthorizationCodeTokenAsync(codeRequest);
-        codeResponse.IsError.ShouldBeFalse();
-        codeResponse.TokenType.ShouldBe("DPoP");
-        GetJKTFromAccessToken(codeResponse).ShouldBe(_JKT);
-
-        var rtRequest = new RefreshTokenRequest
-        {
-            Address = IdentityServerPipeline.TokenEndpoint,
-            ClientId = "client1",
-            ClientSecret = "secret",
-            RefreshToken = codeResponse.RefreshToken
-        };
-        // no DPoP header passed here
-
-        var rtResponse = await _mockPipeline.BackChannelClient.RequestRefreshTokenAsync(rtRequest);
+        var rtRequest = CreateRefreshTokenRequest(codeResponse, omitDPoPProof: true);
+        var rtResponse = await Pipeline.BackChannelClient.RequestRefreshTokenAsync(rtRequest);
         rtResponse.IsError.ShouldBeTrue();
         rtResponse.Error.ShouldBe("invalid_request");
     }
@@ -523,102 +233,29 @@ public class DPoPTokenEndpointTests
     [Trait("Category", Category)]
     public async Task public_client_dpop_proof_should_be_required_on_renewal()
     {
-        await _mockPipeline.LoginAsync("bob");
+        var codeRequest = await CreateAuthCodeTokenRequestAsync(clientId: "client2");
+        var codeResponse = await Pipeline.BackChannelClient.RequestAuthorizationCodeTokenAsync(codeRequest);
+        codeResponse.ShouldHaveDPoPThumbprint(JKT);
 
-        _mockPipeline.BrowserClient.AllowAutoRedirect = false;
-
-        var url = _mockPipeline.CreateAuthorizeUrl(
-            clientId: "client2",
-            responseType: "code",
-            responseMode: "query",
-            scope: "openid scope2 offline_access",
-            redirectUri: "https://client2/callback");
-        var response = await _mockPipeline.BrowserClient.GetAsync(url);
-
-        response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
-        response.Headers.Location.ToString().ShouldStartWith("https://client2/callback");
-
-        var authorization = new AuthorizeResponse(response.Headers.Location.ToString());
-        authorization.IsError.ShouldBeFalse();
-
-        var codeRequest = new AuthorizationCodeTokenRequest
-        {
-            Address = IdentityServerPipeline.TokenEndpoint,
-            ClientId = "client2",
-            ClientSecret = "secret",
-            Code = authorization.Code,
-            RedirectUri = "https://client2/callback",
-        };
-        codeRequest.Headers.Add("DPoP", CreateDPoPProofToken());
-
-        var codeResponse = await _mockPipeline.BackChannelClient.RequestAuthorizationCodeTokenAsync(codeRequest);
-        codeResponse.IsError.ShouldBeFalse();
-        codeResponse.TokenType.ShouldBe("DPoP");
-        GetJKTFromAccessToken(codeResponse).ShouldBe(_JKT);
-
-        var rtRequest = new RefreshTokenRequest
-        {
-            Address = IdentityServerPipeline.TokenEndpoint,
-            ClientId = "client2",
-            ClientSecret = "secret",
-            RefreshToken = codeResponse.RefreshToken
-        };
-        // no DPoP header passed here
-
-        var rtResponse = await _mockPipeline.BackChannelClient.RequestRefreshTokenAsync(rtRequest);
+        var rtRequest = CreateRefreshTokenRequest(codeResponse, clientId: "client2", omitDPoPProof: true);
+        var rtResponse = await Pipeline.BackChannelClient.RequestRefreshTokenAsync(rtRequest);
         rtResponse.IsError.ShouldBeTrue();
         rtResponse.Error.ShouldBe("invalid_request");
     }
 
     [Fact]
     [Trait("Category", Category)]
-    public async Task no_dpop_should_not_be_able_to_start_on_renewal()
+    public async Task dpop_should_not_be_able_to_start_on_renewal()
     {
-        await _mockPipeline.LoginAsync("bob");
-
-        _mockPipeline.BrowserClient.AllowAutoRedirect = false;
-
-        var url = _mockPipeline.CreateAuthorizeUrl(
-            clientId: "client1",
-            responseType: "code",
-            responseMode: "query",
-            scope: "openid scope1 offline_access",
-            redirectUri: "https://client1/callback");
-        var response = await _mockPipeline.BrowserClient.GetAsync(url);
-
-        response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
-        response.Headers.Location.ToString().ShouldStartWith("https://client1/callback");
-
-        var authorization = new AuthorizeResponse(response.Headers.Location.ToString());
-        authorization.IsError.ShouldBeFalse();
-
-        var codeRequest = new AuthorizationCodeTokenRequest
-        {
-            Address = IdentityServerPipeline.TokenEndpoint,
-            ClientId = "client1",
-            ClientSecret = "secret",
-            Code = authorization.Code,
-            RedirectUri = "https://client1/callback",
-        };
-
-        // no dpop here
-
-        var codeResponse = await _mockPipeline.BackChannelClient.RequestAuthorizationCodeTokenAsync(codeRequest);
+        // Initial code flow doesn't use dpop
+        var codeRequest = await CreateAuthCodeTokenRequestAsync(omitDPoPProof: true);
+        var codeResponse = await Pipeline.BackChannelClient.RequestAuthorizationCodeTokenAsync(codeRequest);
         codeResponse.IsError.ShouldBeFalse();
 
-        var rtRequest = new RefreshTokenRequest
-        {
-            Address = IdentityServerPipeline.TokenEndpoint,
-            ClientId = "client1",
-            ClientSecret = "secret",
-            RefreshToken = codeResponse.RefreshToken
-        };
+        // Subsequent refresh token request tries to use dpop
+        var rtRequest = CreateRefreshTokenRequest(codeResponse, omitDPoPProof: false);
 
-        CreateNewRSAKey();
-        // now start dpop here
-        rtRequest.Headers.Add("DPoP", CreateDPoPProofToken());
-
-        var rtResponse = await _mockPipeline.BackChannelClient.RequestRefreshTokenAsync(rtRequest);
+        var rtResponse = await Pipeline.BackChannelClient.RequestRefreshTokenAsync(rtRequest);
         rtResponse.IsError.ShouldBeTrue();
     }
 
@@ -626,107 +263,29 @@ public class DPoPTokenEndpointTests
     [Trait("Category", Category)]
     public async Task confidential_client_should_be_able_to_use_different_dpop_key_for_refresh_token_request()
     {
-        await _mockPipeline.LoginAsync("bob");
-
-        _mockPipeline.BrowserClient.AllowAutoRedirect = false;
-
-        var url = _mockPipeline.CreateAuthorizeUrl(
-            clientId: "client1",
-            responseType: "code",
-            responseMode: "query",
-            scope: "openid scope1 offline_access",
-            redirectUri: "https://client1/callback");
-        var response = await _mockPipeline.BrowserClient.GetAsync(url);
-
-        response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
-        response.Headers.Location.ToString().ShouldStartWith("https://client1/callback");
-
-        var authorization = new AuthorizeResponse(response.Headers.Location.ToString());
-        authorization.IsError.ShouldBeFalse();
-
-        var codeRequest = new AuthorizationCodeTokenRequest
-        {
-            Address = IdentityServerPipeline.TokenEndpoint,
-            ClientId = "client1",
-            ClientSecret = "secret",
-            Code = authorization.Code,
-            RedirectUri = "https://client1/callback",
-        };
-        codeRequest.Headers.Add("DPoP", CreateDPoPProofToken());
-
-        var codeResponse = await _mockPipeline.BackChannelClient.RequestAuthorizationCodeTokenAsync(codeRequest);
-        codeResponse.IsError.ShouldBeFalse();
-        codeResponse.TokenType.ShouldBe("DPoP");
-        GetJKTFromAccessToken(codeResponse).ShouldBe(_JKT);
-
-        var rtRequest = new RefreshTokenRequest
-        {
-            Address = IdentityServerPipeline.TokenEndpoint,
-            ClientId = "client1",
-            ClientSecret = "secret",
-            RefreshToken = codeResponse.RefreshToken
-        };
+        var codeRequest = await CreateAuthCodeTokenRequestAsync();
+        var codeResponse = await Pipeline.BackChannelClient.RequestAuthorizationCodeTokenAsync(codeRequest);
+        codeResponse.ShouldHaveDPoPThumbprint(JKT);
 
         CreateNewRSAKey();
-        rtRequest.Headers.Add("DPoP", CreateDPoPProofToken());
+        var rtRequest = CreateRefreshTokenRequest(codeResponse);
 
-        var rtResponse = await _mockPipeline.BackChannelClient.RequestRefreshTokenAsync(rtRequest);
-        rtResponse.IsError.ShouldBeFalse();
-        rtResponse.TokenType.ShouldBe("DPoP");
-        GetJKTFromAccessToken(rtResponse).ShouldBe(_JKT);
+        var rtResponse = await Pipeline.BackChannelClient.RequestRefreshTokenAsync(rtRequest);
+        rtResponse.ShouldHaveDPoPThumbprint(JKT);
     }
 
     [Fact]
     [Trait("Category", Category)]
     public async Task public_client_should_not_be_able_to_use_different_dpop_key_for_refresh_token_request()
     {
-        await _mockPipeline.LoginAsync("bob");
-
-        _mockPipeline.BrowserClient.AllowAutoRedirect = false;
-
-        var url = _mockPipeline.CreateAuthorizeUrl(
-            clientId: "client2",
-            responseType: "code",
-            responseMode: "query",
-            scope: "openid scope2 offline_access",
-            redirectUri: "https://client2/callback");
-        var response = await _mockPipeline.BrowserClient.GetAsync(url);
-
-        response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
-        response.Headers.Location.ToString().ShouldStartWith("https://client2/callback");
-
-        var authorization = new AuthorizeResponse(response.Headers.Location.ToString());
-        authorization.IsError.ShouldBeFalse();
-
-        var codeRequest = new AuthorizationCodeTokenRequest
-        {
-            Address = IdentityServerPipeline.TokenEndpoint,
-            ClientId = "client2",
-            Code = authorization.Code,
-            RedirectUri = "https://client2/callback",
-        };
-        codeRequest.Headers.Add("DPoP", CreateDPoPProofToken());
-
-        var codeResponse = await _mockPipeline.BackChannelClient.RequestAuthorizationCodeTokenAsync(codeRequest);
-        codeResponse.IsError.ShouldBeFalse();
-        codeResponse.TokenType.ShouldBe("DPoP");
-        GetJKTFromAccessToken(codeResponse).ShouldBe(_JKT);
-
-        var rtRequest = new RefreshTokenRequest
-        {
-            Address = IdentityServerPipeline.TokenEndpoint,
-            ClientId = "client2",
-            RefreshToken = codeResponse.RefreshToken
-        };
-
-        var key = CryptoHelper.CreateRsaSecurityKey();
-        var jwk = JsonWebKeyConverter.ConvertFromRSASecurityKey(key);
-        _privateJWK = JsonSerializer.Serialize(jwk);
+        var codeRequest = await CreateAuthCodeTokenRequestAsync(clientId: "client2");
+        var codeResponse = await Pipeline.BackChannelClient.RequestAuthorizationCodeTokenAsync(codeRequest);
+        codeResponse.ShouldHaveDPoPThumbprint(JKT);
 
         CreateNewRSAKey();
-        rtRequest.Headers.Add("DPoP", CreateDPoPProofToken());
+        var rtRequest = CreateRefreshTokenRequest(codeResponse, clientId: "client2");
 
-        var rtResponse = await _mockPipeline.BackChannelClient.RequestRefreshTokenAsync(rtRequest);
+        var rtResponse = await Pipeline.BackChannelClient.RequestRefreshTokenAsync(rtRequest);
         rtResponse.IsError.ShouldBeTrue();
         rtResponse.Error.ShouldBe("invalid_dpop_proof");
     }
@@ -735,66 +294,17 @@ public class DPoPTokenEndpointTests
     [Trait("Category", Category)]
     public async Task public_client_using_same_dpop_key_for_refresh_token_request_should_succeed()
     {
-        await _mockPipeline.LoginAsync("bob");
+        var codeRequest = await CreateAuthCodeTokenRequestAsync(clientId: "client2");
+        var codeResponse = await Pipeline.BackChannelClient.RequestAuthorizationCodeTokenAsync(codeRequest);
+        codeResponse.ShouldHaveDPoPThumbprint(JKT);
 
-        _mockPipeline.BrowserClient.AllowAutoRedirect = false;
+        var firstRefreshRequest = CreateRefreshTokenRequest(codeResponse, clientId: "client2");
+        var firstRefreshResponse = await Pipeline.BackChannelClient.RequestRefreshTokenAsync(firstRefreshRequest);
+        firstRefreshResponse.ShouldHaveDPoPThumbprint(JKT);
 
-        var url = _mockPipeline.CreateAuthorizeUrl(
-            clientId: "client2",
-            responseType: "code",
-            responseMode: "query",
-            scope: "openid scope2 offline_access",
-            redirectUri: "https://client2/callback");
-        var response = await _mockPipeline.BrowserClient.GetAsync(url);
-
-        response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
-        response.Headers.Location.ToString().ShouldStartWith("https://client2/callback");
-
-        var authorization = new AuthorizeResponse(response.Headers.Location.ToString());
-        authorization.IsError.ShouldBeFalse();
-
-        var codeRequest = new AuthorizationCodeTokenRequest
-        {
-            Address = IdentityServerPipeline.TokenEndpoint,
-            ClientId = "client2",
-            Code = authorization.Code,
-            RedirectUri = "https://client2/callback",
-        };
-        codeRequest.Headers.Add("DPoP", CreateDPoPProofToken());
-
-        var codeResponse = await _mockPipeline.BackChannelClient.RequestAuthorizationCodeTokenAsync(codeRequest);
-        codeResponse.IsError.ShouldBeFalse();
-        codeResponse.TokenType.ShouldBe("DPoP");
-        GetJKTFromAccessToken(codeResponse).ShouldBe(_JKT);
-
-        var firstRefreshRequest = new RefreshTokenRequest
-        {
-            Address = IdentityServerPipeline.TokenEndpoint,
-            ClientId = "client2",
-            RefreshToken = codeResponse.RefreshToken
-        };
-        firstRefreshRequest.Headers.Add("DPoP", CreateDPoPProofToken());
-
-        var firstRefreshResponse = await _mockPipeline.BackChannelClient.RequestRefreshTokenAsync(firstRefreshRequest);
-        firstRefreshResponse.IsError.ShouldBeFalse();
-        firstRefreshResponse.TokenType.ShouldBe("DPoP");
-        GetJKTFromAccessToken(firstRefreshResponse).ShouldBe(_JKT);
-
-        var secondRefreshRequest = new RefreshTokenRequest
-        {
-            Address = IdentityServerPipeline.TokenEndpoint,
-            ClientId = "client2",
-            RefreshToken = codeResponse.RefreshToken
-        };
-        secondRefreshRequest.Headers.Add("DPoP", CreateDPoPProofToken());
-
-        firstRefreshRequest.Headers.GetValues("DPoP").FirstOrDefault().ShouldNotBe(
-            secondRefreshRequest.Headers.GetValues("DPoP").FirstOrDefault());
-
-        var secondRefreshResponse = await _mockPipeline.BackChannelClient.RequestRefreshTokenAsync(secondRefreshRequest);
-        secondRefreshResponse.IsError.ShouldBeFalse(secondRefreshResponse.Error);
-        secondRefreshResponse.TokenType.ShouldBe("DPoP");
-        GetJKTFromAccessToken(secondRefreshResponse).ShouldBe(_JKT);
+        var secondRefreshRequest = CreateRefreshTokenRequest(codeResponse, clientId: "client2");
+        var secondRefreshResponse = await Pipeline.BackChannelClient.RequestRefreshTokenAsync(secondRefreshRequest);
+        secondRefreshResponse.ShouldHaveDPoPThumbprint(JKT);
     }
 
 
@@ -802,89 +312,28 @@ public class DPoPTokenEndpointTests
     [Trait("Category", Category)]
     public async Task missing_proof_token_when_required_on_refresh_token_request_should_fail()
     {
-        _dpopConfidentialClient.RequireDPoP = true;
+        ConfidentialClient.RequireDPoP = true;
 
-        await _mockPipeline.LoginAsync("bob");
+        var codeRequest = await CreateAuthCodeTokenRequestAsync();
+        var codeResponse = await Pipeline.BackChannelClient.RequestAuthorizationCodeTokenAsync(codeRequest);
+        codeResponse.ShouldHaveDPoPThumbprint(JKT);
 
-        _mockPipeline.BrowserClient.AllowAutoRedirect = false;
-
-        var url = _mockPipeline.CreateAuthorizeUrl(
-            clientId: "client1",
-            responseType: "code",
-            responseMode: "query",
-            scope: "openid scope1 offline_access",
-            redirectUri: "https://client1/callback");
-        var response = await _mockPipeline.BrowserClient.GetAsync(url);
-
-        response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
-        response.Headers.Location.ToString().ShouldStartWith("https://client1/callback");
-
-        var authorization = new AuthorizeResponse(response.Headers.Location.ToString());
-        authorization.IsError.ShouldBeFalse();
-
-        var codeRequest = new AuthorizationCodeTokenRequest
-        {
-            Address = IdentityServerPipeline.TokenEndpoint,
-            ClientId = "client1",
-            ClientSecret = "secret",
-            Code = authorization.Code,
-            RedirectUri = "https://client1/callback",
-        };
-        codeRequest.Headers.Add("DPoP", CreateDPoPProofToken());
-
-        var codeResponse = await _mockPipeline.BackChannelClient.RequestAuthorizationCodeTokenAsync(codeRequest);
-        codeResponse.IsError.ShouldBeFalse();
-        codeResponse.TokenType.ShouldBe("DPoP");
-        GetJKTFromAccessToken(codeResponse).ShouldBe(_JKT);
-
-        var rtRequest = new RefreshTokenRequest
-        {
-            Address = IdentityServerPipeline.TokenEndpoint,
-            ClientId = "client1",
-            ClientSecret = "secret",
-            RefreshToken = codeResponse.RefreshToken
-        };
-
-        var rtResponse = await _mockPipeline.BackChannelClient.RequestRefreshTokenAsync(rtRequest);
+        var rtRequest = CreateRefreshTokenRequest(codeResponse, omitDPoPProof: true);
+        var rtResponse = await Pipeline.BackChannelClient.RequestRefreshTokenAsync(rtRequest);
         rtResponse.IsError.ShouldBeTrue();
         rtResponse.Error.ShouldBe("invalid_dpop_proof");
     }
 
-    [Fact]
+
+    [Theory]
+    [InlineData(AccessTokenType.Reference)]
+    [InlineData(AccessTokenType.Jwt)]
     [Trait("Category", Category)]
-    public async Task valid_dpop_request_using_reference_token_at_introspection_should_return_binding_information()
+    public async Task valid_dpop_request_at_introspection_should_return_binding_information(AccessTokenType accessTokenType)
     {
-        _dpopConfidentialClient.AccessTokenType = AccessTokenType.Reference;
-
-        await _mockPipeline.LoginAsync("bob");
-
-        _mockPipeline.BrowserClient.AllowAutoRedirect = false;
-
-        var url = _mockPipeline.CreateAuthorizeUrl(
-            clientId: "client1",
-            responseType: "code",
-            responseMode: "query",
-            scope: "openid scope1 offline_access",
-            redirectUri: "https://client1/callback");
-        var response = await _mockPipeline.BrowserClient.GetAsync(url);
-
-        response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
-        response.Headers.Location.ToString().ShouldStartWith("https://client1/callback");
-
-        var authorization = new AuthorizeResponse(response.Headers.Location.ToString());
-        authorization.IsError.ShouldBeFalse();
-
-        var codeRequest = new AuthorizationCodeTokenRequest
-        {
-            Address = IdentityServerPipeline.TokenEndpoint,
-            ClientId = "client1",
-            ClientSecret = "secret",
-            Code = authorization.Code,
-            RedirectUri = "https://client1/callback",
-        };
-        codeRequest.Headers.Add("DPoP", CreateDPoPProofToken());
-
-        var codeResponse = await _mockPipeline.BackChannelClient.RequestAuthorizationCodeTokenAsync(codeRequest);
+        ConfidentialClient.AccessTokenType = accessTokenType;
+        var codeRequest = await CreateAuthCodeTokenRequestAsync();
+        var codeResponse = await Pipeline.BackChannelClient.RequestAuthorizationCodeTokenAsync(codeRequest);
 
         var introspectionRequest = new TokenIntrospectionRequest
         {
@@ -893,107 +342,26 @@ public class DPoPTokenEndpointTests
             ClientSecret = "secret",
             Token = codeResponse.AccessToken,
         };
-        var introspectionResponse = await _mockPipeline.BackChannelClient.IntrospectTokenAsync(introspectionRequest);
+        var introspectionResponse = await Pipeline.BackChannelClient.IntrospectTokenAsync(introspectionRequest);
         introspectionResponse.IsError.ShouldBeFalse();
-        GetJKTFromCnfClaim(introspectionResponse.Claims).ShouldBe(_JKT);
-    }
-
-    [Fact]
-    [Trait("Category", Category)]
-    public async Task valid_dpop_request_using_jwt_at_introspection_should_return_binding_information()
-    {
-        await _mockPipeline.LoginAsync("bob");
-
-        _mockPipeline.BrowserClient.AllowAutoRedirect = false;
-
-        var url = _mockPipeline.CreateAuthorizeUrl(
-            clientId: "client1",
-            responseType: "code",
-            responseMode: "query",
-            scope: "openid scope1 offline_access",
-            redirectUri: "https://client1/callback");
-        var response = await _mockPipeline.BrowserClient.GetAsync(url);
-
-        response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
-        response.Headers.Location.ToString().ShouldStartWith("https://client1/callback");
-
-        var authorization = new AuthorizeResponse(response.Headers.Location.ToString());
-        authorization.IsError.ShouldBeFalse();
-
-        var codeRequest = new AuthorizationCodeTokenRequest
-        {
-            Address = IdentityServerPipeline.TokenEndpoint,
-            ClientId = "client1",
-            ClientSecret = "secret",
-            Code = authorization.Code,
-            RedirectUri = "https://client1/callback",
-        };
-        codeRequest.Headers.Add("DPoP", CreateDPoPProofToken());
-
-        var codeResponse = await _mockPipeline.BackChannelClient.RequestAuthorizationCodeTokenAsync(codeRequest);
-
-        var introspectionRequest = new TokenIntrospectionRequest
-        {
-            Address = IdentityServerPipeline.IntrospectionEndpoint,
-            ClientId = "api1",
-            ClientSecret = "secret",
-            Token = codeResponse.AccessToken,
-        };
-        var introspectionResponse = await _mockPipeline.BackChannelClient.IntrospectTokenAsync(introspectionRequest);
-        introspectionResponse.IsError.ShouldBeFalse();
-        GetJKTFromCnfClaim(introspectionResponse.Claims).ShouldBe(_JKT);
+        GetJKTFromCnfClaim(introspectionResponse.Claims).ShouldBe(JKT);
     }
 
     [Fact]
     [Trait("Category", Category)]
     public async Task matching_dpop_key_thumbprint_on_authorize_endpoint_and_token_endpoint_should_succeed()
     {
-        await _mockPipeline.LoginAsync("bob");
+        var codeRequest = await CreateAuthCodeTokenRequestAsync(dpopJkt: JKT);
 
-        _mockPipeline.BrowserClient.AllowAutoRedirect = false;
-
-        var url = _mockPipeline.CreateAuthorizeUrl(
-            clientId: "client1",
-            responseType: "code",
-            responseMode: "query",
-            scope: "openid scope1 offline_access",
-            redirectUri: "https://client1/callback",
-            extra: new
-            {
-                dpop_jkt = _JKT
-            });
-        var response = await _mockPipeline.BrowserClient.GetAsync(url);
-
-        response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
-        response.Headers.Location.ToString().ShouldStartWith("https://client1/callback");
-
-        var authorization = new AuthorizeResponse(response.Headers.Location.ToString());
-        authorization.IsError.ShouldBeFalse();
-
-        var codeRequest = new AuthorizationCodeTokenRequest
-        {
-            Address = IdentityServerPipeline.TokenEndpoint,
-            ClientId = "client1",
-            ClientSecret = "secret",
-            Code = authorization.Code,
-            RedirectUri = "https://client1/callback",
-        };
-        codeRequest.Headers.Add("DPoP", CreateDPoPProofToken());
-
-        var codeResponse = await _mockPipeline.BackChannelClient.RequestAuthorizationCodeTokenAsync(codeRequest);
-        codeResponse.IsError.ShouldBeFalse();
-        GetJKTFromAccessToken(codeResponse).ShouldBe(_JKT);
+        var codeResponse = await Pipeline.BackChannelClient.RequestAuthorizationCodeTokenAsync(codeRequest);
+        codeResponse.ShouldHaveDPoPThumbprint(JKT);
     }
 
     [Fact]
     [Trait("Category", Category)]
     public async Task dpop_key_thumbprint_too_long_should_fail()
     {
-        await _mockPipeline.LoginAsync("bob");
-
-        _mockPipeline.BrowserClient.AllowAutoRedirect = true;
-
-        var url = _mockPipeline.CreateAuthorizeUrl(
+        var url = Pipeline.CreateAuthorizeUrl(
             clientId: "client1",
             responseType: "code",
             responseMode: "query",
@@ -1003,48 +371,18 @@ public class DPoPTokenEndpointTests
             {
                 dpop_jkt = new string('x', 101)
             });
-        var response = await _mockPipeline.BrowserClient.GetAsync(url);
+        await Pipeline.BrowserClient.GetAsync(url);
 
-        _mockPipeline.ErrorWasCalled.ShouldBeTrue();
+        Pipeline.ErrorWasCalled.ShouldBeTrue();
     }
 
     [Fact]
     [Trait("Category", Category)]
     public async Task mismatched_dpop_key_thumbprint_on_authorize_endpoint_and_token_endpoint_should_fail()
     {
-        await _mockPipeline.LoginAsync("bob");
+        var codeRequest = await CreateAuthCodeTokenRequestAsync(dpopJkt: "invalid");
 
-        _mockPipeline.BrowserClient.AllowAutoRedirect = false;
-
-        var url = _mockPipeline.CreateAuthorizeUrl(
-            clientId: "client1",
-            responseType: "code",
-            responseMode: "query",
-            scope: "openid scope1 offline_access",
-            redirectUri: "https://client1/callback",
-            extra: new
-            {
-                dpop_jkt = "invalid"
-            });
-        var response = await _mockPipeline.BrowserClient.GetAsync(url);
-
-        response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
-        response.Headers.Location.ToString().ShouldStartWith("https://client1/callback");
-
-        var authorization = new AuthorizeResponse(response.Headers.Location.ToString());
-        authorization.IsError.ShouldBeFalse();
-
-        var codeRequest = new AuthorizationCodeTokenRequest
-        {
-            Address = IdentityServerPipeline.TokenEndpoint,
-            ClientId = "client1",
-            ClientSecret = "secret",
-            Code = authorization.Code,
-            RedirectUri = "https://client1/callback",
-        };
-        codeRequest.Headers.Add("DPoP", CreateDPoPProofToken());
-
-        var codeResponse = await _mockPipeline.BackChannelClient.RequestAuthorizationCodeTokenAsync(codeRequest);
+        var codeResponse = await Pipeline.BackChannelClient.RequestAuthorizationCodeTokenAsync(codeRequest);
         codeResponse.IsError.ShouldBeTrue();
         codeResponse.Error.ShouldBe("invalid_dpop_proof");
     }
@@ -1053,62 +391,29 @@ public class DPoPTokenEndpointTests
     [Trait("Category", Category)]
     public async Task server_issued_nonce_should_be_emitted()
     {
-        string nonce = default;
+        var expectedNonce = "nonce";
 
-        _mockPipeline.OnPostConfigureServices += services =>
+        Pipeline.OnPostConfigureServices += services =>
         {
             services.AddSingleton<MockDPoPProofValidator>();
             services.AddSingleton<IDPoPProofValidator>(sp =>
             {
                 var mockValidator = sp.GetRequiredService<MockDPoPProofValidator>();
-                mockValidator.ServerIssuedNonce = nonce;
+                mockValidator.ServerIssuedNonce = expectedNonce;
                 return mockValidator;
             });
         };
-        _mockPipeline.Initialize();
+        Pipeline.Initialize();
 
-        await _mockPipeline.LoginAsync("bob");
+        var codeRequest = await CreateAuthCodeTokenRequestAsync();
 
-        _mockPipeline.BrowserClient.AllowAutoRedirect = false;
-
-        var url = _mockPipeline.CreateAuthorizeUrl(
-            clientId: "client1",
-            responseType: "code",
-            responseMode: "query",
-            scope: "openid scope1 offline_access",
-            redirectUri: "https://client1/callback",
-            extra: new
-            {
-                dpop_jkt = "invalid"
-            });
-        var response = await _mockPipeline.BrowserClient.GetAsync(url);
-
-        response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
-        response.Headers.Location.ToString().ShouldStartWith("https://client1/callback");
-
-        var authorization = new AuthorizeResponse(response.Headers.Location.ToString());
-        authorization.IsError.ShouldBeFalse();
-
-        var codeRequest = new AuthorizationCodeTokenRequest
-        {
-            Address = IdentityServerPipeline.TokenEndpoint,
-            ClientId = "client1",
-            ClientSecret = "secret",
-            Code = authorization.Code,
-            RedirectUri = "https://client1/callback",
-        };
-        codeRequest.Headers.Add("DPoP", CreateDPoPProofToken());
-
-        nonce = "nonce";
-
-        var codeResponse = await _mockPipeline.BackChannelClient.RequestAuthorizationCodeTokenAsync(codeRequest);
+        var codeResponse = await Pipeline.BackChannelClient.RequestAuthorizationCodeTokenAsync(codeRequest);
         codeResponse.IsError.ShouldBeTrue();
         codeResponse.Error.ShouldBe("invalid_dpop_proof");
-        codeResponse.HttpResponse.Headers.GetValues("DPoP-Nonce").Single().ShouldBe("nonce");
-        // TODO: make IdentityModel expose the response headers?
+        codeResponse.DPoPNonce.ShouldBe(expectedNonce);
     }
 
-    public class MockDPoPProofValidator : DefaultDPoPProofValidator
+    internal class MockDPoPProofValidator : DefaultDPoPProofValidator
     {
         public MockDPoPProofValidator(IdentityServerOptions options, IReplayCache replayCache, IClock clock, Microsoft.AspNetCore.DataProtection.IDataProtectionProvider dataProtectionProvider, ILogger<DefaultDPoPProofValidator> logger) : base(options, replayCache, clock, dataProtectionProvider, logger)
         {
@@ -1129,60 +434,38 @@ public class DPoPTokenEndpointTests
         }
     }
 
+    public enum KeyType { RSA, EC }
 
     [Theory]
-    [InlineData("RS256")]
-    [InlineData("RS384")]
-    [InlineData("RS512")]
-    [InlineData("PS256")]
-    [InlineData("PS384")]
-    [InlineData("PS512")]
+    [InlineData("RS256", KeyType.RSA)]
+    [InlineData("RS384", KeyType.RSA)]
+    [InlineData("RS512", KeyType.RSA)]
+    [InlineData("PS256", KeyType.RSA)]
+    [InlineData("PS384", KeyType.RSA)]
+    [InlineData("PS512", KeyType.RSA)]
+    [InlineData("ES256", KeyType.EC)]
+    [InlineData("ES384", KeyType.EC)]
+    [InlineData("ES512", KeyType.EC)]
     [Trait("Category", Category)]
-    public async Task different_rsa_proof_tokens_should_work(string alg)
+    public async Task all_supported_signing_algorithms_should_work(string alg, KeyType keyType)
     {
-        CreateNewRSAKey();
-        var proofToken = CreateDPoPProofToken(alg);
-
-        var request = new ClientCredentialsTokenRequest
+        if (keyType == KeyType.RSA)
         {
-            Address = IdentityServerPipeline.TokenEndpoint,
-            ClientId = "client1",
-            ClientSecret = "secret",
-            Scope = "scope1",
-        };
-        request.Headers.Add("DPoP", proofToken);
+            CreateNewRSAKey();
+        }
+        else
+        {
+            CreateNewECKey();
+        }
 
-        var response = await _mockPipeline.BackChannelClient.RequestClientCredentialsTokenAsync(request);
+        var proofToken = CreateDPoPProofToken(alg);
+        var request = CreateClientCredentialsTokenRequest(proofToken);
+
+        var response = await Pipeline.BackChannelClient.RequestClientCredentialsTokenAsync(request);
+
         response.IsError.ShouldBeFalse();
         response.TokenType.ShouldBe("DPoP");
         var jkt = GetJKTFromAccessToken(response);
-        jkt.ShouldBe(_JKT);
+        jkt.ShouldBe(JKT);
     }
-
-    [Theory]
-    [InlineData("ES256")]
-    [InlineData("ES384")]
-    [InlineData("ES512")]
-    [Trait("Category", Category)]
-    public async Task different_ps_proof_tokens_should_work(string alg)
-    {
-        CreateNewECKey();
-        var proofToken = CreateDPoPProofToken(alg);
-
-        var request = new ClientCredentialsTokenRequest
-        {
-            Address = IdentityServerPipeline.TokenEndpoint,
-            ClientId = "client1",
-            ClientSecret = "secret",
-            Scope = "scope1",
-        };
-        request.Headers.Add("DPoP", proofToken);
-
-        var response = await _mockPipeline.BackChannelClient.RequestClientCredentialsTokenAsync(request);
-        response.IsError.ShouldBeFalse();
-        response.TokenType.ShouldBe("DPoP");
-        var jkt = GetJKTFromAccessToken(response);
-        jkt.ShouldBe(_JKT);
-    }
-
 }

--- a/identity-server/test/IdentityServer.UnitTests/Validation/DPoPProofValidatorTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Validation/DPoPProofValidatorTests.cs
@@ -854,7 +854,7 @@ public class DPoPProofValidatorTests
         result = await _subject.ValidateAsync(_context);
 
         result.IsError.ShouldBeTrue();
-        result.Error.ShouldBe("invalid_dpop_proof");
+        result.Error.ShouldBe("use_dpop_nonce");
         result.ServerIssuedNonce.ShouldNotBeNullOrEmpty();
     }
 
@@ -878,7 +878,7 @@ public class DPoPProofValidatorTests
         result = await _subject.ValidateAsync(_context);
 
         result.IsError.ShouldBeTrue();
-        result.Error.ShouldBe("invalid_dpop_proof");
+        result.Error.ShouldBe("use_dpop_nonce");
         result.ServerIssuedNonce.ShouldNotBeNullOrEmpty();
 
 
@@ -891,7 +891,7 @@ public class DPoPProofValidatorTests
         result = await _subject.ValidateAsync(_context);
 
         result.IsError.ShouldBeTrue();
-        result.Error.ShouldBe("invalid_dpop_proof");
+        result.Error.ShouldBe("use_dpop_nonce");
         result.ServerIssuedNonce.ShouldNotBeNullOrEmpty();
     }
 }


### PR DESCRIPTION
This PR adds support for the DPoP header at the PAR endpoint.

The DPoP header at the PAR endpoint is used to bind authorization codes to the client's dpop key. This can also be done by (and we already support) passing the dpop_jkt parameter.

This change improves our support for RFC 9449, as accepting the DPoP header is a requirement for compliance now that we implement PAR (section 10.1). We also now enforce the rule that if both the header and the dpop_jkt parameter are passed, they must be consistent. 

This PR also significantly refactors the existing DPOP integration tests to make them easier to read and reuse. Most behaviors are the same whether authorize parameters are pushed or not, and either or both of the dpop binding mechanisms can be used with PAR, so we want to run through most of those tests in several ways.

This PR updates our error responses to consistently return "use_dpop_nonce" as the error when a request fails and needs a new nonce, even if an invalid or expired nonce was passed.