### PR TITLE
Options of Allowed Signing Algorithms JWTs and DPoP Proof Tokens

### DIFF
--- a/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/DPoPOptions.cs
+++ b/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/DPoPOptions.cs
@@ -4,6 +4,8 @@
 
 #nullable enable
 
+using Microsoft.IdentityModel.Tokens;
+
 namespace Duende.IdentityServer.Configuration;
 
 /// <summary>
@@ -20,4 +22,23 @@ public class DPoPOptions
     /// Clock skew used in validating DPoP proof token expiration using a server-generated nonce value. Defaults to ten seconds.
     /// </summary>
     public TimeSpan ServerClockSkew { get; set; } = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// The allowed signing algorithms used in validating DPoP proof tokens. Defaults to:
+    /// RSA256, RSA384, RSA512, PS256, PS384, PS512, ES256, ES384, ES512.
+    /// </summary>
+    public ICollection<string> SupportedDPoPSigningAlgorithms { get; set; } =
+    [
+        SecurityAlgorithms.RsaSha256,
+        SecurityAlgorithms.RsaSha384,
+        SecurityAlgorithms.RsaSha512,
+
+        SecurityAlgorithms.RsaSsaPssSha256,
+        SecurityAlgorithms.RsaSsaPssSha384,
+        SecurityAlgorithms.RsaSsaPssSha512,
+
+        SecurityAlgorithms.EcdsaSha256,
+        SecurityAlgorithms.EcdsaSha384,
+        SecurityAlgorithms.EcdsaSha512
+    ];
 }

--- a/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
+++ b/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
@@ -217,7 +217,7 @@ public class IdentityServerOptions
     public TimeSpan JwtValidationClockSkew { get; set; } = TimeSpan.FromSeconds(10);
 
     /// <summary>
-    /// The allowed algorithms for JWT validation. All JWTs validated use this
+    /// The allowed algorithms for JWT validation. Except for DPoP proofs, all JWTs validated by IdentityServer use this
     /// setting to control the allowed signing algorithms. This includes JWT
     /// access tokens passed to the user info, introspection, and local api endpoints,
     /// client authentication JWTs used in private_key_jwt authentication, JWT secured

--- a/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
+++ b/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
@@ -205,13 +205,14 @@ public class IdentityServerOptions
     public PushedAuthorizationOptions PushedAuthorization { get; set; } = new PushedAuthorizationOptions();
 
     /// <summary>
-    /// The allowed clock skew for JWT lifetime validation. All JWTs that have
-    /// their lifetime validated use this setting to control the clock skew of
-    /// lifetime validation. This includes JWT access tokens passed to the user
-    /// info, introspection, and local api endpoints, client authentication JWTs
-    /// used in private_key_jwt authentication, JWT secured authorization
-    /// requests (JAR), and custom usage of the <see cref="TokenValidator"/>,
-    /// such as in a token exchange implementation. Defaults to ten seconds.
+    /// The allowed clock skew for JWT lifetime validation. Except for DPoP proofs,
+    /// all JWTs that have their lifetime validated use this setting to control the
+    /// clock skew of lifetime validation. This includes JWT access tokens passed 
+    /// to the user info, introspection, and local api endpoints, client 
+    /// authentication JWTs used in private_key_jwt authentication, JWT secured
+    /// authorization requests (JAR), and custom usage of the 
+    /// <see cref="TokenValidator"/>, such as in a token exchange implementation. 
+    /// Defaults to ten seconds.
     /// </summary>
     public TimeSpan JwtValidationClockSkew { get; set; } = TimeSpan.FromSeconds(10);
 

--- a/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
+++ b/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
@@ -216,6 +216,17 @@ public class IdentityServerOptions
     public TimeSpan JwtValidationClockSkew { get; set; } = TimeSpan.FromSeconds(10);
 
     /// <summary>
+    /// The allowed algorithms for JWT validation. All JWTs validated use this
+    /// setting to control the allowed signing algorithms. This includes JWT
+    /// access tokens passed to the user info, introspection, and local api endpoints,
+    /// client authentication JWTs used in private_key_jwt authentication, JWT secured
+    /// authorization requests (JAR), and custom usage of the <see cref="TokenValidator"/>,
+    /// such as in a token exchange implementation. Defaults to an empty collection which
+    /// allows all algorithms.
+    /// </summary>
+    public ICollection<string> AllowedJwtAlgorithms { get; set; } = [];
+
+    /// <summary>
     /// Gets or sets the options for enabling and configuring preview features in the server.
     /// Preview features provide access to experimental or in-progress functionality that may undergo
     /// further changes before being finalized.

