### PR TITLE
 DPoP Error Handling in JwtBearerExtensions

### DIFF
--- a/aspnetcore-authentication-jwtbearer/src/AspNetCore.Authentication.JwtBearer/DPoP/DPoPJwtBearerEvents.cs
+++ b/aspnetcore-authentication-jwtbearer/src/AspNetCore.Authentication.JwtBearer/DPoP/DPoPJwtBearerEvents.cs
@@ -82,7 +82,9 @@ internal class DPoPJwtBearerEvents
             }
             else
             {
-                throw new InvalidOperationException("Missing DPoP (proof token) HTTP header");
+                context.HttpContext.Items["DPoP-Error"] = "invalid_request";
+                context.Fail("No DPoP header found");
+                return;
             }
 
             var result = await _validator.Validate(new DPoPProofValidationContext

--- a/aspnetcore-authentication-jwtbearer/src/AspNetCore.Authentication.JwtBearer/DPoP/DPoPJwtBearerEvents.cs
+++ b/aspnetcore-authentication-jwtbearer/src/AspNetCore.Authentication.JwtBearer/DPoP/DPoPJwtBearerEvents.cs
@@ -68,8 +68,19 @@ internal class DPoPJwtBearerEvents
 
         if (TryGetDPoPAccessToken(context.HttpContext.Request, dPoPOptions.ProofTokenMaxLength, out var at))
         {
-            var proofToken = context.HttpContext.Request.GetDPoPProofToken();
-            if (proofToken == null)
+            string proofToken;
+            if (context.Request.Headers.TryGetValue(HttpHeaders.DPoP, out var dPopHeader))
+            {
+                if (dPopHeader.Count > 1)
+                {
+                    context.HttpContext.Items["DPoP-Error"] = "invalid_request";
+                    context.Fail("Multiple DPoP headers found");
+                    return;
+                }
+                
+                proofToken = dPopHeader.First()!;
+            }
+            else
             {
                 throw new InvalidOperationException("Missing DPoP (proof token) HTTP header");
             }

--- a/aspnetcore-authentication-jwtbearer/src/AspNetCore.Authentication.JwtBearer/DPoP/DPoPJwtBearerEvents.cs
+++ b/aspnetcore-authentication-jwtbearer/src/AspNetCore.Authentication.JwtBearer/DPoP/DPoPJwtBearerEvents.cs
@@ -77,7 +77,7 @@ internal class DPoPJwtBearerEvents
                     context.Fail("Multiple DPoP headers found");
                     return;
                 }
-                
+
                 proofToken = dPopHeader.First()!;
             }
             else

--- a/aspnetcore-authentication-jwtbearer/src/AspNetCore.Authentication.JwtBearer/DPoP/DPoPProofValidator.cs
+++ b/aspnetcore-authentication-jwtbearer/src/AspNetCore.Authentication.JwtBearer/DPoP/DPoPProofValidator.cs
@@ -293,7 +293,7 @@ internal class DPoPProofValidator : IDPoPProofValidator
             return;
         }
 
-        if (!result.Payload.TryGetValue(JwtClaimTypes.DPoPHttpUrl, out var htu) || !context.ExpectedUrl.Equals(htu))
+        if (!result.Payload.TryGetValue(JwtClaimTypes.DPoPHttpUrl, out var htu) || !HtuValueIsValid(context.ExpectedUrl, htu as string))
         {
             result.SetError("Invalid 'htu' value.");
             return;
@@ -325,6 +325,31 @@ internal class DPoPProofValidator : IDPoPProofValidator
         {
             Logger.LogDebug("Failed to validate DPoP proof token freshness");
             return;
+        }
+    }
+
+    private bool HtuValueIsValid(string requestedUri, string? htuValue)
+    {
+        if (string.IsNullOrEmpty(requestedUri) || string.IsNullOrEmpty(htuValue))
+        {
+            return false;
+        }
+
+        try
+        {
+            var uri1 = new Uri(requestedUri);
+            var uri2 = new Uri(htuValue);
+        
+            return Uri.Compare(
+                uri1, 
+                uri2, 
+                UriComponents.Scheme | UriComponents.HostAndPort | UriComponents.Path, 
+                UriFormat.SafeUnescaped, 
+                StringComparison.OrdinalIgnoreCase) == 0;
+        }
+        catch (UriFormatException)
+        {
+            return false;
         }
     }
 

