### PR TITLE
Conditionally use new Blazor features based on dotnet version

### DIFF
--- a/bff/templates/src/BffBlazorAutoRenderMode/.template.config/dotnetcli.host.json
+++ b/bff/templates/src/BffBlazorAutoRenderMode/.template.config/dotnetcli.host.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "Framework": {
+      "longName": "framework"
+    }
+  }
+}

--- a/bff/templates/src/BffBlazorAutoRenderMode/.template.config/template.json
+++ b/bff/templates/src/BffBlazorAutoRenderMode/.template.config/template.json
@@ -41,10 +41,43 @@
     "UseMapStaticAssets": {
       "type": "computed",
       "value": "Framework != net8.0"
+    },
+    "IsDevelopmentTime": {
+      "type": "computed",
+      "value": "Framework == ''"
     }
   },
-  "primaryOutputs": [
-    { "path": "BffBlazor/{{ProjectName}}.csproj" },
-    { "path": "BffBlazor.Client/{{ProjectName}}.Client.csproj" }
+  "sources": [
+    {
+      "exclude": [
+        "**/[Bb]in/**",
+        "**/[Oo]bj/**",
+        ".template.config/**/*",
+        "**/*.filelist",
+        "**/*.user",
+        "**/*.lock.json",
+        "BffBlazorAutoRenderMode/Components/CssLinks.razor"
+      ],
+      "modifiers": [
+        {
+          "condition": "(UseMapStaticAssets)",
+          "rename": {
+            "BffBlazorAutoRenderMode/Components/MapStaticAssetsLinkTags.razor": "BffBlazorAutoRenderMode/Components/CssLinks.razor"
+          },
+          "exclude": [
+            "BffBlazorAutoRenderMode/Components/LegacyLinkTags.razor"
+          ]
+        },
+        {
+          "condition": "(!UseMapStaticAssets)",
+          "rename": {
+            "BffBlazorAutoRenderMode/Components/LegacyLinkTags.razor": "BffBlazorAutoRenderMode/Components/CssLinks.razor"
+          },
+          "exclude": [
+            "BffBlazorAutoRenderMode/Components/MapStaticAssetsLinkTags.razor"
+          ]
+        }
+      ]
+    }
   ]
 }

--- a/bff/templates/src/BffBlazorAutoRenderMode/.template.config/template.json
+++ b/bff/templates/src/BffBlazorAutoRenderMode/.template.config/template.json
@@ -20,6 +20,27 @@
       "type": "parameter",
       "datatype": "string",
       "replaces": "BffBlazorAutoRenderMode"
+    },
+    "Framework": {
+      "type": "parameter",
+      "description": "The target framework for the project.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "net9.0",
+          "description": "Target net9.0"
+        },
+        {
+          "choice": "net8.0",
+          "description": "Target net8.0"
+        }
+      ],
+      "replaces": "net9.0",
+      "defaultValue": "net9.0"
+    },
+    "UseMapStaticAssets": {
+      "type": "computed",
+      "value": "Framework != net8.0"
     }
   },
   "primaryOutputs": [

--- a/bff/templates/src/BffBlazorAutoRenderMode/BffBlazorAutoRenderMode.Client/BffBlazorAutoRenderMode.Client.csproj
+++ b/bff/templates/src/BffBlazorAutoRenderMode/BffBlazorAutoRenderMode.Client/BffBlazorAutoRenderMode.Client.csproj
@@ -9,10 +9,17 @@
     <RootNamespace>BffBlazorAutoRenderMode.Client</RootNamespace>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Framework)' == ''">
+    <!-- If we do not have a value for framework from running dotnet new, default to one so things build in an IDE -->
+    <Framework>$(TargetFramework)</Framework>
+  </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.2" Condition="'$(Framework)' == 'net9.0'" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.15" Condition="'$(Framework)' == 'net8.0'" />
     <PackageReference Include="Duende.BFF.Blazor.Client" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.2" Condition="'$(Framework)' == 'net9.0'" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" Condition="'$(Framework)' == 'net8.0'" />
   </ItemGroup>
 
 </Project>

--- a/bff/templates/src/BffBlazorAutoRenderMode/BffBlazorAutoRenderMode/BffBlazorAutoRenderMode.csproj
+++ b/bff/templates/src/BffBlazorAutoRenderMode/BffBlazorAutoRenderMode/BffBlazorAutoRenderMode.csproj
@@ -10,6 +10,7 @@
     <!-- If we do not have a value for framework from running dotnet new, default to one so things build in an IDE -->
     <Framework>$(TargetFramework)</Framework>
     <DefineConstants Condition="'$(Framework)' != 'net8.0'">UseMapStaticAssets</DefineConstants>
