### PR TITLE
Remove "Duende.IdentityServer.Experimental" service name from telemetry

### DIFF
--- a/identity-server/src/Telemetry/Telemetry.cs
+++ b/identity-server/src/Telemetry/Telemetry.cs
@@ -23,7 +23,8 @@ public static class Telemetry
     /// <summary>
     /// Service name used for the experimental non stable counters from Duende IdentityServer
     /// </summary>
-    public const string ServiceNameExperimental = "Duende.IdentityServer.Experimental";
+    [Obsolete("The experimental service name will be removed in a future version. The associated meter is now using the Duende.IdentityServer service name.")]
+    public const string ServiceNameExperimental = ServiceName;
 
     /// <summary>
     /// Metrics configuration.
@@ -93,7 +94,8 @@ public static class Telemetry
         /// <summary>
         /// Meter for experimental counters from IdentityServer
         /// </summary>
-        public static readonly Meter ExperimentalMeter = new Meter(ServiceNameExperimental, ServiceVersion);
+        [Obsolete("The ExperimentalMeter will be removed in a future version. Use the default Meter instead.")]
+        public static readonly Meter ExperimentalMeter = Meter;
 
         /// <summary>
         /// Counter for active requests.
@@ -168,7 +170,7 @@ public static class Telemetry
         /// Successful Api Secret validations
         /// </summary>
         public static Counter<long> ApiSecretValidationCounter
-            = ExperimentalMeter.CreateCounter<long>(Counters.ApiSecretValidation);
+            = Meter.CreateCounter<long>(Counters.ApiSecretValidation);
 
         /// <summary>
         /// Helper method to increase <see cref="ApiSecretValidationCounter"/>
@@ -196,7 +198,7 @@ public static class Telemetry
         /// Successful back channel (CIBA) authentications counter
         /// </summary>
         public static readonly Counter<long> BackChannelAuthenticationCounter =
-            ExperimentalMeter.CreateCounter<long>(Counters.BackchannelAuthentication);
+            Meter.CreateCounter<long>(Counters.BackchannelAuthentication);
 
         /// <summary>
         /// Helper method to increase <see cref="BackChannelAuthenticationCounter"/>
@@ -224,7 +226,7 @@ public static class Telemetry
         /// Client configuration validation
         /// </summary>
         public static Counter<long> ClientValidationCounter =
-            ExperimentalMeter.CreateCounter<long>(Counters.ClientConfigValidation);
+            Meter.CreateCounter<long>(Counters.ClientConfigValidation);
 
         /// <summary>
         /// Helper method to increase <see cref="ClientValidationCounter"/>
@@ -251,7 +253,7 @@ public static class Telemetry
         /// Successful Client Secret validations
         /// </summary>
         public static Counter<long> ClientSecretValidationCounter =
-            ExperimentalMeter.CreateCounter<long>(Counters.ClientSecretValidation);
+            Meter.CreateCounter<long>(Counters.ClientSecretValidation);
 
         /// <summary>
         /// Helper method to increase <see cref="ClientSecretValidationCounter"/>
@@ -279,7 +281,7 @@ public static class Telemetry
         /// Successful device code authentication counter
         /// </summary>
         public static readonly Counter<long> DeviceAuthenticationCounter =
-            ExperimentalMeter.CreateCounter<long>(Counters.DeviceAuthentication);
+            Meter.CreateCounter<long>(Counters.DeviceAuthentication);
 
         /// <summary>
         /// Helper method to increase <see cref="DeviceAuthenticationCounter"/>
@@ -306,7 +308,7 @@ public static class Telemetry
         /// Dynamic identityprovider validations
         /// </summary>
         public static Counter<long> DynamicIdentityProviderValidationCounter
-            = ExperimentalMeter.CreateCounter<long>(Counters.DynamicIdentityProviderValidation);
+            = Meter.CreateCounter<long>(Counters.DynamicIdentityProviderValidation);
 
         /// <summary>
         /// Helper method to increase <see cref="DynamicIdentityProviderValidationCounter"/>
@@ -334,7 +336,7 @@ public static class Telemetry
         /// Introspection success counter
         /// </summary>
         public static readonly Counter<long> IntrospectionCounter =
