### PR TITLE
Use ServiceDefaults for IdSrv host to get Otel in Aspire

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -93,7 +93,6 @@
     <PackageVersion Include="NSubstitute" Version="5.1.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.11.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.11.0-beta.1" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.11.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.11.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -105,6 +105,7 @@
     <PackageVersion Include="Serilog" Version="4.2.0" />
     <PackageVersion Include="Serilog.AspNetCore" Version="8.0.3" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
+    <PackageVersion Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
     <PackageVersion Include="Serilog.Sinks.TextWriter" Version="3.0.0" />
     <PackageVersion Include="Serilog.Sinks.XUnit" Version="3.0.19" />
     <PackageVersion Include="Serilog.Extensions.Logging" Version="9.0.0" />

--- a/identity-server/aspire/ServiceDefaults/Extensions.cs
+++ b/identity-server/aspire/ServiceDefaults/Extensions.cs
@@ -9,7 +9,6 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
-using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 
 namespace Microsoft.Extensions.Hosting;
@@ -64,8 +63,6 @@ public static class Extensions
                     .AddSource(IdentityServerConstants.Tracing.Stores)
                     .AddSource(IdentityServerConstants.Tracing.Validation)
                     .AddAspNetCoreInstrumentation()
-                    // Uncomment the following line to enable gRPC instrumentation (requires the OpenTelemetry.Instrumentation.GrpcNetClient package)
-                    //.AddGrpcClientInstrumentation()
                     .AddHttpClientInstrumentation();
             });
 
@@ -100,25 +97,6 @@ public static class Extensions
             .AddCheck("self", () => HealthCheckResult.Healthy(), ["live"]);
 
         return builder;
-    }
-
-    public static WebApplication MapDefaultEndpoints(this WebApplication app)
-    {
-        // Adding health checks endpoints to applications in non-development environments has security implications.
-        // See https://aka.ms/dotnet/aspire/healthchecks for details before enabling these endpoints in non-development environments.
-        if (app.Environment.IsDevelopment())
-        {
-            // All health checks must pass for app to be considered ready to accept traffic after starting
-            app.MapHealthChecks("/health");
-
-            // Only health checks tagged with the "live" tag must pass for app to be considered alive
-            app.MapHealthChecks("/alive", new HealthCheckOptions
-            {
-                Predicate = r => r.Tags.Contains("live")
-            });
-        }
-
-        return app;
     }
 
     public static IHostApplicationBuilder AddOpenTelemetryMeters(this IHostApplicationBuilder builder, params string[] meterNames)

--- a/identity-server/aspire/ServiceDefaults/Extensions.cs
+++ b/identity-server/aspire/ServiceDefaults/Extensions.cs
@@ -2,8 +2,6 @@
 // See LICENSE in the project root for license information.
 
 using Duende.IdentityServer;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;

--- a/identity-server/aspire/ServiceDefaults/Extensions.cs
+++ b/identity-server/aspire/ServiceDefaults/Extensions.cs
@@ -51,7 +51,9 @@ public static class Extensions
             {
                 metrics.AddAspNetCoreInstrumentation()
                     .AddHttpClientInstrumentation()
-                    .AddRuntimeInstrumentation();
+                    .AddRuntimeInstrumentation()
+                    .AddMeter(Duende.IdentityServer.Telemetry.ServiceName)
+                    .AddMeter(Duende.IdentityServer.Telemetry.ServiceNameExperimental);
             })
             .WithTracing(tracing =>
             {

--- a/identity-server/aspire/ServiceDefaults/Extensions.cs
+++ b/identity-server/aspire/ServiceDefaults/Extensions.cs
@@ -52,8 +52,7 @@ public static class Extensions
                 metrics.AddAspNetCoreInstrumentation()
                     .AddHttpClientInstrumentation()
                     .AddRuntimeInstrumentation()
-                    .AddMeter(Duende.IdentityServer.Telemetry.ServiceName)
-                    .AddMeter(Duende.IdentityServer.Telemetry.ServiceNameExperimental);
+                    .AddMeter(Duende.IdentityServer.Telemetry.ServiceName);
             })
             .WithTracing(tracing =>
             {

--- a/identity-server/aspire/ServiceDefaults/Extensions.cs
+++ b/identity-server/aspire/ServiceDefaults/Extensions.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 
 namespace Microsoft.Extensions.Hosting;
@@ -118,5 +119,23 @@ public static class Extensions
         }
 
         return app;
+    }
+
+    public static IHostApplicationBuilder AddOpenTelemetryMeters(this IHostApplicationBuilder builder, params string[] meterNames)
+    {
+        if (meterNames == null || meterNames.Length == 0)
+        {
+            return builder;
+        }
+
+        builder.Services.ConfigureOpenTelemetryMeterProvider(provider =>
+        {
+            foreach (var meterName in meterNames)
+            {
+                provider.AddMeter(meterName);
+            }
+        });
+
+        return builder;
     }
 }

--- a/identity-server/aspire/ServiceDefaults/SerilogExtensions.cs
+++ b/identity-server/aspire/ServiceDefaults/SerilogExtensions.cs
@@ -18,7 +18,7 @@ public static class SerilogExtensions
                 .Enrich.FromLogContext()
                 .MinimumLevel.Debug()
                 .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
-                .MinimumLevel.Override("Microsoft.AspNetCore.Authentication", LogEventLevel.Debug)
+                .MinimumLevel.Override("Microsoft.AspNetCore.Authentication", LogEventLevel.Information)
                 .MinimumLevel.Override("Microsoft.Hosting.Lifetime", LogEventLevel.Information)
                 .MinimumLevel.Override("System", LogEventLevel.Warning)
                 .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level}] {SourceContext}{NewLine}{Message:lj}{NewLine}{Exception}{NewLine}")

--- a/identity-server/aspire/ServiceDefaults/SerilogExtensions.cs
+++ b/identity-server/aspire/ServiceDefaults/SerilogExtensions.cs
@@ -16,8 +16,11 @@ public static class SerilogExtensions
                 .ReadFrom.Configuration(context.Configuration)
                 .ReadFrom.Services(services)
                 .Enrich.FromLogContext()
