### PR TITLE
Adjust Multiple DPoP Token Error

### DIFF
--- a/identity-server/src/IdentityServer/Endpoints/TokenEndpoint.cs
+++ b/identity-server/src/IdentityServer/Endpoints/TokenEndpoint.cs
@@ -158,7 +158,7 @@ internal class TokenEndpoint : IEndpointHandler
             if (dpopHeader.Count > 1)
             {
                 _logger.LogDebug("Too many DPoP headers provided.");
-                return Error(OidcConstants.TokenErrors.InvalidDPoPProof, "Too many DPoP headers provided.");
+                return Error(OidcConstants.TokenErrors.InvalidRequest, "Too many DPoP headers provided.");
             }
 
             tokenRequest.DPoPProofToken = dpopHeader.First();

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Token/DPoPTokenEndpointTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Token/DPoPTokenEndpointTests.cs
@@ -157,7 +157,7 @@ public class DPoPTokenEndpointTests : DPoPEndpointTestBase
         var response = await Pipeline.BackChannelClient.RequestClientCredentialsTokenAsync(request);
 
         response.IsError.ShouldBeTrue();
-        response.Error.ShouldBe("invalid_dpop_proof");
+        response.Error.ShouldBe("invalid_request");
     }
 
     [Theory]


### PR DESCRIPTION
Adjust the error returned when multiple DPoP headers are sent to conform to the FAPI 2.0 Profile