### PR TITLE
Change error when required DPoP proof is missing

### DIFF
--- a/identity-server/src/IdentityServer/Validation/Default/TokenRequestValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/Default/TokenRequestValidator.cs
@@ -266,7 +266,7 @@ internal class TokenRequestValidator : ITokenRequestValidator
         else if (_validatedRequest.Client.RequireDPoP)
         {
             LogError("Client requires DPoP and a DPoP header value was not provided.");
-            return Invalid(OidcConstants.TokenErrors.InvalidDPoPProof, "Client requires DPoP and a DPoP header value was not provided.");
+            return Invalid(OidcConstants.TokenErrors.InvalidRequest, "Client requires DPoP and a DPoP header value was not provided.");
         }
 
         return Valid();

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Token/DPoPTokenEndpointTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Token/DPoPTokenEndpointTests.cs
@@ -142,7 +142,7 @@ public class DPoPTokenEndpointTests : DPoPEndpointTestBase
         var response = await Pipeline.BackChannelClient.RequestClientCredentialsTokenAsync(request);
 
         response.IsError.ShouldBeTrue();
-        response.Error.ShouldBe("invalid_dpop_proof");
+        response.Error.ShouldBe("invalid_request");
     }
 
     [Fact]
@@ -288,7 +288,7 @@ public class DPoPTokenEndpointTests : DPoPEndpointTestBase
         var rtRequest = CreateRefreshTokenRequest(codeResponse, omitDPoPProof: true);
         var rtResponse = await Pipeline.BackChannelClient.RequestRefreshTokenAsync(rtRequest);
         rtResponse.IsError.ShouldBeTrue();
-        rtResponse.Error.ShouldBe("invalid_dpop_proof");
+        rtResponse.Error.ShouldBe("invalid_request");
     }
 
     [Theory]


### PR DESCRIPTION
As per the FAPI 2.0 conformance test suite, if we are missing a DPoP proof when it is required, we should return an invalid_request error (previously was invalid_dpop_proof).