-                .MinimumLevel.Information()
-                .MinimumLevel.Override("Duende", LogEventLevel.Debug)
+                .MinimumLevel.Debug()
+                .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
+                .MinimumLevel.Override("Microsoft.AspNetCore.Authentication", LogEventLevel.Debug)
+                .MinimumLevel.Override("Microsoft.Hosting.Lifetime", LogEventLevel.Information)
+                .MinimumLevel.Override("System", LogEventLevel.Warning)
                 .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level}] {SourceContext}{NewLine}{Message:lj}{NewLine}{Exception}{NewLine}")
                 .WriteTo.OpenTelemetry(opts =>
                 {

--- a/identity-server/aspire/ServiceDefaults/SerilogExtensions.cs
+++ b/identity-server/aspire/ServiceDefaults/SerilogExtensions.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using Microsoft.AspNetCore.Builder;
+using Serilog;
+using Serilog.Events;
+
+namespace Microsoft.Extensions.Hosting;
+
+public static class SerilogExtensions
+{
+    public static void ConfigureSerilogDefaults(this WebApplicationBuilder builder) =>
+        builder.Host.UseSerilog((context, services, configuration) =>
+        {
+            configuration
+                .ReadFrom.Configuration(context.Configuration)
+                .ReadFrom.Services(services)
+                .Enrich.FromLogContext()
+                .MinimumLevel.Information()
+                .MinimumLevel.Override("Duende", LogEventLevel.Debug)
+                .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level}] {SourceContext}{NewLine}{Message:lj}{NewLine}{Exception}{NewLine}")
+                .WriteTo.OpenTelemetry(opts =>
+                {
+                    opts.Endpoint = builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"] ?? "http://localhost:4317";
+                    opts.Protocol = Serilog.Sinks.OpenTelemetry.OtlpProtocol.Grpc;
+                    opts.ResourceAttributes = new Dictionary<string, object>
+                    {
+                        ["service.name"] = builder.Environment.ApplicationName,
+                    };
+                });
+        });
+}
+
+public static class SerilogDefaults
+{
+    public static void Bootstrap() => Log.Logger = new LoggerConfiguration()
+        .MinimumLevel.Debug()
+        .Enrich.FromLogContext()
+        .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level}] {SourceContext}{NewLine}{Message:lj}{NewLine}{Exception}{NewLine}")
+        .CreateBootstrapLogger();
+}

--- a/identity-server/aspire/ServiceDefaults/ServiceDefaults.csproj
+++ b/identity-server/aspire/ServiceDefaults/ServiceDefaults.csproj
@@ -17,6 +17,8 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
+    <PackageReference Include="Serilog.Sinks.OpenTelemetry"  Version="4.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/identity-server/clients/src/APIs/DPoPApi/Program.cs
+++ b/identity-server/clients/src/APIs/DPoPApi/Program.cs
@@ -3,55 +3,63 @@
 
 using DPoPApi;
 using Serilog;
-using Serilog.Events;
 
-var builder = WebApplication.CreateBuilder(args);
+SerilogDefaults.Bootstrap();
 
-// Configure Serilog early
-Log.Logger = new LoggerConfiguration()
-    .MinimumLevel.Information()
-    .MinimumLevel.Override("SampleApi", LogEventLevel.Debug)
-    .Enrich.FromLogContext()
-    .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level}] {SourceContext}{NewLine}{Message:lj}{NewLine}{Exception}{NewLine}")
-    .CreateLogger();
+try
+{
+    var builder = WebApplication.CreateBuilder(args);
 
-builder.Host.UseSerilog();
+    Console.Title = builder.Environment.ApplicationName;
+    Log.Information("{EnvironmentApplicationName} Starting up", builder.Environment.ApplicationName);
 
-// Include the service defaults from Aspire
-builder.AddServiceDefaults();
+    builder.ConfigureSerilogDefaults();
+    builder.AddServiceDefaults();
 
-builder.Services.AddControllers();
-builder.Services.AddCors();
+    builder.Services.AddControllers();
+    builder.Services.AddCors();
+    builder.Services.AddDistributedMemoryCache();
 
-// this API will accept any access token from the authority
-builder.Services.AddAuthentication("token")
-    .AddJwtBearer("token", options =>
+    // this API will accept any access token from the authority
+    builder.Services.AddAuthentication("token")
+        .AddJwtBearer("token", options =>
+        {
+            options.Authority = builder.Configuration["is-host"];
+            options.TokenValidationParameters.ValidateAudience = false;
+            options.MapInboundClaims = false;
+            options.TokenValidationParameters.ValidTypes = ["at+jwt"];
+        });
+
+    builder.Services.ConfigureDPoPTokensForScheme("token", options =>
     {
-        options.Authority = builder.Configuration["is-host"];
-        options.TokenValidationParameters.ValidateAudience = false;
-        options.MapInboundClaims = false;
-
-        options.TokenValidationParameters.ValidTypes = new[] { "at+jwt" };
+        options.Mode = DPoPMode.DPoPAndBearer;
     });
 
-builder.Services.ConfigureDPoPTokensForScheme("token", options =>
+    var app = builder.Build();
+
+    app.UseSerilogRequestLogging();
+
+    app.UseCors(policy =>
+    {
+        policy.WithOrigins("https://localhost:44300");
+        policy.AllowAnyHeader();
+        policy.AllowAnyMethod();
+        policy.WithExposedHeaders("WWW-Authenticate");
+    });
+
+    app.UseRouting();
+    app.UseAuthentication();
+    app.UseAuthorization();
+
+    app.MapControllers().RequireAuthorization();
+
+    app.Run();
+}
+catch (Exception ex)
 {
-    options.Mode = DPoPMode.DPoPAndBearer;
-});
-
-var app = builder.Build();
-
-app.UseCors(policy =>
+    Log.Fatal(ex, "Unhandled exception");
+}
+finally
 {
-    policy.WithOrigins("https://localhost:44300");
-    policy.AllowAnyHeader();
-    policy.AllowAnyMethod();
-    policy.WithExposedHeaders("WWW-Authenticate");
-});
-
-app.UseRouting();
-app.UseAuthentication();
-app.UseAuthorization();
-app.MapControllers().RequireAuthorization();
-
-app.Run();
+    Log.CloseAndFlush();
+}

