### PR TITLE
DPoP Jwt Bearer extensibility reworked

### DIFF
--- a/aspnetcore-authentication-jwtbearer/src/AspNetCore.Authentication.JwtBearer/DPoP/ConfigureJwtBearerOptions.cs
+++ b/aspnetcore-authentication-jwtbearer/src/AspNetCore.Authentication.JwtBearer/DPoP/ConfigureJwtBearerOptions.cs
@@ -9,7 +9,7 @@ namespace Duende.AspNetCore.Authentication.JwtBearer.DPoP;
 /// <summary>
 /// Ensures that the <see cref="JwtBearerOptions"/> are configured with <see cref="DPoPJwtBearerEvents"/>.
 /// </summary>
-public sealed class ConfigureJwtBearerOptions : IPostConfigureOptions<JwtBearerOptions>
+internal sealed class ConfigureJwtBearerOptions : IPostConfigureOptions<JwtBearerOptions>
 {
     private readonly string _configScheme;
 

--- a/aspnetcore-authentication-jwtbearer/src/AspNetCore.Authentication.JwtBearer/DPoP/ConfigureJwtBearerOptions.cs
+++ b/aspnetcore-authentication-jwtbearer/src/AspNetCore.Authentication.JwtBearer/DPoP/ConfigureJwtBearerOptions.cs
@@ -12,7 +12,7 @@ namespace Duende.AspNetCore.Authentication.JwtBearer.DPoP;
 internal sealed class ConfigureJwtBearerOptions(DPoPJwtBearerEvents dpopEvents) : IPostConfigureOptions<JwtBearerOptions>
 {
     public string? Scheme { get; set; }
-    
+
     public void PostConfigure(string? name, JwtBearerOptions options)
     {
         if (Scheme == name)
@@ -33,7 +33,7 @@ internal sealed class ConfigureJwtBearerOptions(DPoPJwtBearerEvents dpopEvents) 
         }
         return Callback;
     }
-    
+
     private Func<MessageReceivedContext, Task> CreateMessageReceivedCallback(Func<MessageReceivedContext, Task> inner, DPoPJwtBearerEvents dpopEvents)
     {
         async Task Callback(MessageReceivedContext ctx)
@@ -43,7 +43,7 @@ internal sealed class ConfigureJwtBearerOptions(DPoPJwtBearerEvents dpopEvents) 
         }
         return Callback;
     }