--- a/aspnetcore-authentication-jwtbearer/src/AspNetCore.Authentication.JwtBearer/DPoP/DPoPProofValidator.cs
+++ b/aspnetcore-authentication-jwtbearer/src/AspNetCore.Authentication.JwtBearer/DPoP/DPoPProofValidator.cs
@@ -339,12 +339,12 @@ internal class DPoPProofValidator : IDPoPProofValidator
         {
             var uri1 = new Uri(requestedUri);
             var uri2 = new Uri(htuValue);
-        
+
             return Uri.Compare(
-                uri1, 
-                uri2, 
-                UriComponents.Scheme | UriComponents.HostAndPort | UriComponents.Path, 
-                UriFormat.SafeUnescaped, 
+                uri1,
+                uri2,
+                UriComponents.Scheme | UriComponents.HostAndPort | UriComponents.Path,
+                UriFormat.SafeUnescaped,
                 StringComparison.OrdinalIgnoreCase) == 0;
         }
         catch (UriFormatException)

--- a/aspnetcore-authentication-jwtbearer/test/AspNetCore.Authentication.JwtBearer.Tests/DPoP/PayloadTests.cs
+++ b/aspnetcore-authentication-jwtbearer/test/AspNetCore.Authentication.JwtBearer.Tests/DPoP/PayloadTests.cs
@@ -94,6 +94,73 @@ public class PayloadTests : DPoPProofValidatorTestBase
         Result.ShouldBeInvalidProofWithDescription("Invalid 'htu' value.");
         ProofValidator.ReplayCacheShouldNotBeCalled();
     }
+    
+    [Theory]
+    [InlineData("https://example.com?query=1#fragment")]
+    [InlineData("https://example.com/#fragment")]
+    [InlineData("https://example.com/?query=1")]
+    [Trait("Category", "Unit")]
+    public void htu_ignores_query_and_fragment_parts_in_comparison_against_requested_url(string payloadUrl)
+    {
+        Result.Payload = new Dictionary<string, object>
+        {
+            { JwtClaimTypes.DPoPAccessTokenHash, AccessTokenHash },
+            { JwtClaimTypes.JwtId, TokenId },
+            { JwtClaimTypes.DPoPHttpMethod, HttpMethod },
+            { JwtClaimTypes.DPoPHttpUrl, payloadUrl },
+            { JwtClaimTypes.IssuedAt, IssuedAt }
+        };
+
+        ProofValidator.TestTimeProvider.SetUtcNow(DateTimeOffset.FromUnixTimeSeconds(IssuedAt));
+        ProofValidator.ValidatePayload(Context, Result);
+        
+        Result.IsError.ShouldBeFalse(Result.ErrorDescription);
+    }
+    
+    [Theory]
+    [InlineData("https://example.com")]
+    [InlineData("HTTPS://EXAMPLE.COM")]
+    [InlineData("https://EXAMPLE.com")]
+    [InlineData("HtTpS://eXaMpLe.CoM")]
+    [Trait("Category", "Unit")]
+    public void htu_ignores_casing_in_comparison_against_requested_url(string payloadUrl)
+    {
+        Result.Payload = new Dictionary<string, object>
+        {
+            { JwtClaimTypes.DPoPAccessTokenHash, AccessTokenHash },
+            { JwtClaimTypes.JwtId, TokenId },
+            { JwtClaimTypes.DPoPHttpMethod, HttpMethod },
+            { JwtClaimTypes.DPoPHttpUrl, payloadUrl },
+            { JwtClaimTypes.IssuedAt, IssuedAt }
+        };
+
+        ProofValidator.TestTimeProvider.SetUtcNow(DateTimeOffset.FromUnixTimeSeconds(IssuedAt));
+        ProofValidator.ValidatePayload(Context, Result);
+        
+        Result.IsError.ShouldBeFalse(Result.ErrorDescription);
+    }
+    
+    [Theory]
+    [InlineData("https://example.com", "https://example.com:443")]
+    [InlineData("http://example.com", "http://example.com:80")]
+    [Trait("Category", "Unit")]
+    public void htu_uses_scheme_based_normalization_in_comparison_against_requested_url(string expectedUrl, string payloadUrl)
+    {
+        Context = Context with { ExpectedUrl = expectedUrl };
+        Result.Payload = new Dictionary<string, object>
+        {
+            { JwtClaimTypes.DPoPAccessTokenHash, AccessTokenHash },
+            { JwtClaimTypes.JwtId, TokenId },
+            { JwtClaimTypes.DPoPHttpMethod, HttpMethod },
+            { JwtClaimTypes.DPoPHttpUrl, payloadUrl },
+            { JwtClaimTypes.IssuedAt, IssuedAt }
+        };
+
+        ProofValidator.TestTimeProvider.SetUtcNow(DateTimeOffset.FromUnixTimeSeconds(IssuedAt));
+        ProofValidator.ValidatePayload(Context, Result);
+        
+        Result.IsError.ShouldBeFalse(Result.ErrorDescription);
+    }
 
     [Fact]
     [Trait("Category", "Unit")]