--- a/identity-server/clients/src/APIs/ResourceBasedApi/Program.cs
+++ b/identity-server/clients/src/APIs/ResourceBasedApi/Program.cs
@@ -3,67 +3,68 @@
 
 using ResourceBasedApi;
 using Serilog;
-using Serilog.Events;
 
-var builder = WebApplication.CreateBuilder(args);
+SerilogDefaults.Bootstrap();
 
-// Configure Serilog early
-Log.Logger = new LoggerConfiguration()
-    .MinimumLevel.Information()
-    .MinimumLevel.Override("SampleApi", LogEventLevel.Debug)
-    .Enrich.FromLogContext()
-    .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level}] {SourceContext}{NewLine}{Message:lj}{NewLine}{Exception}{NewLine}")
-    .CreateLogger();
+try
+{
+    var builder = WebApplication.CreateBuilder(args);
 
-builder.Host.UseSerilog();
+    Console.Title = builder.Environment.ApplicationName;
+    Log.Information("{EnvironmentApplicationName} Starting up", builder.Environment.ApplicationName);
 
-// Include the service defaults from Aspire
-builder.AddServiceDefaults();
+    builder.ConfigureSerilogDefaults();
+    builder.AddServiceDefaults();
 
-builder.Services.AddControllers();
+    builder.Services.AddControllers();
+    builder.Services.AddCors();
 
-builder.Services.AddCors();
-builder.Services.AddDistributedMemoryCache();
+    builder.Services.AddAuthentication("token")
+        // JWT tokens
+        .AddJwtBearer("token", options =>
+        {
+            options.Authority = builder.Configuration["is-host"];
+            options.Audience = "urn:resource1";
+            options.MapInboundClaims = false;
+            options.TokenValidationParameters.ValidTypes = ["at+jwt"];
 
-builder.Services.AddAuthentication("token")
+            // if token does not contain a dot, it is a reference token
+            options.ForwardDefaultSelector = Selector.ForwardReferenceToken("introspection");
+        })
 
-    // JWT tokens
-    .AddJwtBearer("token", options =>
+        // reference tokens
+        .AddOAuth2Introspection("introspection", options =>
+        {
+            options.Authority = builder.Configuration["is-host"];
+            options.ClientId = "urn:resource1";
+            options.ClientSecret = "secret";
+        });
+
+    var app = builder.Build();
+
+    app.UseSerilogRequestLogging();
+
+    app.UseCors(policy =>
     {
-        options.Authority = "https://localhost:5001";
-        options.Audience = "urn:resource1";
-
-        options.TokenValidationParameters.ValidTypes = new[] { "at+jwt" };
-        options.MapInboundClaims = false;
-
-        // if token does not contain a dot, it is a reference token
-        options.ForwardDefaultSelector = Selector.ForwardReferenceToken("introspection");
-    })
-
-    // reference tokens
-    .AddOAuth2Introspection("introspection", options =>
-    {
-        options.Authority = "https://localhost:5001";
-
-        options.ClientId = "urn:resource1";
-        options.ClientSecret = "secret";
+        policy.WithOrigins("https://localhost:44300");
+        policy.AllowAnyHeader();
+        policy.AllowAnyMethod();
+        policy.WithExposedHeaders("WWW-Authenticate");
     });
 
-var app = builder.Build();
+    app.UseRouting();
+    app.UseAuthentication();
+    app.UseAuthorization();
 
-app.UseCors(policy =>
+    app.MapControllers().RequireAuthorization();
+
+    app.Run();
+}
+catch (Exception ex)
 {
-    policy.WithOrigins(
-        "https://localhost:44300");
-
-    policy.AllowAnyHeader();
-    policy.AllowAnyMethod();
-    policy.WithExposedHeaders("WWW-Authenticate");
-});
-
-app.UseRouting();
-app.UseAuthentication();
-app.UseAuthorization();
-app.MapControllers().RequireAuthorization();
-
-app.Run();
+    Log.Fatal(ex, "Unhandled exception");
+}
+finally
+{
+    Log.CloseAndFlush();
+}

--- a/identity-server/clients/src/MvcAutomaticTokenManagement/HostingExtensions.cs
+++ b/identity-server/clients/src/MvcAutomaticTokenManagement/HostingExtensions.cs
@@ -88,27 +88,6 @@ internal static class HostingExtensions
             client.BaseAddress = new Uri("https://simple-api");
         }).AddServiceDiscovery();
 
-        // var apiKey = _configuration["HoneyCombApiKey"];
-        // var dataset = "IdentityServerDev";
-        //
-        // services.AddOpenTelemetryTracing(builder =>
-        // {
-        //     builder
-        //         //.AddConsoleExporter()
-        //         .SetResourceBuilder(
-        //             ResourceBuilder.CreateDefault()
-        //                 .AddService("MVC TokenManagement"))
-        //         //.SetSampler(new AlwaysOnSampler())
-        //         .AddHttpClientInstrumentation()
-        //         .AddAspNetCoreInstrumentation()
-        //         .AddSqlClientInstrumentation()
-        //         .AddOtlpExporter(option =>
-        //         {
-        //             option.Endpoint = new Uri("https://api.honeycomb.io");
-        //             option.Headers = $"x-honeycomb-team={apiKey},x-honeycomb-dataset={dataset}";
-        //         });
-        // });
-
         return builder.Build();
     }
 

--- a/identity-server/clients/src/MvcAutomaticTokenManagement/Program.cs
+++ b/identity-server/clients/src/MvcAutomaticTokenManagement/Program.cs
@@ -29,7 +29,7 @@ try
         .ConfigurePipeline()
         .Run();
 }
-catch (Exception ex) when (ex.GetType().Name is not "HostAbortedException")
+catch (Exception ex)
 {
     Log.Fatal(ex, messageTemplate: "Unhandled exception");
 }

--- a/identity-server/clients/src/MvcCode/Program.cs
+++ b/identity-server/clients/src/MvcCode/Program.cs
@@ -26,7 +26,7 @@ try
         .ConfigurePipeline()
         .Run();
 }
-catch (Exception ex) when (ex.GetType().Name is not "HostAbortedException")
+catch (Exception ex)
 {
     Log.Fatal(ex, messageTemplate: "Unhandled exception");
 }