+    <IsDevelopmentTime>true</IsDevelopmentTime>
   </PropertyGroup>
   
   <ItemGroup>
@@ -21,5 +22,15 @@
     <PackageReference Include="Duende.BFF" Version="3.0.0" />
     <PackageReference Include="Duende.BFF.Blazor" Version="3.0.0" />
   </ItemGroup>
+  
+  <ItemGroup Condition="'$(IsDevelopmentTime)' == 'true'">
+    <CssHeader Include="Components\MapStaticAssetsLinkTags.razor" Condition="'$(Framework)' == 'net9.0'" />
+    <Content Remove="Components\MapStaticAssetsLinkTags.razor" Condition="'$(Framework)' == 'net8.0'" />
+    <CssHeader Include="Components\LegacyLinkTags.razor" Condition="'$(Framework)' == 'net8.0'" />
+    <Content Remove="Components\LegacyLinkTags.razor" Condition="'$(Framework)' == 'net9.0'" />
+  </ItemGroup>
 
+  <Target Name="RenameCssLinksComponent" BeforeTargets="BeforeBuild" Condition="'$(IsDevelopmentTime)' == 'true'">
+    <Copy SourceFiles="@(CssHeader)" DestinationFiles="Components\CssLinks.razor"/>
+  </Target>
 </Project>

--- a/bff/templates/src/BffBlazorAutoRenderMode/BffBlazorAutoRenderMode/BffBlazorAutoRenderMode.csproj
+++ b/bff/templates/src/BffBlazorAutoRenderMode/BffBlazorAutoRenderMode/BffBlazorAutoRenderMode.csproj
@@ -5,11 +5,19 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
-
+  
+  <PropertyGroup Condition="'$(Framework)' == ''">
+    <!-- If we do not have a value for framework from running dotnet new, default to one so things build in an IDE -->
+    <Framework>$(TargetFramework)</Framework>
+    <DefineConstants Condition="'$(Framework)' != 'net8.0'">UseMapStaticAssets</DefineConstants>
+  </PropertyGroup>
+  
   <ItemGroup>
     <ProjectReference Include="..\BffBlazorAutoRenderMode.Client\BffBlazorAutoRenderMode.Client.csproj" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="9.0.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="9.0.3" Condition="'$(Framework)' == 'net9.0'" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.3" Condition="'$(Framework)' == 'net9.0'" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.15" Condition="'$(Framework)' == 'net8.0'" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.15" Condition="'$(Framework)' == 'net8.0'" />
     <PackageReference Include="Duende.BFF" Version="3.0.0" />
     <PackageReference Include="Duende.BFF.Blazor" Version="3.0.0" />
   </ItemGroup>

--- a/bff/templates/src/BffBlazorAutoRenderMode/BffBlazorAutoRenderMode/Components/App.razor
+++ b/bff/templates/src/BffBlazorAutoRenderMode/BffBlazorAutoRenderMode/Components/App.razor
@@ -5,7 +5,7 @@
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <base href="/"/>
-  @*#if (UseMapStaticAssets) NOTE: This sytnax does not work running out of the IDE, but the templat engine requires it. The appropriate block needs to be copied outside of this comment for IDE development.
+  @*#if (UseMapStaticAssets) NOTE: This sytnax does not work running out of the IDE, but the template engine requires it. The appropriate block needs to be copied outside of this comment for IDE development.
   <link rel="stylesheet" href="@Assets["lib/bootstrap/dist/css/bootstrap.min.css"]"/>
   <link rel="stylesheet" href="@Assets["app.css"]"/>
   <link rel="stylesheet" href="@Assets["BffBlazorAutoRenderMode.styles.css"]"/>

--- a/bff/templates/src/BffBlazorAutoRenderMode/BffBlazorAutoRenderMode/Components/App.razor
+++ b/bff/templates/src/BffBlazorAutoRenderMode/BffBlazorAutoRenderMode/Components/App.razor
@@ -2,20 +2,26 @@
 <html lang="en">
 
 <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <base href="/" />
