### PR TITLE
Harden default logging filters for PAR and Authorize endpoints (7.0)

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
-    <clear />
-    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/src/IdentityServer/Configuration/DependencyInjection/Options/LoggingOptions.cs
+++ b/src/IdentityServer/Configuration/DependencyInjection/Options/LoggingOptions.cs
@@ -51,6 +51,9 @@ public class LoggingOptions
     public ICollection<string> AuthorizeRequestSensitiveValuesFilter { get; set; } = 
         new HashSet<string>
         {
+            // Secrets and assertions may be passed to the authorize endpoint via PAR
+            OidcConstants.TokenRequest.ClientSecret,
+            OidcConstants.TokenRequest.ClientAssertion,
             OidcConstants.AuthorizeRequest.IdTokenHint
         };
 
@@ -58,11 +61,15 @@ public class LoggingOptions
     /// Gets or sets the collection of keys that will be used to redact sensitive values from a pushed authorization request log.
     /// </summary>
     /// <remarks>Please be aware that initializing this property could expose sensitive information in your logs.</remarks>
+    /// <remarks>Note that pushed authorization parameters are eventually handled by the authorize request pipeline.
+    /// In most cases, changes to this collection should also be made to <see cref="AuthorizeRequestSensitiveValuesFilter"/>
+    /// </remarks>
     public ICollection<string> PushedAuthorizationSensitiveValuesFilter { get; set; } =
         new HashSet<string>
         {
             OidcConstants.TokenRequest.ClientSecret,
-            OidcConstants.TokenRequest.ClientAssertion
+            OidcConstants.TokenRequest.ClientAssertion,
+            OidcConstants.AuthorizeRequest.IdTokenHint
         };
 
     /// <summary>

--- a/test/IdentityServer.IntegrationTests/Common/IdentityServerPipeline.cs
+++ b/test/IdentityServer.IntegrationTests/Common/IdentityServerPipeline.cs
@@ -21,6 +21,7 @@ using Duende.IdentityServer.Services;
 using Duende.IdentityServer.Test;
 using FluentAssertions;
 using IdentityModel.Client;
+using IdentityServer.IntegrationTests.Common;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -75,6 +76,9 @@ public class IdentityServerPipeline
     public MockMessageHandler BackChannelMessageHandler { get; set; } = new MockMessageHandler();
     public MockMessageHandler JwtRequestMessageHandler { get; set; } = new MockMessageHandler();
 
+    public MockLogger MockLogger { get; set; } = MockLogger.Create();
+
+    
     public event Action<IServiceCollection> OnPreConfigureServices = services => { };
     public event Action<IServiceCollection> OnPostConfigureServices = services => { };
     public event Action<IApplicationBuilder> OnPreConfigure = app => { };
@@ -103,7 +107,10 @@ public class IdentityServerPipeline
 
         if (enableLogging)
         {
-            builder.ConfigureLogging((ctx, b) => b.AddConsole());
+            // Configure logging so that the logger provider will always use our mock logger
+            // The MockLogger allows us to verify that particular messages were logged.
+            builder.ConfigureLogging((ctx, b) =>
+                b.Services.AddSingleton<ILoggerProvider>(new MockLoggerProvider(MockLogger)));
         }
 
         Server = new TestServer(builder);

--- a/test/IdentityServer.IntegrationTests/Common/MockLogger.cs
+++ b/test/IdentityServer.IntegrationTests/Common/MockLogger.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+
+namespace IdentityServer.IntegrationTests.Common;
+
+public class MockLogger : ILogger
+{
+    public static MockLogger Create() => new MockLogger(new LoggerExternalScopeProvider());
+    public MockLogger(LoggerExternalScopeProvider scopeProvider) => _scopeProvider = scopeProvider;
+
+    public readonly List<string> LogMessages = new();
+
+
+    private readonly LoggerExternalScopeProvider _scopeProvider;
+
+
+    public IDisposable BeginScope<TState>(TState state) where TState : notnull => _scopeProvider.Push(state);
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter) => LogMessages.Add(formatter(state, exception));
+}
+
+public class MockLogger<T> : MockLogger, ILogger<T>
+{
+    public MockLogger(LoggerExternalScopeProvider scopeProvider) : base(scopeProvider)
+    {
+    }
+}
+
+public class MockLoggerProvider(MockLogger logger) : ILoggerProvider
+{
+    public void Dispose()
+    {
+    }
+
+    public ILogger CreateLogger(string categoryName) => logger;
+}

