### PR TITLE
Adjust Default Values for Clock Skew Config Options

### DIFF
--- a/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/DPoPOptions.cs
+++ b/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/DPoPOptions.cs
@@ -19,9 +19,9 @@ public class DPoPOptions
     public TimeSpan ProofTokenValidityDuration { get; set; } = TimeSpan.FromMinutes(1);
 
     /// <summary>
-    /// Clock skew used in validating DPoP proof token expiration using a server-generated nonce value. Defaults to ten seconds.
+    /// Clock skew used in validating DPoP proof token expiration using a server-generated nonce value. Defaults to zero.
     /// </summary>
-    public TimeSpan ServerClockSkew { get; set; } = TimeSpan.FromSeconds(10);
+    public TimeSpan ServerClockSkew { get; set; } = TimeSpan.FromMinutes(0);
 
     /// <summary>
     /// The allowed signing algorithms used in validating DPoP proof tokens. Defaults to:

--- a/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
+++ b/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
@@ -212,9 +212,9 @@ public class IdentityServerOptions
     /// authentication JWTs used in private_key_jwt authentication, JWT secured
     /// authorization requests (JAR), and custom usage of the 
     /// <see cref="TokenValidator"/>, such as in a token exchange implementation. 
-    /// Defaults to ten seconds.
+    /// Defaults to five minutes.
     /// </summary>
-    public TimeSpan JwtValidationClockSkew { get; set; } = TimeSpan.FromSeconds(10);
+    public TimeSpan JwtValidationClockSkew { get; set; } = TimeSpan.FromMinutes(5);
 
     /// <summary>
     /// The allowed algorithms for JWT validation. Except for DPoP proofs, all JWTs validated by IdentityServer use this


### PR DESCRIPTION
**What issue does this PR address?**
Per some internal discussion it will be better to keep the default value of our `JwtValidationClockSkew` in line with the Wilson default and let users adjust as needed. Because we're keeping that as a higher default, there's not a reason to keep it aligned wit the same setting in the DPoP configuration so that setting is being adjusted back to its original value as well.


**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