-    <link rel="stylesheet" href="@Assets["lib/bootstrap/dist/css/bootstrap.min.css"]" />
-    <link rel="stylesheet" href="@Assets["app.css"]" />
-    <link rel="stylesheet" href="@Assets["BffBlazorAutoRenderMode.styles.css"]" />
-    <ImportMap />
-    <link rel="icon" type="image/png" href="favicon.png" />
-    <HeadOutlet />
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <base href="/"/>
+  @*#if (UseMapStaticAssets) NOTE: This sytnax does not work running out of the IDE, but the templat engine requires it. The appropriate block needs to be copied outside of this comment for IDE development.
+  <link rel="stylesheet" href="@Assets["lib/bootstrap/dist/css/bootstrap.min.css"]"/>
+  <link rel="stylesheet" href="@Assets["app.css"]"/>
+  <link rel="stylesheet" href="@Assets["BffBlazorAutoRenderMode.styles.css"]"/>
+  <ImportMap/>
+  ##else
+  <link rel="stylesheet" href="lib/bootstrap/dist/css/bootstrap.min.css"/>
+  <link rel="stylesheet" href="app.css"/>
+  <link rel="stylesheet" href="BffBlazorAutoRenderMode.styles.css"/>
+  ##endif*@
+  <link rel="icon" type="image/png" href="favicon.png"/>
+  <HeadOutlet/>
 </head>
 
 <body>
-    <Routes/>
-    <script src="_framework/blazor.web.js"></script>
+<Routes/>
+<script src="_framework/blazor.web.js"></script>
 </body>
 
 </html>

--- a/bff/templates/src/BffBlazorAutoRenderMode/BffBlazorAutoRenderMode/Components/App.razor
+++ b/bff/templates/src/BffBlazorAutoRenderMode/BffBlazorAutoRenderMode/Components/App.razor
@@ -5,16 +5,7 @@
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <base href="/"/>
-  @*#if (UseMapStaticAssets) NOTE: This sytnax does not work running out of the IDE, but the template engine requires it. The appropriate block needs to be copied outside of this comment for IDE development.
-  <link rel="stylesheet" href="@Assets["lib/bootstrap/dist/css/bootstrap.min.css"]"/>
-  <link rel="stylesheet" href="@Assets["app.css"]"/>
-  <link rel="stylesheet" href="@Assets["BffBlazorAutoRenderMode.styles.css"]"/>
-  <ImportMap/>
-  ##else
-  <link rel="stylesheet" href="lib/bootstrap/dist/css/bootstrap.min.css"/>
-  <link rel="stylesheet" href="app.css"/>
-  <link rel="stylesheet" href="BffBlazorAutoRenderMode.styles.css"/>
-  ##endif*@
+  <CssLinks />
   <link rel="icon" type="image/png" href="favicon.png"/>
   <HeadOutlet/>
 </head>

--- a/bff/templates/src/BffBlazorAutoRenderMode/BffBlazorAutoRenderMode/Components/LegacyLinkTags.razor
+++ b/bff/templates/src/BffBlazorAutoRenderMode/BffBlazorAutoRenderMode/Components/LegacyLinkTags.razor
@@ -1,0 +1,3 @@
+<link rel="stylesheet" href="lib/bootstrap/dist/css/bootstrap.min.css"/>
+<link rel="stylesheet" href="app.css"/>
+<link rel="stylesheet" href="BffBlazorAutoRenderMode.styles.css"/>

--- a/bff/templates/src/BffBlazorAutoRenderMode/BffBlazorAutoRenderMode/Components/MapStaticAssetsLinkTags.razor
+++ b/bff/templates/src/BffBlazorAutoRenderMode/BffBlazorAutoRenderMode/Components/MapStaticAssetsLinkTags.razor
@@ -1,0 +1,4 @@
+<link rel="stylesheet" href="@Assets["lib/bootstrap/dist/css/bootstrap.min.css"]"/>
+<link rel="stylesheet" href="@Assets["app.css"]"/>
+<link rel="stylesheet" href="@Assets["BffBlazorAutoRenderMode.styles.css"]"/>
+<ImportMap/>

--- a/bff/templates/src/BffBlazorAutoRenderMode/BffBlazorAutoRenderMode/Program.cs
+++ b/bff/templates/src/BffBlazorAutoRenderMode/BffBlazorAutoRenderMode/Program.cs
@@ -89,7 +89,12 @@ app.UseAntiforgery();
 // Add the BFF management endpoints, such as login, logout, etc.
 app.MapBffManagementEndpoints();
 
+#if (UseMapStaticAssets)
 app.MapStaticAssets();
+#else
+app.UseDefaultFiles();
+app.UseStaticFiles();
+#endif
 app.MapRazorComponents<App>()
     .AddInteractiveServerRenderMode()
     .AddInteractiveWebAssemblyRenderMode()


### PR DESCRIPTION
**What issue does this PR address?**
There were issues with this template when using dotnet 8 due to the use of MapStaticAssets. These changes add a framework version option and conditionally use the new features added in dotnet 9 based on the selected framework version.

**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