--- a/test/IdentityServer.IntegrationTests/Endpoints/Authorize/PushedAuthorizationTests.cs
+++ b/test/IdentityServer.IntegrationTests/Endpoints/Authorize/PushedAuthorizationTests.cs
@@ -22,14 +22,15 @@ public class PushedAuthorizationTests
 {
     private readonly IdentityServerPipeline _mockPipeline = new();
     private Client _client;
-
+    private string clientSecret = Guid.NewGuid().ToString();
+    
     public PushedAuthorizationTests()
     {
         ConfigureClients();
         ConfigureUsers();
         ConfigureScopesAndResources();
 
-        _mockPipeline.Initialize();
+        _mockPipeline.Initialize(enableLogging: true);
 
         _mockPipeline.Options.Endpoints.EnablePushedAuthorizationEndpoint = true;
     }
@@ -69,11 +70,31 @@ public class PushedAuthorizationTests
     }
 
     [Fact]
+    public async Task sensitive_values_should_not_be_logged_on_bad_request_to_par_endpoint()
+    {
+        // Login
+        await _mockPipeline.LoginAsync("bob");
+        _mockPipeline.BrowserClient.AllowAutoRedirect = false;
+
+        // Push Authorization
+        var expectedCallback = _client.RedirectUris.First();
+        var expectedState = "123_state";
+        var (parJson, statusCode) = await _mockPipeline.PushAuthorizationRequestAsync(
+            clientSecret: clientSecret,
+            redirectUri: "bogus", // <-- Intentionally wrong, to provoke logging an error with raw request
+            state: expectedState
+        );
+       
+        _mockPipeline.MockLogger.LogMessages.Should().ContainMatch("*\"client_secret\": \"***REDACTED***\"*");
+        _mockPipeline.MockLogger.LogMessages.Should().NotContainMatch(clientSecret);
+    }
+
+    [Fact]
     public async Task using_pushed_authorization_when_it_is_globally_disabled_fails()
     {
         _mockPipeline.Options.Endpoints.EnablePushedAuthorizationEndpoint = false;
         
-        var (_, statusCode) = await _mockPipeline.PushAuthorizationRequestAsync();
+        var (_, statusCode) = await _mockPipeline.PushAuthorizationRequestAsync(clientSecret: clientSecret);
         statusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
@@ -123,7 +144,7 @@ public class PushedAuthorizationTests
     public async Task existing_pushed_authorization_request_uris_become_invalid_when_par_is_disabled()
     {
         // PAR is enabled when we push authorization...
-        var (parJson, statusCode) = await _mockPipeline.PushAuthorizationRequestAsync();
+        var (parJson, statusCode) = await _mockPipeline.PushAuthorizationRequestAsync(clientSecret: clientSecret);
         statusCode.Should().Be(HttpStatusCode.Created);
         parJson.Should().NotBeNull();
 
@@ -154,7 +175,7 @@ public class PushedAuthorizationTests
         // Login
         await _mockPipeline.LoginAsync("bob");
 
-        var (parJson, statusCode) = await _mockPipeline.PushAuthorizationRequestAsync();
+        var (parJson, statusCode) = await _mockPipeline.PushAuthorizationRequestAsync(clientSecret: clientSecret);;
         statusCode.Should().Be(HttpStatusCode.Created);
         parJson.Should().NotBeNull();
 
@@ -298,7 +319,7 @@ public class PushedAuthorizationTests
                 ClientId = "client1",
                 ClientSecrets = new []
                 {
-                     new Secret("secret".Sha256())
+                     new Secret(clientSecret.Sha256())
                 },
                 AllowedGrantTypes = GrantTypes.Implicit,
                 RequireConsent = false,


### PR DESCRIPTION
PAR requests sometimes are handled by the same code path as authorize requests, so both endpoint's default
sensitive values filter should be the same.