--- a/aspnetcore-authentication-jwtbearer/test/AspNetCore.Authentication.JwtBearer.Tests/DPoP/PayloadTests.cs
+++ b/aspnetcore-authentication-jwtbearer/test/AspNetCore.Authentication.JwtBearer.Tests/DPoP/PayloadTests.cs
@@ -94,7 +94,7 @@ public class PayloadTests : DPoPProofValidatorTestBase
         Result.ShouldBeInvalidProofWithDescription("Invalid 'htu' value.");
         ProofValidator.ReplayCacheShouldNotBeCalled();
     }
-    
+
     [Theory]
     [InlineData("https://example.com?query=1#fragment")]
     [InlineData("https://example.com/#fragment")]
@@ -113,10 +113,10 @@ public class PayloadTests : DPoPProofValidatorTestBase
 
         ProofValidator.TestTimeProvider.SetUtcNow(DateTimeOffset.FromUnixTimeSeconds(IssuedAt));
         ProofValidator.ValidatePayload(Context, Result);
-        
+
         Result.IsError.ShouldBeFalse(Result.ErrorDescription);
     }
-    
+
     [Theory]
     [InlineData("https://example.com")]
     [InlineData("HTTPS://EXAMPLE.COM")]
@@ -136,10 +136,10 @@ public class PayloadTests : DPoPProofValidatorTestBase
 
         ProofValidator.TestTimeProvider.SetUtcNow(DateTimeOffset.FromUnixTimeSeconds(IssuedAt));
         ProofValidator.ValidatePayload(Context, Result);
-        
+
         Result.IsError.ShouldBeFalse(Result.ErrorDescription);
     }
-    
+
     [Theory]
     [InlineData("https://example.com", "https://example.com:443")]
     [InlineData("http://example.com", "http://example.com:80")]
@@ -158,7 +158,7 @@ public class PayloadTests : DPoPProofValidatorTestBase
 
         ProofValidator.TestTimeProvider.SetUtcNow(DateTimeOffset.FromUnixTimeSeconds(IssuedAt));
         ProofValidator.ValidatePayload(Context, Result);
-        
+
         Result.IsError.ShouldBeFalse(Result.ErrorDescription);
     }
 

--- a/aspnetcore-authentication-jwtbearer/test/AspNetCore.Authentication.JwtBearer.Tests/DPoPIntegrationTests.cs
+++ b/aspnetcore-authentication-jwtbearer/test/AspNetCore.Authentication.JwtBearer.Tests/DPoPIntegrationTests.cs
@@ -65,11 +65,11 @@ public class DPoPIntegrationTests(ITestOutputHelper testOutputHelper)
         identityServer.Clients.Add(DPoPOnlyClient);
         var jwk = CreateJwk();
         var api = await CreateDPoPApi();
-        
+
         var app = new AppHost(identityServer, api, "client1", testOutputHelper,
             configureUserTokenManagementOptions: opt => opt.DPoPJsonWebKey = jwk);
         await app.Initialize();
-        
+
         // Login and get token for api call
         await app.LoginAsync("sub");
         var response = await app.BrowserClient.GetAsync(app.Url("/user_token"));
@@ -91,7 +91,7 @@ public class DPoPIntegrationTests(ITestOutputHelper testOutputHelper)
         });
         proof.ShouldNotBeNull();
         api.HttpClient.DefaultRequestHeaders.Add(OidcConstants.HttpHeaders.DPoP, [proof.ProofToken, proof.ProofToken]);
-       
+
         var result = await api.HttpClient.GetAsync("/");
 
         result.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
@@ -164,7 +164,7 @@ public class DPoPIntegrationTests(ITestOutputHelper testOutputHelper)
         token.AccessToken.ShouldNotBeNull();
         token.DPoPJsonWebKey.ShouldNotBeNull();
         api.HttpClient.SetToken("DPoP", token.AccessToken);
-        
+
         var result = await api.HttpClient.GetAsync("/");
 
         result.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);


### PR DESCRIPTION
**What issue does this PR address?**
- [x] When multiple proof tokens are sent to the RS, we should return an invalid_request error
- [x] The htu claim in DPoP proofs sent to the RS should ignore query and fragment parts when it is compared to the requested URL 
- [x] The htu claim in DPoP proofs should use a case-insensitive comparison to the requested URL
- [x] The htu claim in DPoP proofs should use scheme based normalization (the port should be ignored if that is the default for the scheme, etc)
- [x] A DPoP access token sent to the RS without a DPoP proof (Authorization: DPOP eyJh..., but no DPOP header) should return an invalid_request error 


**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