-            ExperimentalMeter.CreateCounter<long>(Counters.Introspection);
+            Meter.CreateCounter<long>(Counters.Introspection);
 
         /// <summary>
         /// Helper method to increase <see cref="IntrospectionCounter"/>
@@ -362,7 +364,7 @@ public static class Telemetry
         /// Pushed Authorization Request Counter
         /// </summary>
         public static Counter<long> PushedAuthorizationRequestCounter
-            = ExperimentalMeter.CreateCounter<long>(Counters.PushedAuthorizationRequest);
+            = Meter.CreateCounter<long>(Counters.PushedAuthorizationRequest);
 
         /// <summary>
         /// Helper method to increase <see cref="PushedAuthorizationRequestCounter"/>
@@ -389,7 +391,7 @@ public static class Telemetry
         /// Resource Owner Authentication Counter
         /// </summary>
         public static Counter<long> ResourceOwnerAuthenticationCounter
-            = ExperimentalMeter.CreateCounter<long>(Counters.ResourceOwnerAuthentication);
+            = Meter.CreateCounter<long>(Counters.ResourceOwnerAuthentication);
 
         /// <summary>
         /// Helper method to increase <see cref="ResourceOwnerAuthenticationCounter"/>
@@ -416,7 +418,7 @@ public static class Telemetry
         /// Revocation success counter.
         /// </summary>
         public static readonly Counter<long> RevocationCounter =
-            ExperimentalMeter.CreateCounter<long>(Counters.Revocation);
+            Meter.CreateCounter<long>(Counters.Revocation);
 
         /// <summary>
         /// Helper method to increase <see cref="RevocationCounter"/>
@@ -443,7 +445,7 @@ public static class Telemetry
         /// Successful token issuance counter.
         /// </summary>
         public static readonly Counter<long> TokenIssuedCounter =
-            ExperimentalMeter.CreateCounter<long>(Counters.TokenIssued);
+            Meter.CreateCounter<long>(Counters.TokenIssued);
 
         /// <summary>
         /// Helper method to increase <see cref="TokenIssuedCounter"/>

--- a/identity-server/src/Telemetry/Telemetry.cs
+++ b/identity-server/src/Telemetry/Telemetry.cs
@@ -7,7 +7,6 @@ using Duende.IdentityServer.Validation;
 
 namespace Duende.IdentityServer;
 
-
 /// <summary>
 /// Telemetry helpers
 /// </summary>
@@ -88,7 +87,8 @@ public static class Telemetry
         /// <summary>
         /// Counter for active requests.
         /// </summary>
-        public static readonly UpDownCounter<long> ActiveRequestCounter = Meter.CreateUpDownCounter<long>(Counters.ActiveRequests);
+        public static readonly UpDownCounter<long> ActiveRequestCounter =
+            Meter.CreateUpDownCounter<long>(Counters.ActiveRequests);
 
         /// <summary>
         /// Increase <see cref="ActiveRequestCounter"/>
