### PR TITLE
Remove global.json

### DIFF
--- a/.github/workflow-gen/StepExtensions.cs
+++ b/.github/workflow-gen/StepExtensions.cs
@@ -18,7 +18,7 @@ public static class StepExtensions
 
         job.Step()
             .Name("Setup .NET")
-            .ActionsSetupDotNet("3e891b0cb619bf60e2c25674b222b8940e2c1c25", ["8.0.x", "9.0.103"]);
+            .ActionsSetupDotNet("3e891b0cb619bf60e2c25674b222b8940e2c1c25", ["8.0.x", "9.0.x"]);
         // v4.1.0
     }
 

--- a/.github/workflows/aspnetcore-authentication-jwtbearer-ci.yml
+++ b/.github/workflows/aspnetcore-authentication-jwtbearer-ci.yml
@@ -52,7 +52,7 @@ jobs:
       with:
         dotnet-version: |-
           8.0.x
-          9.0.103
+          9.0.x
     - name: Restore
       run: dotnet restore aspnetcore-authentication-jwtbearer.slnf
     - name: Verify Formatting
@@ -83,7 +83,7 @@ jobs:
       with:
         dotnet-version: |-
           8.0.x
-          9.0.103
+          9.0.x
     - name: Restore
       run: dotnet restore aspnetcore-authentication-jwtbearer.slnf
     - name: Build
@@ -152,7 +152,7 @@ jobs:
       with:
         dotnet-version: |-
           8.0.x
-          9.0.103
+          9.0.x
     - name: Restore
       run: dotnet restore aspnetcore-authentication-jwtbearer.slnf
     - name: Build
@@ -194,7 +194,7 @@ jobs:
       with:
         dotnet-version: |-
           8.0.x
-          9.0.103
+          9.0.x
     - name: Tool restore
       run: dotnet tool restore
     - name: Pack aspnetcore-authentication-jwtbearer.slnf

--- a/.github/workflows/aspnetcore-authentication-jwtbearer-release.yml
+++ b/.github/workflows/aspnetcore-authentication-jwtbearer-release.yml
@@ -65,7 +65,7 @@ jobs:
       with:
         dotnet-version: |-
           8.0.x
-          9.0.103
+          9.0.x
     - name: Pack aspnetcore-authentication-jwtbearer.slnf
       run: dotnet pack -c Release aspnetcore-authentication-jwtbearer.slnf -o artifacts
     - name: Tool restore
@@ -106,7 +106,7 @@ jobs:
       with:
         dotnet-version: |-
           8.0.x
-          9.0.103
+          9.0.x
     - name: List files
       run: tree
       shell: bash

--- a/.github/workflows/bff-ci.yml
+++ b/.github/workflows/bff-ci.yml
@@ -52,7 +52,7 @@ jobs:
       with:
         dotnet-version: |-
           8.0.x
-          9.0.103
+          9.0.x
     - name: Restore
       run: dotnet restore bff.slnf
     - name: Verify Formatting
@@ -83,7 +83,7 @@ jobs:
       with:
         dotnet-version: |-
           8.0.x
-          9.0.103
+          9.0.x
     - name: Restore
       run: dotnet restore bff.slnf
     - name: Build
@@ -131,7 +131,7 @@ jobs:
       with:
         dotnet-version: |-
           8.0.x
-          9.0.103
+          9.0.x
     - name: Restore
       run: dotnet restore bff.slnf
     - name: Build
@@ -190,7 +190,7 @@ jobs:
       with:
         dotnet-version: |-
           8.0.x
-          9.0.103
+          9.0.x
     - name: Restore
       run: dotnet restore bff.slnf
     - name: Build
@@ -232,7 +232,7 @@ jobs:
       with:
         dotnet-version: |-
           8.0.x
-          9.0.103
+          9.0.x
     - name: Tool restore
       run: dotnet tool restore
     - name: Pack bff.slnf

--- a/.github/workflows/bff-release.yml
+++ b/.github/workflows/bff-release.yml
@@ -65,7 +65,7 @@ jobs:
       with:
         dotnet-version: |-
           8.0.x
-          9.0.103
+          9.0.x
     - name: Pack bff.slnf
       run: dotnet pack -c Release bff.slnf -o artifacts
     - name: Tool restore
@@ -106,7 +106,7 @@ jobs:
       with:
         dotnet-version: |-
           8.0.x
-          9.0.103
+          9.0.x
     - name: List files
       run: tree
       shell: bash

--- a/.github/workflows/identity-server-ci.yml
+++ b/.github/workflows/identity-server-ci.yml
@@ -52,7 +52,7 @@ jobs:
       with:
         dotnet-version: |-
           8.0.x
-          9.0.103
+          9.0.x
     - name: Restore
       run: dotnet restore identity-server.slnf
     - name: Verify Formatting
@@ -83,7 +83,7 @@ jobs:
       with:
         dotnet-version: |-
           8.0.x
-          9.0.103
+          9.0.x
     - name: Restore
       run: dotnet restore identity-server.slnf
     - name: Build
@@ -208,7 +208,7 @@ jobs:
       with:
         dotnet-version: |-
           8.0.x
-          9.0.103
+          9.0.x
     - name: Restore
       run: dotnet restore identity-server.slnf
     - name: Build
@@ -250,7 +250,7 @@ jobs:
       with:
         dotnet-version: |-
           8.0.x
-          9.0.103
+          9.0.x
     - name: Tool restore
       run: dotnet tool restore
     - name: Pack identity-server.slnf

--- a/.github/workflows/identity-server-release.yml
+++ b/.github/workflows/identity-server-release.yml
@@ -65,7 +65,7 @@ jobs:
       with:
         dotnet-version: |-
           8.0.x
-          9.0.103
+          9.0.x
     - name: Pack identity-server.slnf
       run: dotnet pack -c Release identity-server.slnf -o artifacts
     - name: Tool restore
@@ -106,7 +106,7 @@ jobs:
       with:
         dotnet-version: |-
           8.0.x
-          9.0.103
+          9.0.x
     - name: List files
       run: tree
       shell: bash

--- a/.github/workflows/templates-release.yml
+++ b/.github/workflows/templates-release.yml
@@ -45,7 +45,7 @@ jobs:
       with:
         dotnet-version: |-
           8.0.x
-          9.0.103
+          9.0.x
     - name: Checkout target branch
       if: github.event.inputs.branch != 'main'
       run: git checkout ${{ github.event.inputs.branch }}
@@ -108,7 +108,7 @@ jobs:
       with:
         dotnet-version: |-
           8.0.x
-          9.0.103
+          9.0.x
     - name: List files
       run: tree
       shell: bash

--- a/global.json
+++ b/global.json
@@ -1,7 +1,0 @@
-{
-  "sdk": {
-    "version": "9.0.103",
-    "rollForward": "latestPatch",
-    "allowPrerelease": false
-  }
-}


### PR DESCRIPTION
We no longer need to pin the sdk version, because the fix for the dotnet format issue that originally prompted that has been released.