### PR TITLE
Ensure WWW-Authenticate uses a single HTTP header 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Visual Studio Code workspace options
+.vscode/settings.json

--- a/identity-server/Directory.Build.targets
+++ b/identity-server/Directory.Build.targets
@@ -27,6 +27,7 @@
         <!--tests -->
         <PackageReference Update="FluentAssertions" Version="6.5.1"/>
         <PackageReference Update="FluentAssertions.Web" Version="1.5.0"/>
+        <PackageReference Update="Shouldly" Version="4.2.1" />
         <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Update="xunit" Version="2.9.0"/>
         <PackageReference Update="xunit.runner.visualstudio" Version="2.5.4" PrivateAssets="All"/>

--- a/identity-server/test/Configuration.IntegrationTests/Configuration.IntegrationTests.csproj
+++ b/identity-server/test/Configuration.IntegrationTests/Configuration.IntegrationTests.csproj
@@ -23,6 +23,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Shouldly" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />

--- a/identity-server/test/EntityFramework.IntegrationTests/EntityFramework.IntegrationTests.csproj
+++ b/identity-server/test/EntityFramework.IntegrationTests/EntityFramework.IntegrationTests.csproj
@@ -9,6 +9,7 @@
         <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio" />
         <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Shouldly" />
 
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />

--- a/identity-server/test/EntityFramework.Storage.IntegrationTests/EntityFramework.Storage.IntegrationTests.csproj
+++ b/identity-server/test/EntityFramework.Storage.IntegrationTests/EntityFramework.Storage.IntegrationTests.csproj
@@ -13,6 +13,7 @@
         <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio" />
         <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Shouldly" />
 
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
@@ -21,7 +22,7 @@
 
     <ItemGroup>
         <!-- The packages in this ItemGroup are all transitive dependencies that
-             would otherwise resolve to a version with a security vulnerabilitiy. 
+             would otherwise resolve to a version with a security vulnerability. 
              In future, we would like to update Microsoft.Data.SqlClient and
              Microsoft.EntityFrameworkCore, and remove these explicit dependencies
              (assuming that future versions of the intermediate dependencies that

--- a/identity-server/test/EntityFramework.Storage.UnitTests/EntityFramework.Storage.UnitTests.csproj
+++ b/identity-server/test/EntityFramework.Storage.UnitTests/EntityFramework.Storage.UnitTests.csproj
@@ -6,6 +6,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Shouldly" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio" />

--- a/identity-server/test/IdentityServer.IntegrationTests/IdentityServer.IntegrationTests.csproj
+++ b/identity-server/test/IdentityServer.IntegrationTests/IdentityServer.IntegrationTests.csproj
@@ -18,6 +18,7 @@
         <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />
         <PackageReference Include="FluentAssertions" />
         <PackageReference Include="FluentAssertions.Web" />
+        <PackageReference Include="Shouldly" />
     </ItemGroup>
 
     <ItemGroup>

--- a/identity-server/test/IdentityServer.UnitTests/Endpoints/Results/ProtectedResourceErrorResultTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Endpoints/Results/ProtectedResourceErrorResultTests.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using Duende.IdentityServer.Endpoints.Results;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Net.Http.Headers;
+using Xunit;
+
+namespace UnitTests.Endpoints.Results;
+
+public class ProtectedResourceErrorResultTests
+{
+    private readonly ProtectedResourceErrorHttpWriter writer = new();
+
+    [Fact]
+    public void WwwAuthenticate_header_with_error_and_description_should_be_a_single_line()
+    {
+        var context = new DefaultHttpContext();
+
+        writer.WriteHttpResponse(
+            new ProtectedResourceErrorResult("oops", "big oops"),
+            context
+        );
+
+        var wwwAuthHeader = context.Response.Headers[HeaderNames.WWWAuthenticate].ToString();
+        wwwAuthHeader.Should().BeEquivalentTo(
+            """
+            Bearer realm="IdentityServer",error="oops",error_description="big oops"
+            """);
+    }
+    
+    [Fact]
+    public void WwwAuthenticate_header_with_error_should_be_a_single_line()
+    {
+        var context = new DefaultHttpContext();
+
+        writer.WriteHttpResponse(
+            new ProtectedResourceErrorResult("oops"),
+            context
+        );
+
+        var wwwAuthHeader = context.Response.Headers[HeaderNames.WWWAuthenticate].ToString();
+        wwwAuthHeader.Should().BeEquivalentTo(
+            """
+            Bearer realm="IdentityServer",error="oops"
+            """);
+    }
+
+    [Fact]
+    public void WwwAuthenticate_header_should_always_be_a_single_string_value()
+    {
+        var context = new DefaultHttpContext();
+
+        writer.WriteHttpResponse(
+            new ProtectedResourceErrorResult("oops", "big oops"),
+            context
+        );
+
+        var wwwAuthHeader = context.Response.Headers[HeaderNames.WWWAuthenticate];
+        wwwAuthHeader.Count.Should().Be(1);
+    }
+}

--- a/identity-server/test/IdentityServer.UnitTests/Endpoints/Results/ProtectedResourceErrorResultTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Endpoints/Results/ProtectedResourceErrorResultTests.cs
@@ -2,9 +2,9 @@
 // See LICENSE in the project root for license information.
 
 using Duende.IdentityServer.Endpoints.Results;
-using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Net.Http.Headers;
+using Shouldly;
 using Xunit;
 
 namespace UnitTests.Endpoints.Results;
@@ -24,12 +24,12 @@ public class ProtectedResourceErrorResultTests
         );
 
         var wwwAuthHeader = context.Response.Headers[HeaderNames.WWWAuthenticate].ToString();
-        wwwAuthHeader.Should().BeEquivalentTo(
+        wwwAuthHeader.ShouldBe(
             """
             Bearer realm="IdentityServer",error="oops",error_description="big oops"
             """);
     }
-    
+
     [Fact]
     public void WwwAuthenticate_header_with_error_should_be_a_single_line()
     {
@@ -41,7 +41,7 @@ public class ProtectedResourceErrorResultTests
         );
 
         var wwwAuthHeader = context.Response.Headers[HeaderNames.WWWAuthenticate].ToString();
-        wwwAuthHeader.Should().BeEquivalentTo(
+        wwwAuthHeader.ShouldBe(
             """
             Bearer realm="IdentityServer",error="oops"
             """);
@@ -58,6 +58,6 @@ public class ProtectedResourceErrorResultTests
         );
 
         var wwwAuthHeader = context.Response.Headers[HeaderNames.WWWAuthenticate];
-        wwwAuthHeader.Count.Should().Be(1);
+        wwwAuthHeader.Count.ShouldBe(1);
     }
 }

--- a/identity-server/test/IdentityServer.UnitTests/IdentityServer.UnitTests.csproj
+++ b/identity-server/test/IdentityServer.UnitTests/IdentityServer.UnitTests.csproj
@@ -16,6 +16,7 @@
         <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />
         <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Shouldly" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Introduce tests for ProtectedResourceErrorResult to ensure WWW-Authenticate header formatting is correct. Refactor header construction values into a single string.