-    
+
     private Func<TokenValidatedContext, Task> CreateTokenValidatedCallback(Func<TokenValidatedContext, Task> inner, DPoPJwtBearerEvents dpopEvents)
     {
         async Task Callback(TokenValidatedContext ctx)

--- a/aspnetcore-authentication-jwtbearer/src/AspNetCore.Authentication.JwtBearer/DPoP/ConfigureJwtBearerOptions.cs
+++ b/aspnetcore-authentication-jwtbearer/src/AspNetCore.Authentication.JwtBearer/DPoP/ConfigureJwtBearerOptions.cs
@@ -9,33 +9,48 @@ namespace Duende.AspNetCore.Authentication.JwtBearer.DPoP;
 /// <summary>
 /// Ensures that the <see cref="JwtBearerOptions"/> are configured with <see cref="DPoPJwtBearerEvents"/>.
 /// </summary>
-internal sealed class ConfigureJwtBearerOptions : IPostConfigureOptions<JwtBearerOptions>
+internal sealed class ConfigureJwtBearerOptions(DPoPJwtBearerEvents dpopEvents) : IPostConfigureOptions<JwtBearerOptions>
 {
-    private readonly string _configScheme;
-
-    /// <summary>
-    /// Constructs a new instance of <see cref="ConfigureJwtBearerOptions"/> that will operate on the specified scheme name.
-    /// </summary>
-    public ConfigureJwtBearerOptions(string configScheme) => _configScheme = configScheme;
-
-    /// <inheritdoc/>
+    public string? Scheme { get; set; }
+    
     public void PostConfigure(string? name, JwtBearerOptions options)
     {
-        if (_configScheme == name)
+        if (Scheme == name)
         {
-            if (options.EventsType != null && !typeof(DPoPJwtBearerEvents).IsAssignableFrom(options.EventsType))
-            {
-                throw new Exception("EventsType on JwtBearerOptions must derive from DPoPJwtBearerEvents to work with the DPoP support.");
-            }
-            if (options.Events != null && !typeof(DPoPJwtBearerEvents).IsAssignableFrom(options.Events.GetType()))
-            {
-                throw new Exception("Events on JwtBearerOptions must derive from DPoPJwtBearerEvents to work with the DPoP support.");
-            }
-
-            if (options.Events == null && options.EventsType == null)
-            {
-                options.EventsType = typeof(DPoPJwtBearerEvents);
-            }
+            options.Events ??= new JwtBearerEvents(); // Despite nullability annotations saying this is unnecessary, it sometimes is null
+            options.Events.OnChallenge = CreateChallengeCallback(options.Events.OnChallenge, dpopEvents);
+            options.Events.OnMessageReceived = CreateMessageReceivedCallback(options.Events.OnMessageReceived, dpopEvents);
+            options.Events.OnTokenValidated = CreateTokenValidatedCallback(options.Events.OnTokenValidated, dpopEvents);
         }
+    }
+
+    private Func<JwtBearerChallengeContext, Task> CreateChallengeCallback(Func<JwtBearerChallengeContext, Task> inner, DPoPJwtBearerEvents dpopEvents)
+    {
+        async Task Callback(JwtBearerChallengeContext ctx)
+        {
+            await inner(ctx);
+            await dpopEvents.Challenge(ctx);
+        }
+        return Callback;
+    }
+    
+    private Func<MessageReceivedContext, Task> CreateMessageReceivedCallback(Func<MessageReceivedContext, Task> inner, DPoPJwtBearerEvents dpopEvents)
+    {
+        async Task Callback(MessageReceivedContext ctx)
+        {
+            await inner(ctx);
+            await dpopEvents.MessageReceived(ctx);
+        }
+        return Callback;
+    }
+    
+    private Func<TokenValidatedContext, Task> CreateTokenValidatedCallback(Func<TokenValidatedContext, Task> inner, DPoPJwtBearerEvents dpopEvents)
+    {
+        async Task Callback(TokenValidatedContext ctx)
+        {
+            await inner(ctx);
+            await dpopEvents.TokenValidated(ctx);
+        }
+        return Callback;
     }
 }

--- a/aspnetcore-authentication-jwtbearer/src/AspNetCore.Authentication.JwtBearer/DPoP/DPoPJwtBearerEvents.cs
+++ b/aspnetcore-authentication-jwtbearer/src/AspNetCore.Authentication.JwtBearer/DPoP/DPoPJwtBearerEvents.cs
@@ -13,6 +13,10 @@ using static Duende.IdentityModel.OidcConstants;
 
 namespace Duende.AspNetCore.Authentication.JwtBearer.DPoP;
 
+
+// TODO - refactor this to instead create callbacks that wrap any existing events, a la
+// Duende.Bff.SessionManagement.Configuration.PostConfigureSlidingExpirationCheck
+
 /// <summary>
 /// Events for the Jwt Bearer authentication handler that enable DPoP.
 /// </summary>
@@ -78,12 +82,13 @@ public class DPoPJwtBearerEvents : JwtBearerEvents
 
             var result = await _validator.Validate(new DPoPProofValidationContext
             {
+                Options = dPoPOptions,
                 Scheme = context.Scheme.Name,
                 ProofToken = proofToken,
                 AccessToken = at,
                 AccessTokenClaims = context.Principal?.Claims ?? [],
-                Method = context.HttpContext.Request.Method,
-                Url = context.HttpContext.Request.Scheme + "://" + context.HttpContext.Request.Host + context.HttpContext.Request.PathBase + context.HttpContext.Request.Path
+                ExpectedMethod = context.HttpContext.Request.Method,
+                ExpectedUrl = context.HttpContext.Request.Scheme + "://" + context.HttpContext.Request.Host + context.HttpContext.Request.PathBase + context.HttpContext.Request.Path
             });
 
             if (result.IsError)

--- a/aspnetcore-authentication-jwtbearer/src/AspNetCore.Authentication.JwtBearer/DPoP/DPoPJwtBearerEvents.cs
+++ b/aspnetcore-authentication-jwtbearer/src/AspNetCore.Authentication.JwtBearer/DPoP/DPoPJwtBearerEvents.cs
@@ -17,7 +17,7 @@ namespace Duende.AspNetCore.Authentication.JwtBearer.DPoP;
 /// <summary>
 /// Events for the Jwt Bearer authentication handler that enable DPoP.
 /// </summary>
-internal class DPoPJwtBearerEvents : JwtBearerEvents
+internal class DPoPJwtBearerEvents
 {
     private readonly IOptionsMonitor<DPoPOptions> _optionsMonitor;
     private readonly IDPoPProofValidator _validator;
@@ -26,9 +26,6 @@ internal class DPoPJwtBearerEvents : JwtBearerEvents
     /// <summary>
     /// Constructs a new instance of <see cref="DPoPJwtBearerEvents"/>. 
     /// </summary>
-    /// <param name="optionsMonitor"></param>
-    /// <param name="validator"></param>
-    /// <param name="logger"></param>
     public DPoPJwtBearerEvents(IOptionsMonitor<DPoPOptions> optionsMonitor, IDPoPProofValidator validator, ILogger<DPoPJwtBearerEvents> logger)
     {
         _optionsMonitor = optionsMonitor;

--- a/aspnetcore-authentication-jwtbearer/src/AspNetCore.Authentication.JwtBearer/DPoP/DPoPJwtBearerEvents.cs
+++ b/aspnetcore-authentication-jwtbearer/src/AspNetCore.Authentication.JwtBearer/DPoP/DPoPJwtBearerEvents.cs
@@ -14,13 +14,10 @@ using static Duende.IdentityModel.OidcConstants;
 namespace Duende.AspNetCore.Authentication.JwtBearer.DPoP;
 
 
-// TODO - refactor this to instead create callbacks that wrap any existing events, a la
-// Duende.Bff.SessionManagement.Configuration.PostConfigureSlidingExpirationCheck
-
 /// <summary>
 /// Events for the Jwt Bearer authentication handler that enable DPoP.
 /// </summary>
-public class DPoPJwtBearerEvents : JwtBearerEvents
+internal class DPoPJwtBearerEvents : JwtBearerEvents
 {
     private readonly IOptionsMonitor<DPoPOptions> _optionsMonitor;
     private readonly IDPoPProofValidator _validator;
@@ -43,7 +40,7 @@ public class DPoPJwtBearerEvents : JwtBearerEvents
     /// Attempts to retrieve a DPoP access token from incoming requests, and
     /// optionally enforces its presence.
     /// </summary>
-    public override Task MessageReceived(MessageReceivedContext context)
+    public Task MessageReceived(MessageReceivedContext context)
     {
         _logger.LogDebug("MessageReceived invoked in a JWT bearer authentication scheme using DPoP");
 
@@ -66,7 +63,7 @@ public class DPoPJwtBearerEvents : JwtBearerEvents
     /// <summary>
     /// Ensures that a valid DPoP proof token accompanies DPoP access tokens.
     /// </summary>
-    public override async Task TokenValidated(TokenValidatedContext context)
+    public async Task TokenValidated(TokenValidatedContext context)
     {
         _logger.LogDebug("TokenValidated invoked in a JWT bearer authentication scheme using DPoP");
 
@@ -160,7 +157,7 @@ public class DPoPJwtBearerEvents : JwtBearerEvents
     /// Adds the necessary HTTP headers and response codes for DPoP error
     /// handling and nonce generation.
     /// </summary>
-    public override Task Challenge(JwtBearerChallengeContext context)
+    public Task Challenge(JwtBearerChallengeContext context)
     {
         _logger.LogDebug("Challenge invoked in a JWT bearer authentication scheme using DPoP");
         var dPoPOptions = _optionsMonitor.Get(context.Scheme.Name);

--- a/aspnetcore-authentication-jwtbearer/src/AspNetCore.Authentication.JwtBearer/DPoP/DPoPOptions.cs
+++ b/aspnetcore-authentication-jwtbearer/src/AspNetCore.Authentication.JwtBearer/DPoP/DPoPOptions.cs
@@ -1,12 +1,15 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
+using Duende.IdentityModel;
+using Microsoft.IdentityModel.Tokens;
+
 namespace Duende.AspNetCore.Authentication.JwtBearer.DPoP;
 
 /// <summary>
 /// Options for DPoP.
 /// </summary>
-public class DPoPOptions
+public sealed class DPoPOptions
 {
     /// <summary>
     /// Controls if both DPoP and Bearer tokens are allowed, or only DPoP. Defaults to <see cref="DPoPMode.DPoPOnly"/>.
@@ -43,4 +46,26 @@ public class DPoPOptions
     /// prevent resource-exhaustion attacks. Defaults to 4000 characters.
     /// </summary>
     public int ProofTokenMaxLength { get; set; } = 4000;
+
+    public TokenValidationParameters ProofTokenValidationParameters = new()
+    {
+        ValidateAudience = false,
+        ValidateIssuer = false,
+        ValidateLifetime = false, // We validate lifetime manually, using either iat, server issued nonce, or both
+        ValidTypes = [JwtClaimTypes.JwtTypes.DPoPProofToken],
+        ValidAlgorithms =
+        [
+            SecurityAlgorithms.RsaSha256,
+            SecurityAlgorithms.RsaSha384,
+            SecurityAlgorithms.RsaSha512,
+
+            SecurityAlgorithms.RsaSsaPssSha256,
+            SecurityAlgorithms.RsaSsaPssSha384,
+            SecurityAlgorithms.RsaSsaPssSha512,
+
+            SecurityAlgorithms.EcdsaSha256,
+            SecurityAlgorithms.EcdsaSha384,
+            SecurityAlgorithms.EcdsaSha512
+        ],
+    };
 }

--- a/aspnetcore-authentication-jwtbearer/src/AspNetCore.Authentication.JwtBearer/DPoP/DPoPProofValidatonContext.cs
+++ b/aspnetcore-authentication-jwtbearer/src/AspNetCore.Authentication.JwtBearer/DPoP/DPoPProofValidatonContext.cs
@@ -8,7 +8,7 @@ namespace Duende.AspNetCore.Authentication.JwtBearer.DPoP;
 /// <summary>
 /// Provides contextual information about a DPoP proof during validation.
 /// </summary>
-public record DPoPProofValidationContext
+public sealed record DPoPProofValidationContext
 {
     /// <summary>
     /// The ASP.NET Core authentication scheme triggering the validation
@@ -16,14 +16,14 @@ public record DPoPProofValidationContext
     public required string Scheme { get; init; }
 
     /// <summary>
-    /// The HTTP URL to validate
+    /// The HTTP URL that is expected in the DPoP proof as the htu claim.
     /// </summary>
-    public required string Url { get; init; }
+    public required string ExpectedUrl { get; init; }
 
     /// <summary>
-    /// The HTTP method to validate
+    /// The HTTP method that is expected in the DPoP proof as the htm claim.
     /// </summary>
-    public required string Method { get; init; }
+    public required string ExpectedMethod { get; init; }
 
     /// <summary>
     /// The DPoP proof token to validate
@@ -31,7 +31,7 @@ public record DPoPProofValidationContext
     public required string ProofToken { get; init; }
 
     /// <summary>
-    /// The access token
+    /// The access token that is expected to be bound to the DPoP proof key
     /// </summary>
     public required string AccessToken { get; init; }
 
@@ -41,4 +41,9 @@ public record DPoPProofValidationContext
     /// might be an expensive operation (especially if the token is a reference token).
     /// </summary>
     public IEnumerable<Claim> AccessTokenClaims { get; init; } = [];
+
+    /// <summary>
+    /// The configured options to use when validating the DPoP proof.
+    /// </summary>
+    public required DPoPOptions Options { get; init; }
 }

--- a/aspnetcore-authentication-jwtbearer/src/AspNetCore.Authentication.JwtBearer/DPoP/DPoPProofValidatonResult.cs
+++ b/aspnetcore-authentication-jwtbearer/src/AspNetCore.Authentication.JwtBearer/DPoP/DPoPProofValidatonResult.cs
@@ -8,7 +8,8 @@ namespace Duende.AspNetCore.Authentication.JwtBearer.DPoP;
 /// <summary>
 /// Describes the result of validating a DPoP Proof.
 /// </summary>
-public class DPoPProofValidationResult
+// TODO - Consider success and error types
+public sealed class DPoPProofValidationResult
 {
     /// <summary>
     /// Indicates if the result was successful or not
@@ -73,9 +74,9 @@ public class DPoPProofValidationResult
     /// <summary>
     /// Sets the error properties of the result.
     /// </summary>
-    public void SetError(string description, string message = OidcConstants.TokenErrors.InvalidDPoPProof)
+    public void SetError(string description, string error = OidcConstants.TokenErrors.InvalidDPoPProof)
     {
-        Error = message;
+        Error = error;
         ErrorDescription = description;
         IsError = true;
     }

--- a/aspnetcore-authentication-jwtbearer/src/AspNetCore.Authentication.JwtBearer/DPoP/DPoPProofValidatonResult.cs
+++ b/aspnetcore-authentication-jwtbearer/src/AspNetCore.Authentication.JwtBearer/DPoP/DPoPProofValidatonResult.cs
@@ -8,7 +8,6 @@ namespace Duende.AspNetCore.Authentication.JwtBearer.DPoP;
 /// <summary>
 /// Describes the result of validating a DPoP Proof.
 /// </summary>
-// TODO - Consider success and error types
 public sealed class DPoPProofValidationResult
 {
     /// <summary>

--- a/aspnetcore-authentication-jwtbearer/src/AspNetCore.Authentication.JwtBearer/DPoP/DPoPProofValidator.cs
+++ b/aspnetcore-authentication-jwtbearer/src/AspNetCore.Authentication.JwtBearer/DPoP/DPoPProofValidator.cs
@@ -158,7 +158,7 @@ internal class DPoPProofValidator : IDPoPProofValidator
         }
     }
 
-    internal bool ValidateJwk(DPoPProofValidationContext context, DPoPProofValidationResult result)
+    internal void ValidateJwk(DPoPProofValidationContext context, DPoPProofValidationResult result)
     {
         JsonWebToken token;
 
@@ -171,14 +171,14 @@ internal class DPoPProofValidator : IDPoPProofValidator
         {
             Logger.LogDebug("Error parsing DPoP proof token: {error}", ex.Message);
             result.SetError("Malformed DPoP proof token.");
-            return false;
+            return;
         }
 
         if (!token.TryGetHeaderValue<JsonElement>(JwtClaimTypes.JsonWebKey, out var jwkValues))
         {
             Logger.LogDebug("Failed to get jwk header");
             result.SetError("Invalid 'jwk' value.");
-            return false;
+            return;
         }
 
         var jwkJson = JsonSerializer.Serialize(jwkValues);
@@ -192,20 +192,18 @@ internal class DPoPProofValidator : IDPoPProofValidator
         {
             Logger.LogDebug("Error parsing DPoP jwk value: {error}", ex.Message);
             result.SetError("Invalid 'jwk' value.");
-            return false;
+            return;
         }
 
         if (jwk.HasPrivateKey)
         {
             Logger.LogDebug("'jwk' value contains a private key.");
             result.SetError("'jwk' value contains a private key.");
-            return false;
+            return;
         }
 
         result.JsonWebKey = jwkJson;
         result.JsonWebKeyThumbprint = jwk.CreateThumbprint();
-
-        return true;
     }
 
     /// <summary>

--- a/aspnetcore-authentication-jwtbearer/src/AspNetCore.Authentication.JwtBearer/DPoP/DPoPProofValidator.cs
+++ b/aspnetcore-authentication-jwtbearer/src/AspNetCore.Authentication.JwtBearer/DPoP/DPoPProofValidator.cs
@@ -81,7 +81,7 @@ internal class DPoPProofValidator : IDPoPProofValidator
             Logger.LogDebug("Failed to validate DPoP jwk");
             return result;
         }
-        
+
         await ValidateToken(context, result);
         if (result.IsError)
         {
@@ -109,7 +109,7 @@ internal class DPoPProofValidator : IDPoPProofValidator
         {
             Logger.LogDebug("Detected replay of DPoP proof token");
         }
-        
+
         Logger.LogDebug("Successfully validated DPoP proof token");
         return result;
     }

--- a/aspnetcore-authentication-jwtbearer/src/AspNetCore.Authentication.JwtBearer/DPoP/DPoPProofValidator.cs
+++ b/aspnetcore-authentication-jwtbearer/src/AspNetCore.Authentication.JwtBearer/DPoP/DPoPProofValidator.cs
@@ -14,62 +14,43 @@ using Microsoft.IdentityModel.Tokens;
 namespace Duende.AspNetCore.Authentication.JwtBearer.DPoP;
 
 /// <summary>
-/// Default implementation of IDPoPProofValidator.
+/// Validates DPoP proofs.
 /// </summary>
-public class DefaultDPoPProofValidator : IDPoPProofValidator
+internal class DPoPProofValidator : IDPoPProofValidator
 {
     private const string DataProtectorPurpose = "DPoPJwtBearerEvents-DPoPProofValidation-nonce";
 
     /// <summary>
-    /// The signing algorithms supported for DPoP proofs.
-    /// </summary>
-    protected readonly static IEnumerable<string> SupportedSigningAlgorithms =
-    [
-        SecurityAlgorithms.RsaSha256,
-        SecurityAlgorithms.RsaSha384,
-        SecurityAlgorithms.RsaSha512,
-
-        SecurityAlgorithms.RsaSsaPssSha256,
-        SecurityAlgorithms.RsaSsaPssSha384,
-        SecurityAlgorithms.RsaSsaPssSha512,
-
-        SecurityAlgorithms.EcdsaSha256,
-        SecurityAlgorithms.EcdsaSha384,
-        SecurityAlgorithms.EcdsaSha512
-    ];
-
-
-    /// <summary>
     /// Provides the options for DPoP proof validation. 
     /// </summary>
-    protected readonly IOptionsMonitor<DPoPOptions> OptionsMonitor;
+    internal readonly IOptionsMonitor<DPoPOptions> OptionsMonitor;
 
     /// <summary>
     /// Protects and unprotects nonce values.
     /// </summary>
-    protected readonly IDataProtector DataProtector;
+    internal readonly IDataProtector DataProtector;
 
     /// <summary>
     /// Caches proof tokens to detect replay.
     /// </summary>
-    protected readonly IReplayCache ReplayCache;
+    internal readonly IReplayCache ReplayCache;
 
     /// <summary>
     /// Clock for checking proof expiration.
     /// </summary>
-    protected readonly TimeProvider TimeProvider;
+    internal readonly TimeProvider TimeProvider;
 
     /// <summary>
     /// The logger.
     /// </summary>
-    protected readonly ILogger<DefaultDPoPProofValidator> Logger;
+    internal readonly ILogger<DPoPProofValidator> Logger;
 
     /// <summary>
-    /// Constructs a new instance of the <see cref="DefaultDPoPProofValidator"/>.
+    /// Constructs a new instance of the <see cref="DPoPProofValidator"/>.
     /// </summary>
-    public DefaultDPoPProofValidator(IOptionsMonitor<DPoPOptions> optionsMonitor,
+    public DPoPProofValidator(IOptionsMonitor<DPoPOptions> optionsMonitor,
         IDataProtectionProvider dataProtectionProvider, IReplayCache replayCache,
-        TimeProvider timeProvider, ILogger<DefaultDPoPProofValidator> logger)
+        TimeProvider timeProvider, ILogger<DPoPProofValidator> logger)
     {
         OptionsMonitor = optionsMonitor;
         DataProtector = dataProtectionProvider.CreateProtector(DataProtectorPurpose);
@@ -89,42 +70,95 @@ public class DefaultDPoPProofValidator : IDPoPProofValidator
         if (string.IsNullOrEmpty(context.ProofToken))
         {
             Logger.LogDebug("Missing DPoP proof value");
-            result.SetError("Missing DPoP proof value");
+            result.SetError("Missing DPoP proof value", OidcConstants.TokenErrors.InvalidRequest);
             return result;
         }
 
-        await ValidateHeader(context, result, cancellationToken);
+        // MUST validate jwk before calling ValidateToken - the signature is validated using the jwk
+        ValidateJwk(context, result);
         if (result.IsError)
         {
-            Logger.LogDebug("Failed to validate DPoP header");
+            Logger.LogDebug("Failed to validate DPoP jwk");
             return result;
         }
-
-        await ValidateSignature(context, result, cancellationToken);
+        
+        await ValidateToken(context, result);
         if (result.IsError)
         {
             Logger.LogDebug("Failed to validate DPoP signature");
             return result;
         }
 
-        await ValidatePayload(context, result);
+        ValidateCnf(context, result);
+        if (result.IsError)
+        {
+            Logger.LogDebug("Failed to validate DPoP cnf");
+            return result;
+        }
+
+        ValidatePayload(context, result);
         if (result.IsError)
         {
             Logger.LogDebug("Failed to validate DPoP payload");
             return result;
         }
 
+        // we do replay at the end, so we only add to the reply cache if everything else is ok
+        await ValidateReplay(context, result, cancellationToken);
+        if (result.IsError)
+        {
+            Logger.LogDebug("Detected replay of DPoP proof token");
+        }
+        
         Logger.LogDebug("Successfully validated DPoP proof token");
         return result;
     }
 
-    /// <summary>
-    /// Validates the header.
-    /// </summary>
-    protected virtual Task ValidateHeader(
-        DPoPProofValidationContext context,
-        DPoPProofValidationResult result,
-        CancellationToken cancellationToken = default)
+    internal void ValidateCnf(DPoPProofValidationContext context, DPoPProofValidationResult result)
+    {
+        var cnf = context.AccessTokenClaims.FirstOrDefault(c => c.Type == JwtClaimTypes.Confirmation);
+
+        if (cnf is not { Value.Length: > 0 })
+        {
+            Logger.LogDebug("Empty cnf value in DPoP access token.");
+            result.SetError("Missing 'cnf' value.");
+            return;
+        }
+        try
+        {
+            var cnfJson = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(cnf.Value);
+            if (cnfJson == null)
+            {
+                Logger.LogDebug("Null cnf value in DPoP access token.");
+                result.SetError("Invalid 'cnf' value.");
+            }
+            else if (cnfJson.TryGetValue(JwtClaimTypes.ConfirmationMethods.JwkThumbprint, out var jktJson))
+            {
+                var accessTokenJkt = jktJson.ToString();
+                if (accessTokenJkt == result.JsonWebKeyThumbprint)
+                {
+                    result.Confirmation = cnf.Value;
+                }
+                else
+                {
+                    Logger.LogDebug("jkt in DPoP access token does not match proof token key thumbprint.");
+                    result.SetError("Invalid 'cnf' value.");
+                }
+            }
+            else
+            {
+                Logger.LogDebug("jkt member missing from cnf claim in DPoP access token.");
+                result.SetError("Invalid 'cnf' value.");
+            }
+        }
+        catch (JsonException e)
+        {
+            Logger.LogDebug("Failed to parse DPoP cnf claim: {JsonExceptionMessage}", e.Message);
+            result.SetError("Invalid 'cnf' value.");
+        }
+    }
+
+    internal bool ValidateJwk(DPoPProofValidationContext context, DPoPProofValidationResult result)
     {
         JsonWebToken token;
 
@@ -135,30 +169,16 @@ public class DefaultDPoPProofValidator : IDPoPProofValidator
         }
         catch (Exception ex)
         {
-            Logger.LogDebug("Error parsing DPoP token: {error}", ex.Message);
-            result.SetError("Malformed DPoP token.");
-            return Task.CompletedTask;
-        }
-
-        if (!token.TryGetHeaderValue<string>("typ", out var typ) || typ != JwtClaimTypes.JwtTypes.DPoPProofToken)
-        {
-            Logger.LogDebug("Failed to get typ header");
-            result.SetError("Invalid 'typ' value.");
-            return Task.CompletedTask;
-        }
-
-        if (!token.TryGetHeaderValue<string>("alg", out var alg) || !SupportedSigningAlgorithms.Contains(alg))
-        {
-            Logger.LogDebug("Failed to get valid alg header");
-            result.SetError("Invalid 'alg' value.");
-            return Task.CompletedTask;
+            Logger.LogDebug("Error parsing DPoP proof token: {error}", ex.Message);
+            result.SetError("Malformed DPoP proof token.");
+            return false;
         }
 
         if (!token.TryGetHeaderValue<JsonElement>(JwtClaimTypes.JsonWebKey, out var jwkValues))
         {
             Logger.LogDebug("Failed to get jwk header");
             result.SetError("Invalid 'jwk' value.");
-            return Task.CompletedTask;
+            return false;
         }
 
         var jwkJson = JsonSerializer.Serialize(jwkValues);
@@ -172,97 +192,49 @@ public class DefaultDPoPProofValidator : IDPoPProofValidator
         {
             Logger.LogDebug("Error parsing DPoP jwk value: {error}", ex.Message);
             result.SetError("Invalid 'jwk' value.");
-            return Task.CompletedTask;
+            return false;
         }
 
         if (jwk.HasPrivateKey)
         {
             Logger.LogDebug("'jwk' value contains a private key.");
             result.SetError("'jwk' value contains a private key.");
-            return Task.CompletedTask;
+            return false;
         }
 
         result.JsonWebKey = jwkJson;
         result.JsonWebKeyThumbprint = jwk.CreateThumbprint();
 
-        var cnf = context.AccessTokenClaims.FirstOrDefault(c => c.Type == JwtClaimTypes.Confirmation);
-        if (cnf is not { Value.Length: > 0 })
-        {
-            Logger.LogDebug("Empty cnf value in DPoP access token.");
-            result.SetError("Missing 'cnf' value.");
-            return Task.CompletedTask;
-        }
-        try
-        {
-            var cnfJson = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(cnf.Value);
-            if (cnfJson == null)
-            {
-                Logger.LogDebug("Null cnf value in DPoP access token.");
-                result.SetError("Invalid 'cnf' value.");
-                return Task.CompletedTask;
-            }
-            else if (cnfJson.TryGetValue(JwtClaimTypes.ConfirmationMethods.JwkThumbprint, out var jktJson))
-            {
-                var accessTokenJkt = jktJson.ToString();
-                if (accessTokenJkt == result.JsonWebKeyThumbprint)
-                {
-                    result.Confirmation = cnf.Value;
-                }
-                else
-                {
-                    Logger.LogDebug("jkt in DPoP access token does not match proof token key thumbprint.");
-                }
-            }
-            else
-            {
-                Logger.LogDebug("jkt member missing from cnf claim in DPoP access token.");
-            }
-        }
-        catch (JsonException e)
-        {
-            Logger.LogDebug("Failed to parse DPoP cnf claim: {JsonExceptionMessage}", e.Message);
-        }
-        if (result.Confirmation == null)
-        {
-            result.SetError("Invalid 'cnf' value.");
-        }
-        return Task.CompletedTask;
+        return true;
     }
 
     /// <summary>
-    /// Validates the signature.
+    /// Performs all the validation that we can using the JsonWebTokenHandler, including signature, alg, and typ validation
     /// </summary>
-    protected virtual async Task ValidateSignature(
+    internal async Task ValidateToken(
         DPoPProofValidationContext context,
-        DPoPProofValidationResult result,
-        CancellationToken cancellationToken = default)
+        DPoPProofValidationResult result)
     {
         TokenValidationResult? tokenValidationResult = null;
 
         try
         {
-            var key = new JsonWebKey(result.JsonWebKey);
-            var tvp = new TokenValidationParameters
-            {
-                ValidateAudience = false,
-                ValidateIssuer = false,
-                ValidateLifetime = false,
-                IssuerSigningKey = key,
-            };
+            var tvp = context.Options.ProofTokenValidationParameters;
+            tvp.IssuerSigningKey = new JsonWebKey(result.JsonWebKey);
 
             var handler = new JsonWebTokenHandler();
             tokenValidationResult = await handler.ValidateTokenAsync(context.ProofToken, tvp);
         }
         catch (Exception ex)
         {
-            Logger.LogDebug("Error parsing DPoP token: {error}", ex.Message);
-            result.SetError("Invalid signature on DPoP token.");
+            Logger.LogDebug("Error parsing DPoP proof token: {error}", ex.Message);
+            result.SetError("Invalid DPoP proof token.");
         }
 
         if (tokenValidationResult?.Exception != null)
         {
-            Logger.LogDebug("Error parsing DPoP token: {error}", tokenValidationResult.Exception.Message);
-            result.SetError("Invalid signature on DPoP token.");
+            Logger.LogDebug("Error validating DPoP proof token: {error}", tokenValidationResult.Exception.Message);
+            result.SetError("Invalid DPoP proof token.");
         }
 
         if (tokenValidationResult != null)
@@ -271,10 +243,7 @@ public class DefaultDPoPProofValidator : IDPoPProofValidator
         }
     }
 
-    /// <summary>
-    /// Validates the payload.
-    /// </summary>
-    protected virtual async Task ValidatePayload(DPoPProofValidationContext context, DPoPProofValidationResult result, CancellationToken cancellationToken = default)
+    internal void ValidatePayload(DPoPProofValidationContext context, DPoPProofValidationResult result)
     {
         if (result.Payload is null)
         {
@@ -320,13 +289,13 @@ public class DefaultDPoPProofValidator : IDPoPProofValidator
             return;
         }
 
-        if (!result.Payload.TryGetValue(JwtClaimTypes.DPoPHttpMethod, out var htm) || !context.Method.Equals(htm))
+        if (!result.Payload.TryGetValue(JwtClaimTypes.DPoPHttpMethod, out var htm) || !context.ExpectedMethod.Equals(htm))
         {
             result.SetError("Invalid 'htm' value.");
             return;
         }
 
-        if (!result.Payload.TryGetValue(JwtClaimTypes.DPoPHttpUrl, out var htu) || !context.Url.Equals(htu))
+        if (!result.Payload.TryGetValue(JwtClaimTypes.DPoPHttpUrl, out var htu) || !context.ExpectedUrl.Equals(htu))
         {
             result.SetError("Invalid 'htu' value.");
             return;
@@ -353,25 +322,18 @@ public class DefaultDPoPProofValidator : IDPoPProofValidator
             result.Nonce = nonce as string;
         }
 
-        await ValidateFreshness(context, result, cancellationToken);
+        ValidateFreshness(context, result);
         if (result.IsError)
         {
-            Logger.LogDebug("Failed to validate DPoP token freshness");
+            Logger.LogDebug("Failed to validate DPoP proof token freshness");
             return;
-        }
-
-        // we do replay at the end, so we only add to the reply cache if everything else is ok
-        await ValidateReplay(context, result, cancellationToken);
-        if (result.IsError)
-        {
-            Logger.LogDebug("Detected replay of DPoP token");
         }
     }
 
     /// <summary>
     /// Validates if the token has been replayed.
     /// </summary>
-    protected virtual async Task ValidateReplay(
+    internal async Task ValidateReplay(
         DPoPProofValidationContext context,
         DPoPProofValidationResult result,
         CancellationToken cancellationToken = default)
@@ -384,7 +346,7 @@ public class DefaultDPoPProofValidator : IDPoPProofValidator
             return;
         }
 
-        // get the largest skew based on how client's freshness is validated
+        // get the largest skew based on how the client's freshness is validated
         var validateIat = dPoPOptions.ValidationMode != ExpirationValidationMode.Nonce;
         var validateNonce = dPoPOptions.ValidationMode != ExpirationValidationMode.IssuedAt;
         var skew = TimeSpan.Zero;
@@ -397,7 +359,7 @@ public class DefaultDPoPProofValidator : IDPoPProofValidator
             skew = dPoPOptions.ServerClockSkew;
         }
 
-        // we do x2 here because clock might be before or after, so we're making cache duration 
+        // we do x2 here because the clock might be before or after, so we're making cache duration 
         // longer than the likelihood of proof token expiration, which is done before replay
         skew *= 2;
         var cacheDuration = dPoPOptions.ProofTokenValidityDuration + skew;
@@ -408,17 +370,16 @@ public class DefaultDPoPProofValidator : IDPoPProofValidator
     /// <summary>
     /// Validates freshness of proofs.
     /// </summary>
-    protected virtual async Task ValidateFreshness(
+    internal void ValidateFreshness(
         DPoPProofValidationContext context,
-        DPoPProofValidationResult result,
-        CancellationToken cancellationToken = default)
+        DPoPProofValidationResult result)
     {
         var dPoPOptions = OptionsMonitor.Get(context.Scheme);
 
         var validateIat = dPoPOptions.ValidationMode != ExpirationValidationMode.Nonce;
         if (validateIat)
         {
-            await ValidateIat(context, result, cancellationToken);
+            ValidateIat(context, result);
             if (result.IsError)
             {
                 return;
@@ -428,7 +389,7 @@ public class DefaultDPoPProofValidator : IDPoPProofValidator
         var validateNonce = dPoPOptions.ValidationMode != ExpirationValidationMode.IssuedAt;
         if (validateNonce)
         {
-            await ValidateNonce(context, result, cancellationToken);
+            ValidateNonce(context, result);
             if (result.IsError)
             {
                 return;
@@ -439,26 +400,23 @@ public class DefaultDPoPProofValidator : IDPoPProofValidator
     /// <summary>
     /// Validates the freshness of the iat value.
     /// </summary>
-    protected virtual Task ValidateIat(
+    internal void ValidateIat(
         DPoPProofValidationContext context,
-        DPoPProofValidationResult result,
-        CancellationToken _ = default)
+        DPoPProofValidationResult result)
     {
         // iat is required by an earlier validation, so result.IssuedAt will not be null
         if (IsExpired(context, result, result.IssuedAt!.Value, ExpirationValidationMode.IssuedAt))
         {
             result.SetError("Invalid 'iat' value.");
         }
-        return Task.CompletedTask;
     }
 
     /// <summary>
     /// Validates the freshness of the nonce value.
     /// </summary>
-    protected virtual async Task ValidateNonce(
+    internal void ValidateNonce(
         DPoPProofValidationContext context,
-        DPoPProofValidationResult result,
-        CancellationToken _ = default)
+        DPoPProofValidationResult result)
     {
         if (string.IsNullOrWhiteSpace(result.Nonce))
         {
@@ -467,7 +425,7 @@ public class DefaultDPoPProofValidator : IDPoPProofValidator
             return;
         }
 
-        var time = await GetUnixTimeFromNonceAsync(context, result);
+        var time = GetUnixTimeFromNonce(context, result);
         if (time <= 0)
         {
             Logger.LogDebug("Invalid time value read from the 'nonce' value");
@@ -490,7 +448,7 @@ public class DefaultDPoPProofValidator : IDPoPProofValidator
     /// <summary>
     /// Creates a nonce value to return to the client.
     /// </summary>
-    protected virtual string CreateNonce(DPoPProofValidationContext context, DPoPProofValidationResult result)
+    internal string CreateNonce(DPoPProofValidationContext context, DPoPProofValidationResult result)
     {
         var now = TimeProvider.GetUtcNow().ToUnixTimeSeconds();
         return DataProtector.Protect(now.ToString());
@@ -499,29 +457,30 @@ public class DefaultDPoPProofValidator : IDPoPProofValidator
     /// <summary>
     /// Reads the time the nonce was created.
     /// </summary>
-    protected virtual ValueTask<long> GetUnixTimeFromNonceAsync(DPoPProofValidationContext context, DPoPProofValidationResult result)
+    internal long GetUnixTimeFromNonce(DPoPProofValidationContext context, DPoPProofValidationResult result)
     {
         try
         {
             var value = DataProtector.Unprotect(result.Nonce!); // nonce is required by an earlier validation
             if (long.TryParse(value, out var iat))
             {
-                return ValueTask.FromResult(iat);
+                return iat;
             }
         }
         catch (Exception ex)
         {
+            // TODO - Should we swallow this error? Really?
             Logger.LogDebug("Error parsing DPoP 'nonce' value: {error}", ex.ToString());
         }
 
-        return ValueTask.FromResult<long>(0);
+        return 0;
     }
 
     /// <summary>
     /// Validates the expiration of the DPoP proof.
     /// Returns true if the time is beyond the allowed limits, false otherwise.
     /// </summary>
-    protected virtual bool IsExpired(DPoPProofValidationContext context, DPoPProofValidationResult result, long time,
+    internal bool IsExpired(DPoPProofValidationContext context, DPoPProofValidationResult result, long time,
         ExpirationValidationMode mode)
     {
         var dpopOptions = OptionsMonitor.Get(context.Scheme);

--- a/aspnetcore-authentication-jwtbearer/src/AspNetCore.Authentication.JwtBearer/DPoP/DPoPProofValidator.cs
+++ b/aspnetcore-authentication-jwtbearer/src/AspNetCore.Authentication.JwtBearer/DPoP/DPoPProofValidator.cs
@@ -469,10 +469,10 @@ internal class DPoPProofValidator : IDPoPProofValidator
         }
         catch (Exception ex)
         {
-            // TODO - Should we swallow this error? Really?
             Logger.LogDebug("Error parsing DPoP 'nonce' value: {error}", ex.ToString());
         }
 
+        // We return 0 to indicate failure.
         return 0;
     }
 

--- a/aspnetcore-authentication-jwtbearer/src/AspNetCore.Authentication.JwtBearer/DPoP/DPoPServiceCollectionExtensions.cs
+++ b/aspnetcore-authentication-jwtbearer/src/AspNetCore.Authentication.JwtBearer/DPoP/DPoPServiceCollectionExtensions.cs
@@ -24,7 +24,14 @@ public static class DPoPServiceCollectionExtensions
         services.AddDistributedMemoryCache();
         services.AddTransient<IReplayCache, ReplayCache>();
 
-        services.AddSingleton<IPostConfigureOptions<JwtBearerOptions>>(new ConfigureJwtBearerOptions(scheme));
+        services.AddSingleton<ConfigureJwtBearerOptions>();
+        services.AddSingleton<IPostConfigureOptions<JwtBearerOptions>>(sp =>
+        {
+            var opt = sp.GetRequiredService<ConfigureJwtBearerOptions>();
+            opt.Scheme = scheme;
+            return opt;
+        });
+        services.AddSingleton<IPostConfigureOptions<JwtBearerOptions>, ConfigureJwtBearerOptions>();
 
         return services;
     }

--- a/aspnetcore-authentication-jwtbearer/src/AspNetCore.Authentication.JwtBearer/DPoP/DPoPServiceCollectionExtensions.cs
+++ b/aspnetcore-authentication-jwtbearer/src/AspNetCore.Authentication.JwtBearer/DPoP/DPoPServiceCollectionExtensions.cs
@@ -20,9 +20,9 @@ public static class DPoPServiceCollectionExtensions
         services.AddOptions<DPoPOptions>();
 
         services.AddTransient<DPoPJwtBearerEvents>();
-        services.AddTransient<IDPoPProofValidator, DefaultDPoPProofValidator>();
+        services.AddTransient<IDPoPProofValidator, DPoPProofValidator>();
         services.AddDistributedMemoryCache();
-        services.AddTransient<IReplayCache, DefaultReplayCache>();
+        services.AddTransient<IReplayCache, ReplayCache>();
 
         services.AddSingleton<IPostConfigureOptions<JwtBearerOptions>>(new ConfigureJwtBearerOptions(scheme));
 

--- a/aspnetcore-authentication-jwtbearer/src/AspNetCore.Authentication.JwtBearer/DPoP/ReplayCache.cs
+++ b/aspnetcore-authentication-jwtbearer/src/AspNetCore.Authentication.JwtBearer/DPoP/ReplayCache.cs
@@ -8,16 +8,16 @@ namespace Duende.AspNetCore.Authentication.JwtBearer.DPoP;
 /// <summary>
 /// Default implementation of the replay cache using IDistributedCache
 /// </summary>
-public class DefaultReplayCache : IReplayCache
+internal class ReplayCache : IReplayCache
 {
     private const string Prefix = "DPoPJwtBearerEvents-DPoPReplay-jti-";
 
     private readonly IDistributedCache _cache;
 
     /// <summary>
-    /// Constructs new instances of <see cref="DefaultReplayCache"/>.
+    /// Constructs new instances of <see cref="ReplayCache"/>.
     /// </summary>
-    public DefaultReplayCache(IDistributedCache cache) => _cache = cache;
+    public ReplayCache(IDistributedCache cache) => _cache = cache;
 
     /// <inheritdoc />
     public async Task Add(string handle, DateTimeOffset expiration, CancellationToken cancellationToken)

--- a/aspnetcore-authentication-jwtbearer/test/AspNetCore.Authentication.JwtBearer.Tests/AspNetCore.Authentication.JwtBearer.Tests.csproj
+++ b/aspnetcore-authentication-jwtbearer/test/AspNetCore.Authentication.JwtBearer.Tests/AspNetCore.Authentication.JwtBearer.Tests.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Duende.IdentityServer" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" VersionOverride="9.0.4" />
     <PackageReference Include="Meziantou.Extensions.Logging.Xunit" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="NSubstitute" />

--- a/aspnetcore-authentication-jwtbearer/test/AspNetCore.Authentication.JwtBearer.Tests/DPoP/AccessTokenCnfTests.cs
+++ b/aspnetcore-authentication-jwtbearer/test/AspNetCore.Authentication.JwtBearer.Tests/DPoP/AccessTokenCnfTests.cs
@@ -13,23 +13,23 @@ public class AccessTokenCnfTests : DPoPProofValidatorTestBase
 {
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task missing_cnf_should_fail()
+    public void missing_cnf_should_fail()
     {
         Context.AccessTokenClaims
             .ShouldNotContain(c => c.Type == JwtClaimTypes.Confirmation);
 
-        await ProofValidator.ValidateHeader(Context, Result);
+        ProofValidator.ValidateCnf(Context, Result);
 
         Result.ShouldBeInvalidProofWithDescription("Missing 'cnf' value.");
     }
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task empty_cnf_value_should_fail()
+    public void empty_cnf_value_should_fail()
     {
         Context = Context with { AccessTokenClaims = [new Claim(JwtClaimTypes.Confirmation, string.Empty)] };
 
-        await ProofValidator.ValidateHeader(Context, Result);
+        ProofValidator.ValidateCnf(Context, Result);
 
         Result.ShouldBeInvalidProofWithDescription("Missing 'cnf' value.");
     }
@@ -46,18 +46,18 @@ public class AccessTokenCnfTests : DPoPProofValidatorTestBase
     [InlineData("[123]")]
     [InlineData("[\"asdf\"]")]
     [InlineData("null")]
-    public async Task non_json_object_cnf_should_fail(string cnf)
+    public void non_json_object_cnf_should_fail(string cnf)
     {
         Context = Context with { AccessTokenClaims = [new Claim(JwtClaimTypes.Confirmation, cnf)] };
 
-        await ProofValidator.ValidateHeader(Context, Result);
+        ProofValidator.ValidateCnf(Context, Result);
 
         Result.ShouldBeInvalidProofWithDescription("Invalid 'cnf' value.");
     }
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task cnf_missing_jkt_should_fail()
+    public void cnf_missing_jkt_should_fail()
     {
         var cnfObject = new Dictionary<string, string>
         {
@@ -65,20 +65,20 @@ public class AccessTokenCnfTests : DPoPProofValidatorTestBase
         };
         Context = Context with { AccessTokenClaims = [new Claim(JwtClaimTypes.Confirmation, JsonSerializer.Serialize(cnfObject))] };
 
-        await ProofValidator.ValidateHeader(Context, Result);
+        ProofValidator.ValidateCnf(Context, Result);
 
         Result.ShouldBeInvalidProofWithDescription("Invalid 'cnf' value.");
     }
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task mismatched_jkt_should_fail()
+    public void mismatched_jkt_should_fail()
     {
         // Generate a new key, and use that in the access token's cnf claim
         // to simulate using the wrong key.
         Context = Context with { AccessTokenClaims = [CnfClaim(GenerateJwk())] };
 
-        await ProofValidator.ValidateHeader(Context, Result);
+        ProofValidator.ValidateCnf(Context, Result);
 
         Result.ShouldBeInvalidProofWithDescription("Invalid 'cnf' value.");
     }

--- a/aspnetcore-authentication-jwtbearer/test/AspNetCore.Authentication.JwtBearer.Tests/DPoP/DPoPProofValidatorTestBase.cs
+++ b/aspnetcore-authentication-jwtbearer/test/AspNetCore.Authentication.JwtBearer.Tests/DPoP/DPoPProofValidatorTestBase.cs
@@ -20,11 +20,21 @@ public abstract class DPoPProofValidatorTestBase
         ProofValidator = CreateProofValidator();
         var jtiBytes = Encoding.UTF8.GetBytes(TokenId);
         TokenIdHash = Base64Url.Encode(SHA256.HashData(jtiBytes));
+        Context = new()
+        {
+            Options = Options,
+            Scheme = "test-auth-scheme",
+            ExpectedMethod = HttpMethod,
+            AccessToken = AccessToken,
+            ProofToken = CreateDPoPProofToken(),
+            ExpectedUrl = HttpUrl
+        };
     }
 
     // This is our system under test
     protected TestDPoPProofValidator ProofValidator { get; init; }
 
+    protected DPoPProofValidationContext Context;
     protected DPoPOptions Options = new();
     protected IReplayCache ReplayCache = Substitute.For<IReplayCache>();
 
@@ -39,14 +49,6 @@ public abstract class DPoPProofValidatorTestBase
         );
     }
 
-    protected DPoPProofValidationContext Context = new()
-    {
-        Scheme = "test-auth-scheme",
-        Method = HttpMethod,
-        AccessToken = AccessToken,
-        ProofToken = CreateDPoPProofToken(),
-        Url = HttpUrl
-    };
 
     protected DPoPProofValidationResult Result = new();
 

--- a/aspnetcore-authentication-jwtbearer/test/AspNetCore.Authentication.JwtBearer.Tests/DPoP/FreshnessTests.cs
+++ b/aspnetcore-authentication-jwtbearer/test/AspNetCore.Authentication.JwtBearer.Tests/DPoP/FreshnessTests.cs
@@ -10,22 +10,22 @@ public class FreshnessTests : DPoPProofValidatorTestBase
 {
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task can_retrieve_issued_at_unix_time_from_nonce()
+    public void can_retrieve_issued_at_unix_time_from_nonce()
     {
         Result.Nonce = ProofValidator.TestDataProtector.Protect(IssuedAt.ToString());
 
-        var actual = await ProofValidator.GetUnixTimeFromNonceAsync(Context, Result);
+        var actual = ProofValidator.GetUnixTimeFromNonce(Context, Result);
 
         actual.ShouldBe(IssuedAt);
     }
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task invalid_nonce_is_treated_as_zero()
+    public void invalid_nonce_is_treated_as_zero()
     {
         Result.Nonce = ProofValidator.TestDataProtector.Protect("garbage that isn't a long");
 
-        var actual = await ProofValidator.GetUnixTimeFromNonceAsync(Context, Result);
+        var actual = ProofValidator.GetUnixTimeFromNonce(Context, Result);
 
         actual.ShouldBe(0);
     }
@@ -46,12 +46,12 @@ public class FreshnessTests : DPoPProofValidatorTestBase
     [InlineData((string?)null)]
     [InlineData("")]
     [InlineData(" ")]
-    public async Task missing_nonce_returns_use_dpop_nonce_with_server_issued_nonce(string? nonce)
+    public void missing_nonce_returns_use_dpop_nonce_with_server_issued_nonce(string? nonce)
     {
         Result.Nonce = nonce;
         ProofValidator.TestTimeProvider.SetUtcNow(DateTimeOffset.FromUnixTimeSeconds(IssuedAt));
 
-        await ProofValidator.ValidateNonce(Context, Result);
+        ProofValidator.ValidateNonce(Context, Result);
 
         Result.IsError.ShouldBeTrue();
         Result.Error.ShouldBe(OidcConstants.TokenErrors.UseDPoPNonce);
@@ -64,12 +64,12 @@ public class FreshnessTests : DPoPProofValidatorTestBase
     [Trait("Category", "Unit")]
     [InlineData("null")]
     [InlineData("garbage")]
-    public async Task invalid_nonce_returns_use_dpop_nonce_with_server_issued_nonce(string? nonce)
+    public void invalid_nonce_returns_use_dpop_nonce_with_server_issued_nonce(string? nonce)
     {
         Result.Nonce = nonce;
         ProofValidator.TestTimeProvider.SetUtcNow(DateTimeOffset.FromUnixTimeSeconds(IssuedAt));
 
-        await ProofValidator.ValidateNonce(Context, Result);
+        ProofValidator.ValidateNonce(Context, Result);
 
         Result.IsError.ShouldBeTrue();
         Result.Error.ShouldBe(OidcConstants.TokenErrors.UseDPoPNonce);
@@ -80,7 +80,7 @@ public class FreshnessTests : DPoPProofValidatorTestBase
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task expired_nonce_returns_use_dpop_nonce_with_server_issued_nonce()
+    public void expired_nonce_returns_use_dpop_nonce_with_server_issued_nonce()
     {
         Options.ProofTokenValidityDuration = TimeSpan.FromSeconds(ValidFor);
         Options.ServerClockSkew = TimeSpan.FromSeconds(ClockSkew);
@@ -92,7 +92,7 @@ public class FreshnessTests : DPoPProofValidatorTestBase
 
         Result.Nonce = ProofValidator.TestDataProtector.Protect(IssuedAt.ToString());
 
-        await ProofValidator.ValidateNonce(Context, Result);
+        ProofValidator.ValidateNonce(Context, Result);
 
         Result.IsError.ShouldBeTrue();
         Result.Error.ShouldBe(OidcConstants.TokenErrors.UseDPoPNonce);
@@ -169,7 +169,7 @@ public class FreshnessTests : DPoPProofValidatorTestBase
 
         ProofValidator.TestTimeProvider.SetUtcNow(DateTimeOffset.FromUnixTimeSeconds(IssuedAt));
 
-        await ProofValidator.ValidateIat(Context, Result);
+        ProofValidator.ValidateIat(Context, Result);
 
         Result.IsError.ShouldBeFalse();
         Result.Error.ShouldBeNull();
@@ -188,7 +188,7 @@ public class FreshnessTests : DPoPProofValidatorTestBase
         var now = IssuedAt + ClockSkew + ValidFor + 1;
         ProofValidator.TestTimeProvider.SetUtcNow(DateTimeOffset.FromUnixTimeSeconds(now));
 
-        await ProofValidator.ValidateIat(Context, Result);
+        ProofValidator.ValidateIat(Context, Result);
 
         Result.ShouldBeInvalidProofWithDescription("Invalid 'iat' value.");
     }
@@ -212,12 +212,12 @@ public class FreshnessTests : DPoPProofValidatorTestBase
         // Adjust time to exactly on the expiration
         ProofValidator.TestTimeProvider.SetUtcNow(DateTimeOffset.FromUnixTimeSeconds(IssuedAt + ValidFor + ClockSkew));
 
-        await ProofValidator.ValidateFreshness(Context, Result);
+        ProofValidator.ValidateFreshness(Context, Result);
         Result.IsError.ShouldBeFalse();
 
         // Now adjust time to one second later and try again
         ProofValidator.TestTimeProvider.SetUtcNow(DateTimeOffset.FromUnixTimeSeconds(IssuedAt + ValidFor + ClockSkew + 1));
-        await ProofValidator.ValidateFreshness(Context, Result);
+        ProofValidator.ValidateFreshness(Context, Result);
         Result.IsError.ShouldBeTrue();
     }
 
@@ -239,12 +239,12 @@ public class FreshnessTests : DPoPProofValidatorTestBase
         // Adjust time to exactly on the expiration
         ProofValidator.TestTimeProvider.SetUtcNow(DateTimeOffset.FromUnixTimeSeconds(IssuedAt + ValidFor + ClockSkew));
 
-        await ProofValidator.ValidateFreshness(Context, Result);
+        ProofValidator.ValidateFreshness(Context, Result);
         Result.IsError.ShouldBeFalse();
 
         // Now adjust time to one second later and try again
         ProofValidator.TestTimeProvider.SetUtcNow(DateTimeOffset.FromUnixTimeSeconds(IssuedAt + ValidFor + ClockSkew + 1));
-        await ProofValidator.ValidateFreshness(Context, Result);
+        ProofValidator.ValidateFreshness(Context, Result);
         Result.IsError.ShouldBeTrue();
     }
 }

--- a/aspnetcore-authentication-jwtbearer/test/AspNetCore.Authentication.JwtBearer.Tests/DPoP/FreshnessTests.cs
+++ b/aspnetcore-authentication-jwtbearer/test/AspNetCore.Authentication.JwtBearer.Tests/DPoP/FreshnessTests.cs
@@ -161,7 +161,7 @@ public class FreshnessTests : DPoPProofValidatorTestBase
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task unexpired_proofs_do_not_set_errors()
+    public void unexpired_proofs_do_not_set_errors()
     {
         Options.ProofTokenValidityDuration = TimeSpan.FromSeconds(ValidFor);
         Options.ClientClockSkew = TimeSpan.FromSeconds(ClockSkew);
@@ -178,7 +178,7 @@ public class FreshnessTests : DPoPProofValidatorTestBase
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task expired_proofs_set_errors()
+    public void expired_proofs_set_errors()
     {
         Options.ProofTokenValidityDuration = TimeSpan.FromSeconds(ValidFor);
         Options.ClientClockSkew = TimeSpan.FromSeconds(ClockSkew);
@@ -197,7 +197,7 @@ public class FreshnessTests : DPoPProofValidatorTestBase
     [InlineData(ExpirationValidationMode.IssuedAt)]
     [InlineData(ExpirationValidationMode.Both)]
     [Trait("Category", "Unit")]
-    public async Task validate_iat_when_option_is_set(ExpirationValidationMode mode)
+    public void validate_iat_when_option_is_set(ExpirationValidationMode mode)
     {
         Options.ValidationMode = mode;
         Options.ProofTokenValidityDuration = TimeSpan.FromSeconds(ValidFor);
@@ -225,7 +225,7 @@ public class FreshnessTests : DPoPProofValidatorTestBase
     [InlineData(ExpirationValidationMode.Nonce)]
     [InlineData(ExpirationValidationMode.Both)]
     [Trait("Category", "Unit")]
-    public async Task validate_nonce_when_option_is_set(ExpirationValidationMode mode)
+    public void validate_nonce_when_option_is_set(ExpirationValidationMode mode)
     {
         Options.ValidationMode = mode;
         Options.ProofTokenValidityDuration = TimeSpan.FromSeconds(ValidFor);

--- a/aspnetcore-authentication-jwtbearer/test/AspNetCore.Authentication.JwtBearer.Tests/DPoP/PayloadTests.cs
+++ b/aspnetcore-authentication-jwtbearer/test/AspNetCore.Authentication.JwtBearer.Tests/DPoP/PayloadTests.cs
@@ -9,39 +9,41 @@ public class PayloadTests : DPoPProofValidatorTestBase
 {
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task missing_payload_fails()
+    public Task missing_payload_fails()
     {
         Result.Payload = null;
 
-        await ProofValidator.ValidatePayload(Context, Result);
+        ProofValidator.ValidatePayload(Context, Result);
 
         Result.ShouldBeInvalidProofWithDescription("Missing payload");
         ProofValidator.ReplayCacheShouldNotBeCalled();
+        return Task.CompletedTask;
     }
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task missing_ath_fails()
+    public Task missing_ath_fails()
     {
         Result.Payload = new Dictionary<string, object>();
         Result.Payload.ShouldNotContainKey(JwtClaimTypes.DPoPAccessTokenHash);
 
-        await ProofValidator.ValidatePayload(Context, Result);
+        ProofValidator.ValidatePayload(Context, Result);
 
         Result.ShouldBeInvalidProofWithDescription("Invalid 'ath' value.");
         ProofValidator.ReplayCacheShouldNotBeCalled();
+        return Task.CompletedTask;
     }
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task mismatched_ath_fails()
+    public void mismatched_ath_fails()
     {
         Result.Payload = new Dictionary<string, object>
         {
             { JwtClaimTypes.DPoPAccessTokenHash, "garbage that does not hash to the access token" }
         };
 
-        await ProofValidator.ValidatePayload(Context, Result);
+        ProofValidator.ValidatePayload(Context, Result);
 
         Result.ShouldBeInvalidProofWithDescription("Invalid 'ath' value.");
         ProofValidator.ReplayCacheShouldNotBeCalled();
@@ -49,14 +51,14 @@ public class PayloadTests : DPoPProofValidatorTestBase
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task missing_jti_fails()
+    public void missing_jti_fails()
     {
         Result.Payload = new Dictionary<string, object>
         {
             { JwtClaimTypes.DPoPAccessTokenHash, AccessTokenHash },
         };
 
-        await ProofValidator.ValidatePayload(Context, Result);
+        ProofValidator.ValidatePayload(Context, Result);
 
         Result.ShouldBeInvalidProofWithDescription("Invalid 'jti' value.");
         ProofValidator.ReplayCacheShouldNotBeCalled();
@@ -64,7 +66,7 @@ public class PayloadTests : DPoPProofValidatorTestBase
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task missing_htm_fails()
+    public void missing_htm_fails()
     {
         Result.Payload = new Dictionary<string, object>
         {
@@ -72,7 +74,7 @@ public class PayloadTests : DPoPProofValidatorTestBase
             { JwtClaimTypes.JwtId, TokenId },
         };
 
-        await ProofValidator.ValidatePayload(Context, Result);
+        ProofValidator.ValidatePayload(Context, Result);
 
         Result.ShouldBeInvalidProofWithDescription("Invalid 'htm' value.");
         ProofValidator.ReplayCacheShouldNotBeCalled();
@@ -80,7 +82,7 @@ public class PayloadTests : DPoPProofValidatorTestBase
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task missing_htu_fails()
+    public void missing_htu_fails()
     {
         Result.Payload = new Dictionary<string, object>
         {
@@ -89,7 +91,7 @@ public class PayloadTests : DPoPProofValidatorTestBase
             { JwtClaimTypes.DPoPHttpMethod, HttpMethod },
         };
 
-        await ProofValidator.ValidatePayload(Context, Result);
+        ProofValidator.ValidatePayload(Context, Result);
 
         Result.ShouldBeInvalidProofWithDescription("Invalid 'htu' value.");
         ProofValidator.ReplayCacheShouldNotBeCalled();
@@ -97,7 +99,7 @@ public class PayloadTests : DPoPProofValidatorTestBase
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task missing_iat_fails()
+    public void missing_iat_fails()
     {
         Result.Payload = new Dictionary<string, object>
         {
@@ -107,7 +109,7 @@ public class PayloadTests : DPoPProofValidatorTestBase
             { JwtClaimTypes.DPoPHttpUrl, HttpUrl }
         };
 
-        await ProofValidator.ValidatePayload(Context, Result);
+        ProofValidator.ValidatePayload(Context, Result);
 
         Result.ShouldBeInvalidProofWithDescription("Invalid 'iat' value.");
         ProofValidator.ReplayCacheShouldNotBeCalled();
@@ -115,7 +117,7 @@ public class PayloadTests : DPoPProofValidatorTestBase
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task expired_payload_fails()
+    public void expired_payload_fails()
     {
         Options.ProofTokenValidityDuration = TimeSpan.FromSeconds(ValidFor);
         Options.ClientClockSkew = TimeSpan.FromSeconds(ClockSkew);
@@ -129,7 +131,7 @@ public class PayloadTests : DPoPProofValidatorTestBase
         };
 
         ProofValidator.TestTimeProvider.SetUtcNow(DateTimeOffset.FromUnixTimeSeconds(IssuedAt + ValidFor + ClockSkew + 1));
-        await ProofValidator.ValidatePayload(Context, Result);
+        ProofValidator.ValidatePayload(Context, Result);
 
         Result.ShouldBeInvalidProofWithDescription("Invalid 'iat' value.");
         ProofValidator.ReplayCacheShouldNotBeCalled();
@@ -138,7 +140,7 @@ public class PayloadTests : DPoPProofValidatorTestBase
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task valid_payload_succeeds()
+    public void valid_payload_succeeds()
     {
         Result.Payload = new Dictionary<string, object>
         {
@@ -150,7 +152,7 @@ public class PayloadTests : DPoPProofValidatorTestBase
         };
 
         ProofValidator.TestTimeProvider.SetUtcNow(DateTimeOffset.FromUnixTimeSeconds(IssuedAt));
-        await ProofValidator.ValidatePayload(Context, Result);
+        ProofValidator.ValidatePayload(Context, Result);
 
         Result.IsError.ShouldBeFalse(Result.ErrorDescription);
     }

--- a/aspnetcore-authentication-jwtbearer/test/AspNetCore.Authentication.JwtBearer.Tests/DPoP/PayloadTests.cs
+++ b/aspnetcore-authentication-jwtbearer/test/AspNetCore.Authentication.JwtBearer.Tests/DPoP/PayloadTests.cs
@@ -9,7 +9,7 @@ public class PayloadTests : DPoPProofValidatorTestBase
 {
     [Fact]
     [Trait("Category", "Unit")]
-    public Task missing_payload_fails()
+    public void missing_payload_fails()
     {
         Result.Payload = null;
 
@@ -17,12 +17,11 @@ public class PayloadTests : DPoPProofValidatorTestBase
 
         Result.ShouldBeInvalidProofWithDescription("Missing payload");
         ProofValidator.ReplayCacheShouldNotBeCalled();
-        return Task.CompletedTask;
     }
 
     [Fact]
     [Trait("Category", "Unit")]
-    public Task missing_ath_fails()
+    public void missing_ath_fails()
     {
         Result.Payload = new Dictionary<string, object>();
         Result.Payload.ShouldNotContainKey(JwtClaimTypes.DPoPAccessTokenHash);
@@ -31,7 +30,6 @@ public class PayloadTests : DPoPProofValidatorTestBase
 
         Result.ShouldBeInvalidProofWithDescription("Invalid 'ath' value.");
         ProofValidator.ReplayCacheShouldNotBeCalled();
-        return Task.CompletedTask;
     }
 
     [Fact]

--- a/aspnetcore-authentication-jwtbearer/test/AspNetCore.Authentication.JwtBearer.Tests/DPoP/ReplayTests.cs
+++ b/aspnetcore-authentication-jwtbearer/test/AspNetCore.Authentication.JwtBearer.Tests/DPoP/ReplayTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
-using Duende.IdentityModel;
 using NSubstitute;
 
 namespace Duende.AspNetCore.Authentication.JwtBearer.DPoP;

--- a/aspnetcore-authentication-jwtbearer/test/AspNetCore.Authentication.JwtBearer.Tests/DPoP/ReplayTests.cs
+++ b/aspnetcore-authentication-jwtbearer/test/AspNetCore.Authentication.JwtBearer.Tests/DPoP/ReplayTests.cs
@@ -10,25 +10,6 @@ public class ReplayTests : DPoPProofValidatorTestBase
 {
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task replays_detected_in_ValidatePayload_fail()
-    {
-        ProofValidator.TestReplayCache.Exists(TokenIdHash).Returns(true);
-        Result.Payload = new Dictionary<string, object>
-        {
-            { JwtClaimTypes.DPoPAccessTokenHash, AccessTokenHash },
-            { JwtClaimTypes.JwtId, TokenId },
-            { JwtClaimTypes.DPoPHttpMethod, HttpMethod },
-            { JwtClaimTypes.DPoPHttpUrl, HttpUrl },
-            { JwtClaimTypes.IssuedAt, IssuedAt },
-        };
-        ProofValidator.TestTimeProvider.SetUtcNow(DateTimeOffset.FromUnixTimeSeconds(IssuedAt));
-        await ProofValidator.ValidatePayload(Context, Result);
-
-        Result.ShouldBeInvalidProofWithDescription("Detected DPoP proof token replay.");
-    }
-
-    [Fact]
-    [Trait("Category", "Unit")]
     public async Task replays_detected_in_ValidateReplay_fail()
     {
         ReplayCache.Exists(TokenIdHash).Returns(true);

--- a/aspnetcore-authentication-jwtbearer/test/AspNetCore.Authentication.JwtBearer.Tests/DPoP/TestDPoPProofValidator.cs
+++ b/aspnetcore-authentication-jwtbearer/test/AspNetCore.Authentication.JwtBearer.Tests/DPoP/TestDPoPProofValidator.cs
@@ -59,7 +59,7 @@ public class TestDPoPProofValidator
     public async Task ValidateToken(DPoPProofValidationContext context, DPoPProofValidationResult result)
         => await _internalValidator.ValidateToken(context, result);
 
-    public bool ValidateJwk(DPoPProofValidationContext context, DPoPProofValidationResult result)
+    public void ValidateJwk(DPoPProofValidationContext context, DPoPProofValidationResult result)
         => _internalValidator.ValidateJwk(context, result);
 
 }

--- a/aspnetcore-authentication-jwtbearer/test/AspNetCore.Authentication.JwtBearer.Tests/DPoP/TestDPoPProofValidator.cs
+++ b/aspnetcore-authentication-jwtbearer/test/AspNetCore.Authentication.JwtBearer.Tests/DPoP/TestDPoPProofValidator.cs
@@ -2,56 +2,64 @@
 // See LICENSE in the project root for license information.
 
 using Microsoft.AspNetCore.DataProtection;
-using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Time.Testing;
-using NSubstitute;
 
 namespace Duende.AspNetCore.Authentication.JwtBearer.DPoP;
 
-public class TestDPoPProofValidator : DefaultDPoPProofValidator
+public class TestDPoPProofValidator
 {
     public TestDPoPProofValidator(
         IOptionsMonitor<DPoPOptions> optionsMonitor,
-        IReplayCache replayCache) : base(
+        IReplayCache replayCache) => _internalValidator = new(
             optionsMonitor,
             new EphemeralDataProtectionProvider(),
             replayCache,
             new FakeTimeProvider(),
-            Substitute.For<ILogger<DefaultDPoPProofValidator>>())
-    { }
+            new NullLogger<DPoPProofValidator>());
 
-    public IDataProtector TestDataProtector => DataProtector;
-    public FakeTimeProvider TestTimeProvider => (FakeTimeProvider)TimeProvider;
-    public IReplayCache TestReplayCache => ReplayCache;
+    internal DPoPProofValidator _internalValidator;
 
-    public new Task ValidateHeader(DPoPProofValidationContext context, DPoPProofValidationResult result, CancellationToken cancellationToken = default) => base.ValidateHeader(context, result, cancellationToken);
+    public IDataProtector TestDataProtector => _internalValidator.DataProtector;
+    public FakeTimeProvider TestTimeProvider => (FakeTimeProvider)_internalValidator.TimeProvider;
+    public IReplayCache TestReplayCache => _internalValidator.ReplayCache;
 
-    public new Task ValidatePayload(DPoPProofValidationContext context, DPoPProofValidationResult result, CancellationToken cancellationToken = default)
-        => base.ValidatePayload(context, result, cancellationToken);
+    public void ValidatePayload(DPoPProofValidationContext context, DPoPProofValidationResult result)
+        => _internalValidator.ValidatePayload(context, result);
 
-    public new Task ValidateReplay(DPoPProofValidationContext context, DPoPProofValidationResult result, CancellationToken cancellationToken = default)
-        => base.ValidateReplay(context, result, cancellationToken);
+    public Task ValidateReplay(DPoPProofValidationContext context, DPoPProofValidationResult result, CancellationToken cancellationToken = default)
+        => _internalValidator.ValidateReplay(context, result, cancellationToken);
 
-    public new Task ValidateFreshness(DPoPProofValidationContext context, DPoPProofValidationResult result, CancellationToken cancellationToken = default)
-        => base.ValidateFreshness(context, result, cancellationToken);
+    public void ValidateFreshness(DPoPProofValidationContext context, DPoPProofValidationResult result)
+        => _internalValidator.ValidateFreshness(context, result);
 
-    public new Task ValidateIat(DPoPProofValidationContext context, DPoPProofValidationResult result, CancellationToken cancellationToken = default)
-        => base.ValidateIat(context, result, cancellationToken);
+    public void ValidateIat(DPoPProofValidationContext context, DPoPProofValidationResult result)
+        => _internalValidator.ValidateIat(context, result);
 
-    public new Task ValidateNonce(DPoPProofValidationContext context, DPoPProofValidationResult result, CancellationToken cancellationToken = default)
-        => base.ValidateNonce(context, result, cancellationToken);
+    public void ValidateNonce(DPoPProofValidationContext context, DPoPProofValidationResult result)
+        => _internalValidator.ValidateNonce(context, result);
 
-    public new string CreateNonce(DPoPProofValidationContext context, DPoPProofValidationResult result)
-        => base.CreateNonce(context, result);
+    public string CreateNonce(DPoPProofValidationContext context, DPoPProofValidationResult result)
+        => _internalValidator.CreateNonce(context, result);
 
-    public new ValueTask<long> GetUnixTimeFromNonceAsync(DPoPProofValidationContext context, DPoPProofValidationResult result)
-        => base.GetUnixTimeFromNonceAsync(context, result);
+    public long GetUnixTimeFromNonce(DPoPProofValidationContext context, DPoPProofValidationResult result)
+        => _internalValidator.GetUnixTimeFromNonce(context, result);
 
-    public new virtual bool IsExpired(TimeSpan validityDuration, TimeSpan clockSkew, long issuedAtTime)
-        => base.IsExpired(validityDuration, clockSkew, issuedAtTime);
+    public bool IsExpired(TimeSpan validityDuration, TimeSpan clockSkew, long issuedAtTime)
+        => _internalValidator.IsExpired(validityDuration, clockSkew, issuedAtTime);
 
-    public new virtual bool IsExpired(DPoPProofValidationContext context, DPoPProofValidationResult result, long time,
+    public bool IsExpired(DPoPProofValidationContext context, DPoPProofValidationResult result, long time,
         ExpirationValidationMode mode) =>
-        base.IsExpired(context, result, time, mode);
+        _internalValidator.IsExpired(context, result, time, mode);
+
+    public void ValidateCnf(DPoPProofValidationContext context, DPoPProofValidationResult result)
+        => _internalValidator.ValidateCnf(context, result);
+
+    public async Task ValidateToken(DPoPProofValidationContext context, DPoPProofValidationResult result)
+        => await _internalValidator.ValidateToken(context, result);
+
+    public bool ValidateJwk(DPoPProofValidationContext context, DPoPProofValidationResult result)
+        => _internalValidator.ValidateJwk(context, result);
+
 }

--- a/aspnetcore-authentication-jwtbearer/test/AspNetCore.Authentication.JwtBearer.Tests/DPoP/TokenValidationTests.cs
+++ b/aspnetcore-authentication-jwtbearer/test/AspNetCore.Authentication.JwtBearer.Tests/DPoP/TokenValidationTests.cs
@@ -24,7 +24,7 @@ public class TokenValidationTests : DPoPProofValidatorTestBase
     {
         Context = Context with { ProofToken = CreateDPoPProofToken(typ: "dpop+at") }; //Not dpop+jwt!
         ProofValidator.ValidateJwk(Context, Result); // Validate jwk first, as we need it to validate the token.
-        
+
         await ProofValidator.ValidateToken(Context, Result);
 
         Result.ShouldBeInvalidProofWithDescription("Invalid DPoP proof token.");

--- a/aspnetcore-authentication-jwtbearer/test/AspNetCore.Authentication.JwtBearer.Tests/DPoP/TokenValidationTests.cs
+++ b/aspnetcore-authentication-jwtbearer/test/AspNetCore.Authentication.JwtBearer.Tests/DPoP/TokenValidationTests.cs
@@ -5,7 +5,7 @@ using Microsoft.IdentityModel.Tokens;
 
 namespace Duende.AspNetCore.Authentication.JwtBearer.DPoP;
 
-public class HeaderTests : DPoPProofValidatorTestBase
+public class TokenValidationTests : DPoPProofValidatorTestBase
 {
     [Fact]
     [Trait("Category", "Unit")]
@@ -13,20 +13,21 @@ public class HeaderTests : DPoPProofValidatorTestBase
     {
         Context = Context with { ProofToken = "This is obviously not a jwt" };
 
-        await ProofValidator.ValidateHeader(Context, Result);
+        await ProofValidator.ValidateToken(Context, Result);
 
-        Result.ShouldBeInvalidProofWithDescription("Malformed DPoP token.");
+        Result.ShouldBeInvalidProofWithDescription("Invalid DPoP proof token.");
     }
 
     [Fact]
     [Trait("Category", "Unit")]
     public async Task proof_tokens_with_incorrect_typ_header_fail()
     {
-        Context = Context with { ProofToken = CreateDPoPProofToken(typ: "at+jwt") }; //Not dpop+jwt!
+        Context = Context with { ProofToken = CreateDPoPProofToken(typ: "dpop+at") }; //Not dpop+jwt!
+        ProofValidator.ValidateJwk(Context, Result); // Validate jwk first, as we need it to validate the token.
+        
+        await ProofValidator.ValidateToken(Context, Result);
 
-        await ProofValidator.ValidateHeader(Context, Result);
-
-        Result.ShouldBeInvalidProofWithDescription("Invalid 'typ' value.");
+        Result.ShouldBeInvalidProofWithDescription("Invalid DPoP proof token.");
     }
 
     [Theory]
@@ -48,8 +49,9 @@ public class HeaderTests : DPoPProofValidatorTestBase
             ProofToken = CreateDPoPProofToken(alg: alg),
             AccessTokenClaims = [CnfClaim(useECAlgorithm ? PublicEcdsaJwk : PublicRsaJwk)]
         };
+        ProofValidator.ValidateJwk(Context, Result); // Validate jwk first, as we need it to validate the token.
 
-        await ProofValidator.ValidateHeader(Context, Result);
+        await ProofValidator.ValidateToken(Context, Result);
 
         Result.IsError.ShouldBeFalse(Result.ErrorDescription);
     }
@@ -64,9 +66,10 @@ public class HeaderTests : DPoPProofValidatorTestBase
     public async Task disallowed_algorithms_fail(string alg)
     {
         Context = Context with { ProofToken = CreateDPoPProofToken(alg: alg) };
+        ProofValidator.ValidateJwk(Context, Result); // Validate jwk first, as we need it to validate the token.
 
-        await ProofValidator.ValidateHeader(Context, Result);
+        await ProofValidator.ValidateToken(Context, Result);
 
-        Result.ShouldBeInvalidProofWithDescription("Invalid 'alg' value.");
+        Result.ShouldBeInvalidProofWithDescription("Invalid DPoP proof token.");
     }
 }

--- a/aspnetcore-authentication-jwtbearer/test/AspNetCore.Authentication.JwtBearer.Tests/TestFramework/ApiHost.cs
+++ b/aspnetcore-authentication-jwtbearer/test/AspNetCore.Authentication.JwtBearer.Tests/TestFramework/ApiHost.cs
@@ -60,46 +60,5 @@ public class ApiHost : GenericHost
 
         app.UseAuthentication();
         app.UseAuthorization();
-
-        // app.UseEndpoints(endpoints =>
-        // {
-        //     // endpoints.Map("/{**catch-all}", async context =>
-        //     // {
-        //     //     // capture body if present
-        //     //     var body = default(string);
-        //     //     if (context.Request.HasJsonContentType())
-        //     //     {
-        //     //         using (var sr = new StreamReader(context.Request.Body))
-        //     //         {
-        //     //             body = await sr.ReadToEndAsync();
-        //     //         }
-        //     //     }
-        //     //     
-        //     //     // capture request headers
-        //     //     var requestHeaders = new Dictionary<string, List<string>>();
-        //     //     foreach (var header in context.Request.Headers)
-        //     //     {
-        //     //         var values = new List<string>(header.Value.Select(v => v));
-        //     //         requestHeaders.Add(header.Key, values);
-        //     //     }
-        //     //
-        //     //     var response = new ApiResponse(
-        //     //         context.Request.Method,
-        //     //         context.Request.Path.Value,
-        //     //         context.User.FindFirst(("sub"))?.Value,
-        //     //         context.User.FindFirst(("client_id"))?.Value,
-        //     //         context.User.Claims.Select(x => new ClaimRecord(x.Type, x.Value)).ToArray())
-        //     //     {
-        //     //         Body = body,
-        //     //         RequestHeaders = requestHeaders
-        //     //     };
-        //     //
-        //     //     context.Response.StatusCode = ApiStatusCodeToReturn ?? 200;
-        //     //     ApiStatusCodeToReturn = null;
-        //     //
-        //     //     context.Response.ContentType = "application/json";
-        //     //     await context.Response.WriteAsync(JsonSerializer.Serialize(response));
-        //     // });
-        // });
     }
 }


### PR DESCRIPTION
This is a fairly significant refactor of the DPoP jwt bearer extension's extensibility model that makes most of the types internal. The intention is to make the intended extensibility points explicit, rather than just making everything public.