--- a/identity-server/src/IdentityServer/IdentityServerConstants.cs
+++ b/identity-server/src/IdentityServer/IdentityServerConstants.cs
@@ -117,21 +117,6 @@ public static class IdentityServerConstants
         SecurityAlgorithms.EcdsaSha512
     };
 
-    public readonly static IEnumerable<string> SupportedDPoPSigningAlgorithms = new[]
-    {
-        SecurityAlgorithms.RsaSha256,
-        SecurityAlgorithms.RsaSha384,
-        SecurityAlgorithms.RsaSha512,
-
-        SecurityAlgorithms.RsaSsaPssSha256,
-        SecurityAlgorithms.RsaSsaPssSha384,
-        SecurityAlgorithms.RsaSsaPssSha512,
-
-        SecurityAlgorithms.EcdsaSha256,
-        SecurityAlgorithms.EcdsaSha384,
-        SecurityAlgorithms.EcdsaSha512
-    };
-
     public enum RsaSigningAlgorithm
     {
         RS256,

--- a/identity-server/src/IdentityServer/ResponseHandling/Default/DiscoveryResponseGenerator.cs
+++ b/identity-server/src/IdentityServer/ResponseHandling/Default/DiscoveryResponseGenerator.cs
@@ -390,7 +390,7 @@ public class DiscoveryResponseGenerator : IDiscoveryResponseGenerator
 
         if (Options.Endpoints.EnableTokenEndpoint)
         {
-            entries.Add(OidcConstants.Discovery.DPoPSigningAlgorithmsSupported, SupportedDPoPSigningAlgorithms);
+            entries.Add(OidcConstants.Discovery.DPoPSigningAlgorithmsSupported, Options.DPoP.SupportedDPoPSigningAlgorithms);
         }
 
         // custom entries

--- a/identity-server/src/IdentityServer/Validation/Default/DefaultDPoPProofValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/Default/DefaultDPoPProofValidator.cs
@@ -142,7 +142,7 @@ public class DefaultDPoPProofValidator : IDPoPProofValidator
             return Task.CompletedTask;
         }
 
-        if (!token.TryGetHeaderValue<string>(JwtClaimTypes.Algorithm, out var alg) || !IdentityServerConstants.SupportedDPoPSigningAlgorithms.Contains(alg))
+        if (!token.TryGetHeaderValue<string>(JwtClaimTypes.Algorithm, out var alg) || !Options.DPoP.SupportedDPoPSigningAlgorithms.Contains(alg))
         {
             result.IsError = true;
             result.ErrorDescription = "Invalid 'alg' value.";

--- a/identity-server/src/IdentityServer/Validation/Default/JwtRequestValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/Default/JwtRequestValidator.cs
@@ -172,7 +172,8 @@ public class JwtRequestValidator : IJwtRequestValidator
             RequireSignedTokens = true,
             RequireExpirationTime = true,
 
-            ClockSkew = Options.JwtValidationClockSkew
+            ClockSkew = Options.JwtValidationClockSkew,
+            ValidAlgorithms = Options.AllowedJwtAlgorithms
         };
 
         var strictJarValidation = context.StrictJarValidation.HasValue ? context.StrictJarValidation.Value : Options.StrictJarValidation;

--- a/identity-server/src/IdentityServer/Validation/Default/PrivateKeyJwtSecretValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/Default/PrivateKeyJwtSecretValidator.cs
@@ -119,7 +119,8 @@ public class PrivateKeyJwtSecretValidator : ISecretValidator
             RequireSignedTokens = true,
             RequireExpirationTime = true,
 
-            ClockSkew = _options.JwtValidationClockSkew
+            ClockSkew = _options.JwtValidationClockSkew,
+            ValidAlgorithms = _options.AllowedJwtAlgorithms
         };
 
         var issuer = await _issuerNameService.GetCurrentAsync();

--- a/identity-server/src/IdentityServer/Validation/Default/TokenValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/Default/TokenValidator.cs
@@ -279,7 +279,8 @@ internal class TokenValidator : ITokenValidator
             ValidIssuer = await _issuerNameService.GetCurrentAsync(),
             IssuerSigningKeys = validationKeys.Select(k => k.Key),
             ValidateLifetime = validateLifetime,
-            ClockSkew = _options.JwtValidationClockSkew
+            ClockSkew = _options.JwtValidationClockSkew,
+            ValidAlgorithms = _options.AllowedJwtAlgorithms
         };
 
         if (audience.IsPresent())

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Discovery/DiscoveryEndpointTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Discovery/DiscoveryEndpointTests.cs
@@ -2,6 +2,7 @@
 // See LICENSE in the project root for license information.
 
 using System.Text.Json;