--- a/identity-server/clients/src/MvcDPoP/Program.cs
+++ b/identity-server/clients/src/MvcDPoP/Program.cs
@@ -29,7 +29,7 @@ try
         .ConfigurePipeline()
         .Run();
 }
-catch (Exception ex) when (ex.GetType().Name is not "HostAbortedException")
+catch (Exception ex)
 {
     Log.Fatal(ex, messageTemplate: "Unhandled exception");
 }

--- a/identity-server/clients/src/MvcHybridBackChannel/HostingExtensions.cs
+++ b/identity-server/clients/src/MvcHybridBackChannel/HostingExtensions.cs
@@ -82,27 +82,6 @@ internal static class HostingExtensions
         })
         .AddServiceDiscovery();
 
-        // var apiKey = _configuration["HoneyCombApiKey"];
-        // var dataset = "IdentityServerDev";
-
-        // services.AddOpenTelemetryTracing(builder =>
-        // {
-        //     builder
-        //         //.AddConsoleExporter()
-        //         .SetResourceBuilder(
-        //             ResourceBuilder.CreateDefault()
-        //                 .AddService("MVC Hybrid Backchannnel"))
-        //         //.SetSampler(new AlwaysOnSampler())
-        //         .AddHttpClientInstrumentation()
-        //         .AddAspNetCoreInstrumentation()
-        //         .AddSqlClientInstrumentation()
-        //         .AddOtlpExporter(option =>
-        //         {
-        //             option.Endpoint = new Uri("https://api.honeycomb.io");
-        //             option.Headers = $"x-honeycomb-team={apiKey},x-honeycomb-dataset={dataset}";
-        //         });
-        // });
-
         return builder.Build();
     }
 

--- a/identity-server/clients/src/MvcHybridBackChannel/Program.cs
+++ b/identity-server/clients/src/MvcHybridBackChannel/Program.cs
@@ -26,7 +26,7 @@ try
         .ConfigurePipeline()
         .Run();
 }
-catch (Exception ex) when (ex.GetType().Name is not "HostAbortedException")
+catch (Exception ex)
 {
     Log.Fatal(ex, messageTemplate: "Unhandled exception");
 }

--- a/identity-server/clients/src/MvcJarJwt/HostingExtensions.cs
+++ b/identity-server/clients/src/MvcJarJwt/HostingExtensions.cs
@@ -83,27 +83,6 @@ internal static class HostingExtensions
             client.BaseAddress = new Uri("https://simple-api");
         }).AddServiceDiscovery();
 
-        // var apiKey = _configuration["HoneyCombApiKey"];
-        // var dataset = "IdentityServerDev";
-        //
-        // services.AddOpenTelemetryTracing(builder =>
-        // {
-        //     builder
-        //         //.AddConsoleExporter()
-        //         .SetResourceBuilder(
-        //             ResourceBuilder.CreateDefault()
-        //                 .AddService("MVC JAR JWT"))
-        //         //.SetSampler(new AlwaysOnSampler())
-        //         .AddHttpClientInstrumentation()
-        //         .AddAspNetCoreInstrumentation()
-        //         .AddSqlClientInstrumentation()
-        //         .AddOtlpExporter(option =>
-        //         {
-        //             option.Endpoint = new Uri("https://api.honeycomb.io");
-        //             option.Headers = $"x-honeycomb-team={apiKey},x-honeycomb-dataset={dataset}";
-        //         });
-        // });
-
         return builder.Build();
     }
 

--- a/identity-server/clients/src/MvcJarJwt/Program.cs
+++ b/identity-server/clients/src/MvcJarJwt/Program.cs
@@ -26,7 +26,7 @@ try
         .ConfigurePipeline()
         .Run();
 }
-catch (Exception ex) when (ex.GetType().Name is not "HostAbortedException")
+catch (Exception ex)
 {
     Log.Fatal(ex, messageTemplate: "Unhandled exception");
 }

--- a/identity-server/clients/src/MvcJarUriJwt/HostingExtensions.cs
+++ b/identity-server/clients/src/MvcJarUriJwt/HostingExtensions.cs
@@ -88,27 +88,6 @@ internal static class HostingExtensions
             client.BaseAddress = new Uri(simpleApi);
         }).AddServiceDiscovery();
 
-        // var apiKey = _configuration["HoneyCombApiKey"];
-        // var dataset = "IdentityServerDev";
-        //
-        // services.AddOpenTelemetryTracing(builder =>
-        // {
-        //     builder
-        //         //.AddConsoleExporter()
-        //         .SetResourceBuilder(
-        //             ResourceBuilder.CreateDefault()
-        //                 .AddService("MVC JAR UriJwt"))
-        //         //.SetSampler(new AlwaysOnSampler())
-        //         .AddHttpClientInstrumentation()
-        //         .AddAspNetCoreInstrumentation()
-        //         .AddSqlClientInstrumentation()
-        //         .AddOtlpExporter(option =>
-        //         {
-        //             option.Endpoint = new Uri("https://api.honeycomb.io");
-        //             option.Headers = $"x-honeycomb-team={apiKey},x-honeycomb-dataset={dataset}";
-        //         });
-        // });
-
         return builder.Build();
     }
 

--- a/identity-server/clients/src/MvcJarUriJwt/Program.cs
+++ b/identity-server/clients/src/MvcJarUriJwt/Program.cs
@@ -26,7 +26,7 @@ try
         .ConfigurePipeline()
         .Run();
 }
-catch (Exception ex) when (ex.GetType().Name is not "HostAbortedException")
+catch (Exception ex)
 {
     Log.Fatal(ex, messageTemplate: "Unhandled exception");
 }

--- a/identity-server/hosts/AspNetIdentity/Host.AspNetIdentity.csproj
+++ b/identity-server/hosts/AspNetIdentity/Host.AspNetIdentity.csproj
@@ -8,11 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog.AspNetCore" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" />
-
     <PackageReference Include="OpenTelemetry" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
@@ -20,6 +18,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
     <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" />
+    <PackageReference Include="Serilog.AspNetCore" />
   </ItemGroup>
 
   <ItemGroup>

