### PR TITLE
Update minver config

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,7 +28,8 @@
     </ItemGroup>
 
     <PropertyGroup>
-        <MinVerAutoIncrement>minor</MinVerAutoIncrement>
+        <MinVerAutoIncrement>patch</MinVerAutoIncrement>
+        <MinVerTagPrefix>is-</MinVerTagPrefix>
         <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
- Autoincrement patch instead of minor. Major and minor version numbers are explicitly controlled by our release process.
- Add missing is- tag prefix config

(Intention is to merge this forward through all release branches, which should correct the version numbers of internal builds of bug fixes on release branches).