+using Duende.IdentityModel;
 using Duende.IdentityModel.Client;
 using Duende.IdentityServer;
 using Duende.IdentityServer.Configuration;
@@ -331,5 +332,25 @@ public class DiscoveryEndpointTests
 
         var result = await pipeline.BackChannelClient.GetDiscoveryDocumentAsync("https://server/.well-known/openid-configuration");
         result.MtlsEndpointAliases.PushedAuthorizationRequestEndpoint.ShouldNotBeNull();
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task dpop_signing_algorithms_supported_respects_configuration()
+    {
+        var pipeline = new IdentityServerPipeline();
+        pipeline.Initialize();
+
+        var supportedAlgorithms = new List<string>
+        {
+            SecurityAlgorithms.RsaSha256,
+            SecurityAlgorithms.EcdsaSha256
+        };
+        pipeline.Options.DPoP.SupportedDPoPSigningAlgorithms = supportedAlgorithms;
+
+        var result = await pipeline.BackChannelClient.GetDiscoveryDocumentAsync("https://server/.well-known/openid-configuration");
+
+        var supportedAlgorithmsFromResponse = result.TryGetStringArray(OidcConstants.Discovery.DPoPSigningAlgorithmsSupported);
+        supportedAlgorithmsFromResponse.ShouldBe(supportedAlgorithms);
     }
 }

--- a/identity-server/test/IdentityServer.UnitTests/Validation/AccessTokenValidation.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Validation/AccessTokenValidation.cs
@@ -269,6 +269,23 @@ public class AccessTokenValidation
 
     [Fact]
     [Trait("Category", Category)]
+    public async Task Jwt_created_with_signing_algorithm_not_allowed_by_identity_server_settings_is_considered_invalid()
+    {
+        var signer = Factory.CreateDefaultTokenCreator();
+        var token = TokenFactory.CreateAccessToken(new Client { ClientId = "roclient" }, "valid", 600, "read", "write");
+        var jwt = await signer.CreateTokenAsync(token);
+
+        var options = TestIdentityServerOptions.Create();
+        options.AllowedJwtAlgorithms = ["Test"];
+        var validator = Factory.CreateTokenValidator(options: options);
+        var result = await validator.ValidateAccessTokenAsync(jwt);
+
+        result.IsError.ShouldBeTrue();
+        result.Error.ShouldBe(OidcConstants.ProtectedResourceErrors.InvalidToken);
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
     public async Task Valid_AccessToken_but_Client_not_active()
     {
         var store = Factory.CreateReferenceTokenStore();

--- a/identity-server/test/IdentityServer.UnitTests/Validation/DPoPProofValidatorTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Validation/DPoPProofValidatorTests.cs
@@ -531,6 +531,7 @@ public class DPoPProofValidatorTests
     [Trait("Category", Category)]
     public async Task invalid_alg_should_fail_validation()
     {
+        _options.DPoP.SupportedDPoPSigningAlgorithms = [SecurityAlgorithms.EcdsaSha512];
         var key = new SymmetricSecurityKey(Duende.IdentityModel.CryptoRandom.CreateRandomKey(32));
         _publicJWK = JsonSerializer.Serialize(key);
         CreateHeaderValuesFromPublicKey();

--- a/identity-server/test/IdentityServer.UnitTests/Validation/Secrets/PrivateKeyJwtSecretValidation.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Validation/Secrets/PrivateKeyJwtSecretValidation.cs
@@ -458,4 +458,25 @@ public class PrivateKeyJwtSecretValidation
 
         result.Success.ShouldBeFalse();
     }
+
+    [Fact]
+    public async Task Signing_Algorithm_Not_Allowed_By_Configuration()
+    {
+        var clientId = "certificate_base64_valid";
+        var client = await _clients.FindEnabledClientByIdAsync(clientId);
+
+        var token = CreateToken(clientId);
+        var secret = new ParsedSecret
+        {
+            Id = clientId,
+            Credential = new JwtSecurityTokenHandler().WriteToken(token),
+            Type = IdentityServerConstants.ParsedSecretTypes.JwtBearer
+        };
+
+        _options.AllowedJwtAlgorithms = ["Test"];
+
+        var result = await _validator.ValidateAsync(client.ClientSecrets, secret);
+
+        result.Success.ShouldBeFalse();
+    }
 }


### PR DESCRIPTION
**What issue does this PR address?**
Adds new options for allowed signing algorithms for JWTs and DPoP proof tokens for scenarios when the supported algorithms need to be restricted such as the FAPI 2.0 Profile.


**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