--- a/identity-server/hosts/AspNetIdentity/HostingExtensions.cs
+++ b/identity-server/hosts/AspNetIdentity/HostingExtensions.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using Serilog;
-using Serilog.Events;
 
 namespace IdentityServerHost;
 
@@ -102,6 +101,9 @@ internal static class HostingExtensions
         app.UseRouting();
         app.UseIdentityServer();
         app.UseAuthorization();
+
+        // health checks
+        app.MapHealthChecks("/health");
 
         // UI
         app.MapRazorPages()

--- a/identity-server/hosts/AspNetIdentity/HostingExtensions.cs
+++ b/identity-server/hosts/AspNetIdentity/HostingExtensions.cs
@@ -29,28 +29,6 @@ internal static class HostingExtensions
         builder.ConfigureIdentityServer();
         builder.AddExternalIdentityProviders();
 
-        // var apiKey = builder.Configuration["HoneyCombApiKey"];
-        // var dataset = "IdentityServerDev";
-        //
-        // builder.Services.AddOpenTelemetryTracing(builder =>
-        // {
-        //     builder
-        //         //.AddConsoleExporter()
-        //         .AddSource(IdentityServerConstants.Tracing.ServiceName)
-        //         .SetResourceBuilder(
-        //             ResourceBuilder.CreateDefault()
-        //                 .AddService("IdentityServerHost.AspId"))
-        //         //.SetSampler(new AlwaysOnSampler())
-        //         .AddHttpClientInstrumentation()
-        //         .AddAspNetCoreInstrumentation()
-        //         .AddSqlClientInstrumentation()
-        //         .AddOtlpExporter(option =>
-        //         {
-        //             option.Endpoint = new Uri("https://api.honeycomb.io");
-        //             option.Headers = $"x-honeycomb-team={apiKey},x-honeycomb-dataset={dataset}";
-        //         });
-        // });
-
         return builder.Build();
     }
 

--- a/identity-server/hosts/AspNetIdentity/HostingExtensions.cs
+++ b/identity-server/hosts/AspNetIdentity/HostingExtensions.cs
@@ -94,8 +94,7 @@ internal static class HostingExtensions
 
     internal static WebApplication ConfigurePipeline(this WebApplication app)
     {
-        app.UseSerilogRequestLogging(
-            options => options.GetLevel = (httpContext, elapsed, ex) => LogEventLevel.Debug);
+        app.UseSerilogRequestLogging();
 
         app.UseDeveloperExceptionPage();
         app.UseStaticFiles();

--- a/identity-server/hosts/AspNetIdentity/Program.cs
+++ b/identity-server/hosts/AspNetIdentity/Program.cs
@@ -7,22 +7,18 @@ using Duende.IdentityServer.Licensing;
 using IdentityServerHost;
 using Serilog;
 
-Console.Title = "IdentityServer (AspNetIdentity)";
-
-Log.Logger = new LoggerConfiguration()
-    .WriteTo.Console(formatProvider: CultureInfo.InvariantCulture)
-    .CreateBootstrapLogger();
-
-Log.Information("Host.AspNetIdentity Starting up");
+SerilogDefaults.Bootstrap();
 
 try
 {
     var builder = WebApplication.CreateBuilder(args);
 
-    builder.Host.UseSerilog((ctx, lc) => lc
-        .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level}] {SourceContext}{NewLine}{Message:lj}{NewLine}{Exception}{NewLine}", formatProvider: CultureInfo.InvariantCulture)
-        .Enrich.FromLogContext()
-        .ReadFrom.Configuration(ctx.Configuration));
+    Console.Title = builder.Environment.ApplicationName;
+    Log.Information("{EnvironmentApplicationName} Starting up", builder.Environment.ApplicationName);
+
+    builder.ConfigureSerilogDefaults();
+    builder.AddServiceDefaults()
+        .AddOpenTelemetryMeters(IdentityServerHost.Pages.Telemetry.ServiceName);
 
     var app = builder
         .ConfigureServices()

--- a/identity-server/hosts/AspNetIdentity/appsettings.json
+++ b/identity-server/hosts/AspNetIdentity/appsettings.json
@@ -1,16 +1,4 @@
 {
-  "Serilog": {
-    "MinimumLevel": {
-      "Default": "Debug",
-      "Override": {
-        "Microsoft": "Warning",
-        "Microsoft.Hosting.Lifetime": "Information",
-        "Microsoft.AspNetCore.Authentication": "Debug",
-        "System": "Warning"
-      }
-    }
-  },
-
   "ConnectionStrings": {
     "DefaultConnection": ""
   }

--- a/identity-server/hosts/Configuration/HostingExtensions.cs
+++ b/identity-server/hosts/Configuration/HostingExtensions.cs
@@ -41,35 +41,6 @@ internal static class HostingExtensions
             return Task.FromResult(principal);
         });
 