@@ -136,7 +136,8 @@ public static class Telemetry
         {
             if (clientId != null)
             {
-                OperationCounter.Add(1, new(Tags.Client, clientId), new(Tags.Error, error), new(Tags.Result, TagValues.Error));
+                OperationCounter.Add(1, new(Tags.Client, clientId), new(Tags.Error, error),
+                    new(Tags.Result, TagValues.Error));
             }
             else
             {
@@ -457,7 +458,8 @@ public static class Telemetry
         /// <param name="grantType">Grant Type</param>
         /// <param name="error">Error</param>
         /// <param name="requestType">Type of authorization request</param>
-        public static void TokenIssuedFailure(string clientId, string grantType, AuthorizeRequestType? requestType, string error)
+        public static void TokenIssuedFailure(string clientId, string grantType, AuthorizeRequestType? requestType,
+            string error)
         {
             Failure(error, clientId);
             TokenIssuedCounter.Add(1,

--- a/identity-server/src/Telemetry/Telemetry.cs
+++ b/identity-server/src/Telemetry/Telemetry.cs
@@ -21,12 +21,6 @@ public static class Telemetry
     public const string ServiceName = "Duende.IdentityServer";
 
     /// <summary>
-    /// Service name used for the experimental non stable counters from Duende IdentityServer
-    /// </summary>
-    [Obsolete("The experimental service name will be removed in a future version. The associated meter is now using the Duende.IdentityServer service name.")]
-    public const string ServiceNameExperimental = ServiceName;
-
-    /// <summary>
     /// Metrics configuration.
     /// </summary>
     public static class Metrics
@@ -90,12 +84,6 @@ public static class Telemetry
         /// Meter for IdentityServer
         /// </summary>
         public static readonly Meter Meter = new Meter(ServiceName, ServiceVersion);
-
-        /// <summary>
-        /// Meter for experimental counters from IdentityServer
-        /// </summary>
-        [Obsolete("The ExperimentalMeter will be removed in a future version. Use the default Meter instead.")]
-        public static readonly Meter ExperimentalMeter = Meter;
 
         /// <summary>
         /// Counter for active requests.

--- a/identity-server/src/Telemetry/Telemetry.cs
+++ b/identity-server/src/Telemetry/Telemetry.cs
@@ -13,7 +13,7 @@ namespace Duende.IdentityServer;
 /// </summary>
 public static class Telemetry
 {
-    private readonly static string ServiceVersion = typeof(Telemetry).Assembly.GetName().Version.ToString();
+    internal static readonly string ServiceVersion = typeof(Telemetry).Assembly.GetName().Version!.ToString();
 
     /// <summary>
     /// Service name used for Duende IdentityServer.
@@ -151,7 +151,7 @@ public static class Telemetry
         public static void UnHandledException(Exception ex)
             => OperationCounter.Add(1,
                 new(Tags.Type, ex.GetType().Name),
-                new(Tags.Method, ex.TargetSite.Name),
+                new(Tags.Method, ex.TargetSite?.Name),
                 new(Tags.Result, TagValues.InternalError));
 
         /// <summary>

--- a/identity-server/test/IdentityServer.UnitTests/Telemetry/TelemetryTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Telemetry/TelemetryTests.cs
@@ -35,35 +35,36 @@ public class TelemetryTests
         using var measurements = StartListeningForMeasurements(out var results);
 
         Duende.IdentityServer.Telemetry.Metrics.Failure("oops");
-    
+
         results.Count.ShouldBe(1);
         results[0].Name.ShouldBe("tokenservice.operation");
         results[0].Value.ShouldBe(1);
     }
-    
+
     [Fact]
     public void Success_adds_to_operation_counter()
     {
         using var measurements = StartListeningForMeasurements(out var results);
 
         Duende.IdentityServer.Telemetry.Metrics.Success("test.client");
-    
+
         results.Count.ShouldBe(1);
         results[0].Name.ShouldBe("tokenservice.operation");
         results[0].Value.ShouldBe(1);
         results[0].Tags[0].Value.ShouldBe("test.client");
     }
 
-    private static MeterListener StartListeningForMeasurements(out List<(string Name, long Value, KeyValuePair<string, object?>[] Tags)> results)
+    private static MeterListener StartListeningForMeasurements(
+        out List<(string Name, long Value, KeyValuePair<string, object?>[] Tags)> results)
     {
         var listener = new MeterListener();
-        List<(string Name, long Value, KeyValuePair<string,object?>[] Tags)> measurements = new();
-        
+        List<(string Name, long Value, KeyValuePair<string, object?>[] Tags)> measurements = new();
+
         listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, _) =>
         {
             measurements.Add((instrument.Name, measurement, tags.ToArray()));
         });
-        
+
         listener.InstrumentPublished = (instrument, meterListener) =>
         {
             if (instrument.Meter.Name == "Duende.IdentityServer")

--- a/identity-server/test/IdentityServer.UnitTests/Telemetry/TelemetryTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Telemetry/TelemetryTests.cs
@@ -9,18 +9,10 @@ namespace IdentityServer.UnitTests.Telemetry;
 public class TelemetryTests
 {
     [Fact]
-    public void ServiceName_is_Duende_IdentityServer()
-    {
-        Duende.IdentityServer.Telemetry.ServiceName
-            .ShouldBe("Duende.IdentityServer");
-    }
+    public void ServiceName_is_Duende_IdentityServer() => Duende.IdentityServer.Telemetry.ServiceName.ShouldBe("Duende.IdentityServer");
 
     [Fact]
-    public void ServiceVersion_is_not_null()
-    {
-        Duende.IdentityServer.Telemetry.ServiceVersion
-            .ShouldNotBeNull();
-    }
+    public void ServiceVersion_is_not_null() => Duende.IdentityServer.Telemetry.ServiceVersion.ShouldNotBeNull();
 
     [Fact]
     public void Meter_should_has_service_name_of_Duende_IdentityServer()

--- a/identity-server/test/IdentityServer.UnitTests/Telemetry/TelemetryTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Telemetry/TelemetryTests.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+#nullable enable
+using System.Diagnostics.Metrics;
+
+namespace IdentityServer.UnitTests.Telemetry;
+
+public class TelemetryTests
+{
+    [Fact]
+    public void ServiceName_is_Duende_IdentityServer()
+    {
+        Duende.IdentityServer.Telemetry.ServiceName
+            .ShouldBe("Duende.IdentityServer");
+    }
+
+    [Fact]
+    public void ServiceVersion_is_not_null()
+    {
+        Duende.IdentityServer.Telemetry.ServiceVersion
+            .ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void Meter_should_has_service_name_of_Duende_IdentityServer()
+    {
+        var meter = Duende.IdentityServer.Telemetry.Metrics.Meter;
+        meter.Name.ShouldBe("Duende.IdentityServer");
+    }
+
+    [Fact]
+    public void Failure_adds_to_operation_counter()
+    {
+        using var measurements = StartListeningForMeasurements(out var results);
+
+        Duende.IdentityServer.Telemetry.Metrics.Failure("oops");
+    
+        results.Count.ShouldBe(1);
+        results[0].Name.ShouldBe("tokenservice.operation");
+        results[0].Value.ShouldBe(1);
+    }
+    
+    [Fact]
+    public void Success_adds_to_operation_counter()
+    {
+        using var measurements = StartListeningForMeasurements(out var results);
+
+        Duende.IdentityServer.Telemetry.Metrics.Success("test.client");
+    
+        results.Count.ShouldBe(1);
+        results[0].Name.ShouldBe("tokenservice.operation");
+        results[0].Value.ShouldBe(1);
+        results[0].Tags[0].Value.ShouldBe("test.client");
+    }
+
+    private static MeterListener StartListeningForMeasurements(out List<(string Name, long Value, KeyValuePair<string, object?>[] Tags)> results)
+    {
+        var listener = new MeterListener();
+        List<(string Name, long Value, KeyValuePair<string,object?>[] Tags)> measurements = new();
+        
+        listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, _) =>
+        {
+            measurements.Add((instrument.Name, measurement, tags.ToArray()));
+        });
+        
+        listener.InstrumentPublished = (instrument, meterListener) =>
+        {
+            if (instrument.Meter.Name == "Duende.IdentityServer")
+            {
+                meterListener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.Start();
+        results = measurements;
+        return listener;
+    }
+}

--- a/identity-server/test/IdentityServer.UnitTests/Telemetry/TelemetryTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Telemetry/TelemetryTests.cs
@@ -67,7 +67,7 @@ public class TelemetryTests
 
         listener.InstrumentPublished = (instrument, meterListener) =>
         {
-            if (instrument.Meter.Name == "Duende.IdentityServer")
+            if (instrument.Meter.Name == Duende.IdentityServer.Telemetry.ServiceName)
             {
                 meterListener.EnableMeasurementEvents(instrument);
             }


### PR DESCRIPTION
As documented at https://docs.duendesoftware.com/identityserver/diagnostics/otel/, the detailed metrics moved from the "Duende.IdentityServer.Experimental" service name to the stable "Duende.IdentityServer". These metrics are instrumented by the IdentityServer middleware and services, and track usage of specific flows and features.

If you have subscribed to the associated meters, for example in an OpenTelemetry dashboard, you'll need to update the service name going forward.

Associated docs PR: https://github.com/DuendeSoftware/docs.duendesoftware.com/pull/713