-
-        // var apiKey = builder.Configuration["HoneyCombApiKey"];
-        // var dataset = "IdentityServerDev";
-        //
-        // builder.Services.AddOpenTelemetryTracing(builder =>
-        // {
-        //     builder
-        //         .AddSource(IdentityServerConstants.Tracing.Basic)
-        //         .AddSource(IdentityServerConstants.Tracing.Cache)
-        //         .AddSource(IdentityServerConstants.Tracing.Services)
-        //         .AddSource(IdentityServerConstants.Tracing.Stores)
-        //         .AddSource(IdentityServerConstants.Tracing.Validation)
-        //
-        //         .SetResourceBuilder(
-        //             ResourceBuilder.CreateDefault()
-        //                 .AddService("IdentityServerHost.Main"))
-        //
-        //         //.SetSampler(new AlwaysOnSampler())
-        //         .AddHttpClientInstrumentation()
-        //         .AddAspNetCoreInstrumentation()
-        //         .AddSqlClientInstrumentation()
-        //         //.AddConsoleExporter()
-        //         .AddOtlpExporter(option =>
-        //         {
-        //             option.Endpoint = new Uri("https://api.honeycomb.io");
-        //             option.Headers = $"x-honeycomb-team={apiKey},x-honeycomb-dataset={dataset}";
-        //         });
-        // });
-
         builder.Services.Configure<KestrelServerOptions>(kestrelOptions =>
         {
             kestrelOptions.ConfigureHttpsDefaults(https =>

--- a/identity-server/hosts/Configuration/HostingExtensions.cs
+++ b/identity-server/hosts/Configuration/HostingExtensions.cs
@@ -10,7 +10,6 @@ using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Https;
 using Microsoft.IdentityModel.Tokens;
 using Serilog;
-using Serilog.Events;
 
 namespace IdentityServerHost;
 

--- a/identity-server/hosts/Configuration/HostingExtensions.cs
+++ b/identity-server/hosts/Configuration/HostingExtensions.cs
@@ -125,8 +125,7 @@ internal static class HostingExtensions
 
     internal static WebApplication ConfigurePipeline(this WebApplication app)
     {
-        app.UseSerilogRequestLogging(
-            options => options.GetLevel = (httpContext, elapsed, ex) => LogEventLevel.Debug);
+        app.UseSerilogRequestLogging();
 
         app.UseCookiePolicy();
 

--- a/identity-server/hosts/Configuration/Program.cs
+++ b/identity-server/hosts/Configuration/Program.cs
@@ -6,36 +6,19 @@ using System.Text;
 using Duende.IdentityServer.Licensing;
 using IdentityServerHost;
 using Serilog;
-using Serilog.Events;
-using Serilog.Sinks.SystemConsole.Themes;
 
-Console.Title = "IdentityServer (Configuration)";
-
-Log.Logger = new LoggerConfiguration()
-    .WriteTo.Console(formatProvider: CultureInfo.InvariantCulture)
-    .CreateBootstrapLogger();
-
-Log.Information("Host.Main Starting up");
+SerilogDefaults.Bootstrap();
 
 try
 {
     var builder = WebApplication.CreateBuilder(args);
 
-    builder.Host.UseSerilog((ctx, lc) => lc
-        .WriteTo.Console(
-            outputTemplate:
-            "[{Timestamp:HH:mm:ss} {Level}] {SourceContext}{NewLine}{Message:lj}{NewLine}{Exception}{NewLine}",
-            theme: AnsiConsoleTheme.Code,
-            formatProvider: CultureInfo.InvariantCulture)
-        .MinimumLevel.Debug()
-        .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
-        .MinimumLevel.Override("Microsoft.Hosting.Lifetime", LogEventLevel.Information)
-        .MinimumLevel.Override("System", LogEventLevel.Warning)
-        .MinimumLevel.Override("Microsoft.AspNetCore.Authentication", LogEventLevel.Information)
-        .Enrich.FromLogContext());
+    Console.Title = builder.Environment.ApplicationName;
+    Log.Information("{EnvironmentApplicationName} Starting up", builder.Environment.ApplicationName);
 
-    // Add ServiceDefaults from Aspire
-    builder.AddServiceDefaults();
+    builder.ConfigureSerilogDefaults();
+    builder.AddServiceDefaults()
+        .AddOpenTelemetryMeters(IdentityServerHost.Pages.Telemetry.ServiceName);
 
     var app = builder
         .ConfigureServices()

--- a/identity-server/hosts/EntityFramework-dotnet9/Host.EntityFramework.dotnet9.csproj
+++ b/identity-server/hosts/EntityFramework-dotnet9/Host.EntityFramework.dotnet9.csproj
@@ -8,10 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog.AspNetCore" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" />
-
     <PackageReference Include="OpenTelemetry" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
@@ -19,6 +17,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
     <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" />
+    <PackageReference Include="Serilog.AspNetCore" />
   </ItemGroup>
 
   <ItemGroup>

--- a/identity-server/hosts/EntityFramework-dotnet9/HostingExtensions.cs
+++ b/identity-server/hosts/EntityFramework-dotnet9/HostingExtensions.cs
@@ -132,8 +132,7 @@ internal static class HostingExtensions
 
     internal static WebApplication ConfigurePipeline(this WebApplication app)
     {
-        app.UseSerilogRequestLogging(
-            options => options.GetLevel = (httpContext, elapsed, ex) => LogEventLevel.Debug);
+        app.UseSerilogRequestLogging();
 
         app.UseCookiePolicy();
 

--- a/identity-server/hosts/EntityFramework-dotnet9/HostingExtensions.cs
+++ b/identity-server/hosts/EntityFramework-dotnet9/HostingExtensions.cs
@@ -12,7 +12,6 @@ using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Https;
 using Microsoft.IdentityModel.Tokens;
 using Serilog;
-using Serilog.Events;
 
 namespace IdentityServerHost;
 

--- a/identity-server/hosts/EntityFramework-dotnet9/HostingExtensions.cs
+++ b/identity-server/hosts/EntityFramework-dotnet9/HostingExtensions.cs
@@ -43,28 +43,6 @@ internal static class HostingExtensions
             return Task.FromResult(principal);
         });
 
-        // var apiKey = builder.Configuration["HoneyCombApiKey"];
-        // var dataset = "IdentityServerDev";
-        //
-        // builder.Services.AddOpenTelemetryTracing(builder =>
-        // {
-        //     builder
-        //         //.AddConsoleExporter()
-        //         .AddSource(IdentityServerConstants.Tracing.ServiceName)
-        //         .SetResourceBuilder(
-        //             ResourceBuilder.CreateDefault()
-        //                 .AddService("IdentityServerHost.EF"))
-        //         //.SetSampler(new AlwaysOnSampler())
-        //         .AddHttpClientInstrumentation()
-        //         .AddAspNetCoreInstrumentation()
-        //         .AddSqlClientInstrumentation()
-        //         .AddOtlpExporter(option =>
-        //         {
-        //             option.Endpoint = new Uri("https://api.honeycomb.io");
-        //             option.Headers = $"x-honeycomb-team={apiKey},x-honeycomb-dataset={dataset}";
-        //         });
-        // });
-
         builder.Services.Configure<KestrelServerOptions>(kestrelOptions =>
         {
             kestrelOptions.ConfigureHttpsDefaults(https =>

--- a/identity-server/hosts/EntityFramework-dotnet9/Program.cs
+++ b/identity-server/hosts/EntityFramework-dotnet9/Program.cs
@@ -24,6 +24,8 @@ try
         .Enrich.FromLogContext()
         .ReadFrom.Configuration(ctx.Configuration));
 
+    builder.AddServiceDefaults();
+
     var app = builder
         .ConfigureServices()
         .ConfigurePipeline();

--- a/identity-server/hosts/EntityFramework-dotnet9/Program.cs
+++ b/identity-server/hosts/EntityFramework-dotnet9/Program.cs
@@ -7,24 +7,18 @@ using Duende.IdentityServer.Licensing;
 using IdentityServerHost;
 using Serilog;
 
-Console.Title = "IdentityServer (EntityFramework)";
-
-Log.Logger = new LoggerConfiguration()
-    .WriteTo.Console(formatProvider: CultureInfo.InvariantCulture)
-    .CreateBootstrapLogger();
-
-Log.Information("Host.EntityFramework Starting up");
+SerilogDefaults.Bootstrap();
 
 try
 {
     var builder = WebApplication.CreateBuilder(args);
 
-    builder.Host.UseSerilog((ctx, lc) => lc
-        .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level}] {SourceContext}{NewLine}{Message:lj}{NewLine}{Exception}{NewLine}", formatProvider: CultureInfo.InvariantCulture)
-        .Enrich.FromLogContext()
-        .ReadFrom.Configuration(ctx.Configuration));
+    Console.Title = builder.Environment.ApplicationName;
+    Log.Information("{EnvironmentApplicationName} Starting up", builder.Environment.ApplicationName);
 
-    builder.AddServiceDefaults();
+    builder.ConfigureSerilogDefaults();
+    builder.AddServiceDefaults()
+        .AddOpenTelemetryMeters(IdentityServerHost.Pages.Telemetry.ServiceName);
 
     var app = builder
         .ConfigureServices()

--- a/identity-server/hosts/EntityFramework-dotnet9/appsettings.json
+++ b/identity-server/hosts/EntityFramework-dotnet9/appsettings.json
@@ -1,16 +1,4 @@
 {
-  "Serilog": {
-    "MinimumLevel": {
-      "Default": "Debug",
-      "Override": {
-        "Microsoft": "Warning",
-        "Microsoft.Hosting.Lifetime": "Information",
-        "Microsoft.AspNetCore.Authentication": "Debug",
-        "System": "Warning"
-      }
-    }
-  },
-
   "ConnectionStrings": {
     "DefaultConnection": ""
   }

--- a/identity-server/hosts/EntityFramework/Host.EntityFramework.csproj
+++ b/identity-server/hosts/EntityFramework/Host.EntityFramework.csproj
@@ -8,11 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog.AspNetCore" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Certificate" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
-
     <PackageReference Include="OpenTelemetry" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
@@ -20,6 +18,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
     <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" />
+    <PackageReference Include="Serilog.AspNetCore" />
   </ItemGroup>
 
   <ItemGroup>

--- a/identity-server/hosts/EntityFramework/HostingExtensions.cs
+++ b/identity-server/hosts/EntityFramework/HostingExtensions.cs
@@ -132,8 +132,7 @@ internal static class HostingExtensions
 
     internal static WebApplication ConfigurePipeline(this WebApplication app)
     {
-        app.UseSerilogRequestLogging(
-            options => options.GetLevel = (httpContext, elapsed, ex) => LogEventLevel.Debug);
+        app.UseSerilogRequestLogging();
 
         app.UseCookiePolicy();
 

--- a/identity-server/hosts/EntityFramework/HostingExtensions.cs
+++ b/identity-server/hosts/EntityFramework/HostingExtensions.cs
@@ -12,7 +12,6 @@ using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Https;
 using Microsoft.IdentityModel.Tokens;
 using Serilog;
-using Serilog.Events;
 
 namespace IdentityServerHost;
 

--- a/identity-server/hosts/EntityFramework/HostingExtensions.cs
+++ b/identity-server/hosts/EntityFramework/HostingExtensions.cs
@@ -43,28 +43,6 @@ internal static class HostingExtensions
             return Task.FromResult(principal);
         });
 
-        // var apiKey = builder.Configuration["HoneyCombApiKey"];
-        // var dataset = "IdentityServerDev";
-        //
-        // builder.Services.AddOpenTelemetryTracing(builder =>
-        // {
-        //     builder
-        //         //.AddConsoleExporter()
-        //         .AddSource(IdentityServerConstants.Tracing.ServiceName)
-        //         .SetResourceBuilder(
-        //             ResourceBuilder.CreateDefault()
-        //                 .AddService("IdentityServerHost.EF"))
-        //         //.SetSampler(new AlwaysOnSampler())
-        //         .AddHttpClientInstrumentation()
-        //         .AddAspNetCoreInstrumentation()
-        //         .AddSqlClientInstrumentation()
-        //         .AddOtlpExporter(option =>
-        //         {
-        //             option.Endpoint = new Uri("https://api.honeycomb.io");
-        //             option.Headers = $"x-honeycomb-team={apiKey},x-honeycomb-dataset={dataset}";
-        //         });
-        // });
-
         builder.Services.Configure<KestrelServerOptions>(kestrelOptions =>
         {
             kestrelOptions.ConfigureHttpsDefaults(https =>

--- a/identity-server/hosts/EntityFramework/Program.cs
+++ b/identity-server/hosts/EntityFramework/Program.cs
@@ -7,22 +7,18 @@ using Duende.IdentityServer.Licensing;
 using IdentityServerHost;
 using Serilog;
 
-Console.Title = "IdentityServer (EntityFramework)";
-
-Log.Logger = new LoggerConfiguration()
-    .WriteTo.Console(formatProvider: CultureInfo.InvariantCulture)
-    .CreateBootstrapLogger();
-
-Log.Information("Host.EntityFramework Starting up");
+SerilogDefaults.Bootstrap();
 
 try
 {
     var builder = WebApplication.CreateBuilder(args);
 
-    builder.Host.UseSerilog((ctx, lc) => lc
-        .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level}] {SourceContext}{NewLine}{Message:lj}{NewLine}{Exception}{NewLine}", formatProvider: CultureInfo.InvariantCulture)
-        .Enrich.FromLogContext()
-        .ReadFrom.Configuration(ctx.Configuration));
+    Console.Title = builder.Environment.ApplicationName;
+    Log.Information("{EnvironmentApplicationName} Starting up", builder.Environment.ApplicationName);
+
+    builder.ConfigureSerilogDefaults();
+    builder.AddServiceDefaults()
+        .AddOpenTelemetryMeters(IdentityServerHost.Pages.Telemetry.ServiceName);
 
     var app = builder
         .ConfigureServices()

--- a/identity-server/hosts/EntityFramework/appsettings.json
+++ b/identity-server/hosts/EntityFramework/appsettings.json
@@ -1,16 +1,4 @@
 {
-  "Serilog": {
-    "MinimumLevel": {
-      "Default": "Debug",
-      "Override": {
-        "Microsoft": "Warning",
-        "Microsoft.Hosting.Lifetime": "Information",
-        "Microsoft.AspNetCore.Authentication": "Debug",
-        "System": "Warning"
-      }
-    }
-  },
-
   "ConnectionStrings": {
     "DefaultConnection": ""
   }

--- a/identity-server/hosts/main/Host.Main.csproj
+++ b/identity-server/hosts/main/Host.Main.csproj
@@ -22,16 +22,13 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" PrivateAssets="All" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" />
-
     <PackageReference Include="OpenTelemetry" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
-    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
     <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" />
-
     <PackageReference Include="Serilog.AspNetCore" />
   </ItemGroup>
 

--- a/identity-server/hosts/main/HostingExtensions.cs
+++ b/identity-server/hosts/main/HostingExtensions.cs
@@ -8,10 +8,7 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Https;
 using Microsoft.IdentityModel.Tokens;
-using OpenTelemetry.Metrics;
-using OpenTelemetry.Resources;
 using Serilog;
-using Serilog.Events;
 
 namespace IdentityServerHost;
 
@@ -41,25 +38,6 @@ internal static class HostingExtensions
 
             return Task.FromResult(principal);
         });
-
-        var openTelemetry = builder.Services.AddOpenTelemetry();
-
-        openTelemetry.ConfigureResource(r => r
-            .AddService(builder.Environment.ApplicationName));
-
-        openTelemetry.WithMetrics(m => m
-            .AddMeter(Telemetry.ServiceName)
-            .AddMeter(Pages.Telemetry.ServiceName)
-            .AddPrometheusExporter());
-
-        //openTelemetry.WithTracing(t => t
-        //    .AddSource(IdentityServerConstants.Tracing.Basic)
-        //    .AddSource(IdentityServerConstants.Tracing.Cache)
-        //    .AddSource(IdentityServerConstants.Tracing.Services)
-        //    .AddSource(IdentityServerConstants.Tracing.Stores)
-        //    .AddSource(IdentityServerConstants.Tracing.Validation)
-        //    .AddAspNetCoreInstrumentation()
-        //    .AddConsoleExporter());
 
         builder.Services.Configure<KestrelServerOptions>(kestrelOptions =>
         {
@@ -166,9 +144,6 @@ internal static class HostingExtensions
         // UI
         app.MapRazorPages()
             .RequireAuthorization();
-
-        // Map /metrics that displays Otel data in human readable form.
-        app.UseOpenTelemetryPrometheusScrapingEndpoint();
 
         return app;
     }

--- a/identity-server/hosts/main/HostingExtensions.cs
+++ b/identity-server/hosts/main/HostingExtensions.cs
@@ -145,8 +145,7 @@ internal static class HostingExtensions
 
     internal static WebApplication ConfigurePipeline(this WebApplication app)
     {
-        app.UseSerilogRequestLogging(
-            options => options.GetLevel = (httpContext, elapsed, ex) => LogEventLevel.Debug);
+        app.UseSerilogRequestLogging();
 
         app.UseCookiePolicy();
 

--- a/identity-server/hosts/main/Program.cs
+++ b/identity-server/hosts/main/Program.cs
@@ -7,22 +7,18 @@ using Duende.IdentityServer.Licensing;
 using IdentityServerHost;
 using Serilog;
 
-Console.Title = "IdentityServer (Main)";
-
-Log.Logger = new LoggerConfiguration()
-    .WriteTo.Console(formatProvider: CultureInfo.InvariantCulture)
-    .CreateBootstrapLogger();
-
-Log.Information("Host.Main Starting up");
+SerilogDefaults.Bootstrap();
 
 try
 {
     var builder = WebApplication.CreateBuilder(args);
 
-    builder.Host.UseSerilog((ctx, lc) => lc
-        .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level}] {SourceContext}{NewLine}{Message:lj}{NewLine}{Exception}{NewLine}", formatProvider: CultureInfo.InvariantCulture)
-        .Enrich.FromLogContext()
-        .ReadFrom.Configuration(ctx.Configuration));
+    Console.Title = builder.Environment.ApplicationName;
+    Log.Information("{EnvironmentApplicationName} Starting up", builder.Environment.ApplicationName);
+
+    builder.ConfigureSerilogDefaults();
+    builder.AddServiceDefaults()
+        .AddOpenTelemetryMeters(IdentityServerHost.Pages.Telemetry.ServiceName);
 
     var app = builder
         .ConfigureServices()

--- a/identity-server/src/EntityFramework.Storage/Stores/ServerSideSessionStore.cs
+++ b/identity-server/src/EntityFramework.Storage/Stores/ServerSideSessionStore.cs
@@ -89,7 +89,7 @@ public class ServerSideSessionStore : IServerSideSessionStore
         cancellationToken = cancellationToken == CancellationToken.None ? CancellationTokenProvider.CancellationToken : cancellationToken;
 
         var entity = (await Context.ServerSideSessions.AsNoTracking().Where(x => x.Key == key)
-                .ToArrayAsync(cancellationToken))
+            .ToArrayAsync(cancellationToken))
             .SingleOrDefault(x => x.Key == key);
 
         var model = default(ServerSideSession);


### PR DESCRIPTION
Now that we have Aspire for the dev environment I think it makes sense to have OTel completely wired up for those hosts too. I simply called AddServiceDefaults from the IdSrv host. Is that risky? Could there be other side effects?

For now I've just done one host and created this as a draft. If everything is ok I'll make the same changes to other hosts.