### PR TITLE
Reworked supported algorithm options

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
 		<PackageVersion Include="Duende.AccessTokenManagement" Version="3.2.0" />
 		<PackageVersion Include="Duende.AccessTokenManagement.OpenIdConnect" Version="3.2.0" />
 		<PackageVersion Include="Duende.AspNetCore.Authentication.JwtBearer" Version="0.1.3" />
-		<PackageVersion Include="Duende.IdentityModel" Version="7.1.0-preview.1" />
+		<PackageVersion Include="Duende.IdentityModel" Version="7.1.0-preview.2" />
 		<PackageVersion Include="Duende.IdentityModel.OidcClient" Version="6.0.1" />
 		<PackageVersion Include="Duende.IdentityServer" Version="7.1.0" />
 		<PackageVersion Include="IdentityModel.AspNetCore.OAuth2Introspection" Version="6.2.0" />
@@ -108,23 +108,23 @@
 
 		<PackageVersion Include="PublicApiGenerator" Version="11.1.0" />
 		<PackageVersion Include="RichardSzalay.MockHttp" Version="7.0.0" />
-		
+
 		<PackageVersion Include="Serilog" Version="4.2.0" />
 		<PackageVersion Include="Serilog.AspNetCore" Version="8.0.3" />
 		<PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
 		<PackageVersion Include="Serilog.Sinks.TextWriter" Version="3.0.0" />
 		<PackageVersion Include="Serilog.Sinks.XUnit" Version="3.0.19" />
 		<PackageVersion Include="Serilog.Extensions.Logging" Version="9.0.0" />
-		
+
 		<PackageVersion Include="Shouldly" Version="4.2.1" />
 		<PackageVersion Include="SimpleExec" Version="12.0.0" />
-		
+
 		<PackageVersion Include="System.IdentityModel.Tokens.Jwt" Condition="'$(TargetFramework)' == 'net8.0'" Version="7.1.2" />
 		<PackageVersion Include="System.IdentityModel.Tokens.Jwt" Condition="'$(TargetFramework)' == 'net9.0'" Version="8.0.1" />
 		<PackageVersion Include="System.Net.Http" Version="4.3.4" />
 		<PackageVersion Include="System.Text.Json" Version="8.0.5" />
 		<PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
-		
+
 		<PackageVersion Include="xunit.core" Version="2.9.3" />
 		<PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
 		<PackageVersion Include="Xunit.SkippableFact" Version="1.5.23" />
@@ -134,14 +134,14 @@
 		<!-- Transitive Dependencies -->
 		<!-- These packages are all transitive dependencies that would
             otherwise resolve to a version with a security vulnerability. In future, we
-            would like to update Microsoft.Data.SqlClient and 
+            would like to update Microsoft.Data.SqlClient and
             Microsoft.EntityFrameworkCore, and remove these explicit dependencies (assuming
             that future versions of the intermediate dependencies that don't have this
             problem exist someday). -->
-		<PackageVersion Include="Azure.Identity" Version="1.11.4" />
-		<PackageVersion Include="System.Formats.Asn1" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.1" />
-		<PackageVersion Include="System.Formats.Asn1" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.0" />
-		<PackageVersion Include="System.Drawing.Common" Version="6.0.0" />
-		<PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.2" />
-	</ItemGroup>
+    <PackageVersion Include="Azure.Identity" Version="1.11.4" />
+    <PackageVersion Include="System.Formats.Asn1" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.1" />
+    <PackageVersion Include="System.Formats.Asn1" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.0" />
+    <PackageVersion Include="System.Drawing.Common" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.2" />
+  </ItemGroup>
 </Project>

--- a/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/DPoPOptions.cs
+++ b/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/DPoPOptions.cs
@@ -27,6 +27,22 @@ public class DPoPOptions
     /// The allowed signing algorithms used in validating DPoP proof tokens. Defaults to:
     /// RSA256, RSA384, RSA512, PS256, PS384, PS512, ES256, ES384, ES512.
     /// </summary>
+    ///
+    /// <summary>
+    /// <para>
+    /// Specifies the allowed signature algorithms for DPoP proof tokens. The "alg" headers of proofs
+    /// are validated against this collection, and the dpop_signing_alg_values_supported discovery property is populated
+    /// with these values.
+    /// </para>
+    /// <para>
+    /// Defaults to [RS256, RS384, RS512, PS256, PS384, PS512, ES256, ES384, ES512], which allows the RSA, Probabilistic
+    /// RSA, or ECDSA signing algorithms with 256, 384, or 512-bit SHA hashing.
+    /// </para>
+    /// <para>
+    /// If set to an empty collection, all algorithms (including symmetric algorithms) are allowed, and the
+    /// dpop_signing_alg_values_supported will not be set. Explicitly listing the expected values is recommended.
+    ///</para>
+    /// </summary>
     public ICollection<string> SupportedDPoPSigningAlgorithms { get; set; } =
     [
         SecurityAlgorithms.RsaSha256,

--- a/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
+++ b/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
@@ -6,6 +6,7 @@
 
 using Duende.IdentityServer.Stores.Serialization;
 using Duende.IdentityServer.Validation;
+using Microsoft.IdentityModel.Tokens;
 
 namespace Duende.IdentityServer.Configuration;
 
@@ -205,27 +206,86 @@ public class IdentityServerOptions
     public PushedAuthorizationOptions PushedAuthorization { get; set; } = new PushedAuthorizationOptions();
 
     /// <summary>
-    /// The allowed clock skew for JWT lifetime validation. Except for DPoP proofs,
-    /// all JWTs that have their lifetime validated use this setting to control the
-    /// clock skew of lifetime validation. This includes JWT access tokens passed
-    /// to the user info, introspection, and local api endpoints, client
-    /// authentication JWTs used in private_key_jwt authentication, JWT secured
-    /// authorization requests (JAR), and custom usage of the
-    /// <see cref="TokenValidator"/>, such as in a token exchange implementation.
+    /// The allowed clock skew for JWT lifetime validation. This setting controls the clock skew of lifetime validation
+    /// for all JWTs except DPoP proofs, including
+    /// <list type="bullet">
+    /// <item>JWT access tokens passed to the user info, introspection, and local api endpoints</item>
+    /// <item>Authentication JWTs used in private_key_jwt authentication</item>
+    /// <item> JWT secured authorization requests (JAR request objects)</item>
+    /// <item> Custom usage of the <see cref="TokenValidator"/>, such as in a token exchange implementation.</item>
+    /// </list>
+    ///
     /// Defaults to five minutes.
     /// </summary>
     public TimeSpan JwtValidationClockSkew { get; set; } = TimeSpan.FromMinutes(5);
 
     /// <summary>
-    /// The allowed algorithms for JWT validation. Except for DPoP proofs, all JWTs validated by IdentityServer use this
-    /// setting to control the allowed signing algorithms. This includes JWT
-    /// access tokens passed to the user info, introspection, and local api endpoints,
-    /// client authentication JWTs used in private_key_jwt authentication, JWT secured
-    /// authorization requests (JAR), and custom usage of the <see cref="TokenValidator"/>,
-    /// such as in a token exchange implementation. Defaults to an empty collection which
-    /// allows all algorithms.
+    /// <para>
+    /// Specifies the allowed signature algorithms for JWT secured authorization requests (JAR). The "alg" header of JAR
+    /// request objects is validated against this collection, and the
+    /// request_object_signing_alg_values_supported discovery property is populated with these values.
+    /// </para>
+    /// <para>
+    /// Defaults to [RS256, RS384, RS512, PS256, PS384, PS512, ES256, ES384, ES512, HS256, HS384, HS512], which allows
+    /// the RSA, Probabilistic RSA, ECDSA, or HMAC signing algorithms with 256, 384, or 512-bit SHA hashing.
+    /// </para>
+    /// <para>
+    /// If set to an empty collection, all algorithms are allowed, but the request_object_signing_alg_values_supported
+    /// will not be set. Explicitly listing the expected values is recommended.
+    ///</para>
     /// </summary>
-    public ICollection<string> AllowedJwtAlgorithms { get; set; } = [];
+    public ICollection<string> SupportedRequestObjectSigningAlgorithms { get; set; } =
+    [
+        SecurityAlgorithms.RsaSha256,
+        SecurityAlgorithms.RsaSha384,
+        SecurityAlgorithms.RsaSha512,
+
+        SecurityAlgorithms.RsaSsaPssSha256,
+        SecurityAlgorithms.RsaSsaPssSha384,
+        SecurityAlgorithms.RsaSsaPssSha512,
+
+        SecurityAlgorithms.EcdsaSha256,
+        SecurityAlgorithms.EcdsaSha384,
+        SecurityAlgorithms.EcdsaSha512,
+
+        SecurityAlgorithms.HmacSha256,
+        SecurityAlgorithms.HmacSha384,
+        SecurityAlgorithms.HmacSha512
+    ];
+
+    /// <summary>
+    /// <para>
+    /// Specifies the allowed signature algorithms for client authentication using client assertions (the
+    /// private_key_jwt parameter). The "alg" header of client assertions is validated against this collection, and the
+    /// token_endpoint_auth_signing_alg_values_supported discovery property is populated with these values.
+    /// </para>
+    /// <para>
+    /// Defaults to [RS256, RS384, RS512, PS256, PS384, PS512, ES256, ES384, ES512, HS256, HS384, HS512], which allows
+    /// the RSA, Probabilistic RSA, ECDSA, or HMAC signing algorithms with 256, 384, or 512-bit SHA hashing.
+    /// </para>
+    /// <para>
+    /// If set to an empty collection, all algorithms are allowed, but the
+    /// token_endpoint_auth_signing_alg_values_supported will not be set. Explicitly listing the expected values is
+    /// recommended.
+    ///</para>
+    /// </summary>
+    public ICollection<string> SupportedClientAssertionSigningAlgorithms { get; set; } = [
+        SecurityAlgorithms.RsaSha256,
+        SecurityAlgorithms.RsaSha384,
+        SecurityAlgorithms.RsaSha512,
+
+        SecurityAlgorithms.RsaSsaPssSha256,
+        SecurityAlgorithms.RsaSsaPssSha384,
+        SecurityAlgorithms.RsaSsaPssSha512,
+
+        SecurityAlgorithms.EcdsaSha256,
+        SecurityAlgorithms.EcdsaSha384,
+        SecurityAlgorithms.EcdsaSha512,
+
+        SecurityAlgorithms.HmacSha256,
+        SecurityAlgorithms.HmacSha384,
+        SecurityAlgorithms.HmacSha512
+    ];
 
     /// <summary>
     /// Gets or sets the options for enabling and configuring preview features in the server.

--- a/identity-server/src/IdentityServer/ResponseHandling/Default/DiscoveryResponseGenerator.cs
+++ b/identity-server/src/IdentityServer/ResponseHandling/Default/DiscoveryResponseGenerator.cs
@@ -328,7 +328,8 @@ public class DiscoveryResponseGenerator : IDiscoveryResponseGenerator
             }
             entries.Add(OidcConstants.Discovery.TokenEndpointAuthenticationMethodsSupported, types);
 
-            if (types.Contains(OidcConstants.EndpointAuthenticationMethods.PrivateKeyJwt))
+            if (types.Contains(OidcConstants.EndpointAuthenticationMethods.PrivateKeyJwt) &&
+                !IEnumerableExtensions.IsNullOrEmpty(Options.SupportedClientAssertionSigningAlgorithms))
             {
                 entries.Add(OidcConstants.Discovery.TokenEndpointAuthSigningAlgorithmsSupported,
                     Options.SupportedClientAssertionSigningAlgorithms);
@@ -349,7 +350,11 @@ public class DiscoveryResponseGenerator : IDiscoveryResponseGenerator
         {
             entries.Add(OidcConstants.Discovery.RequestParameterSupported, true);
 
-            entries.Add(OidcConstants.Discovery.RequestObjectSigningAlgorithmsSupported, Options.SupportedRequestObjectSigningAlgorithms);
+            if (!IEnumerableExtensions.IsNullOrEmpty(Options.SupportedRequestObjectSigningAlgorithms))
+            {
+                entries.Add(OidcConstants.Discovery.RequestObjectSigningAlgorithmsSupported,
+                    Options.SupportedRequestObjectSigningAlgorithms);
+            }
 
             if (Options.Endpoints.EnableJwtRequestUri)
             {
@@ -376,7 +381,8 @@ public class DiscoveryResponseGenerator : IDiscoveryResponseGenerator
             entries.Add(OidcConstants.Discovery.BackchannelUserCodeParameterSupported, true);
         }
 
-        if (Options.Endpoints.EnableTokenEndpoint)
+        if (Options.Endpoints.EnableTokenEndpoint &&
+            !IEnumerableExtensions.IsNullOrEmpty(Options.DPoP.SupportedDPoPSigningAlgorithms))
         {
             entries.Add(OidcConstants.Discovery.DPoPSigningAlgorithmsSupported, Options.DPoP.SupportedDPoPSigningAlgorithms);
         }

--- a/identity-server/src/IdentityServer/ResponseHandling/Default/DiscoveryResponseGenerator.cs
+++ b/identity-server/src/IdentityServer/ResponseHandling/Default/DiscoveryResponseGenerator.cs
@@ -328,6 +328,7 @@ public class DiscoveryResponseGenerator : IDiscoveryResponseGenerator
             }
 
             entries.Add(OidcConstants.Discovery.TokenEndpointAuthenticationMethodsSupported, types);
+            entries.Add(OidcConstants.Discovery.TokenEndpointAuthSigningAlgorithmsSupported, Options.AllowedJwtAlgorithms);
         }
 
         var signingCredentials = await Keys.GetAllSigningCredentialsAsync();

--- a/identity-server/src/IdentityServer/ResponseHandling/Default/DiscoveryResponseGenerator.cs
+++ b/identity-server/src/IdentityServer/ResponseHandling/Default/DiscoveryResponseGenerator.cs
@@ -331,7 +331,7 @@ public class DiscoveryResponseGenerator : IDiscoveryResponseGenerator
             if (types.Contains(OidcConstants.EndpointAuthenticationMethods.PrivateKeyJwt))
             {
                 entries.Add(OidcConstants.Discovery.TokenEndpointAuthSigningAlgorithmsSupported,
-                    Options.AllowedJwtAlgorithms);
+                    Options.SupportedClientAssertionSigningAlgorithms);
             }
         }
 
@@ -349,25 +349,7 @@ public class DiscoveryResponseGenerator : IDiscoveryResponseGenerator
         {
             entries.Add(OidcConstants.Discovery.RequestParameterSupported, true);
 
-            // TODO
-            entries.Add(OidcConstants.Discovery.RequestObjectSigningAlgorithmsSupported, new[]
-            {
-                SecurityAlgorithms.RsaSha256,
-                SecurityAlgorithms.RsaSha384,
-                SecurityAlgorithms.RsaSha512,
-
-                SecurityAlgorithms.RsaSsaPssSha256,
-                SecurityAlgorithms.RsaSsaPssSha384,
-                SecurityAlgorithms.RsaSsaPssSha512,
-
-                SecurityAlgorithms.EcdsaSha256,
-                SecurityAlgorithms.EcdsaSha384,
-                SecurityAlgorithms.EcdsaSha512,
-
-                SecurityAlgorithms.HmacSha256,
-                SecurityAlgorithms.HmacSha384,
-                SecurityAlgorithms.HmacSha512
-            });
+            entries.Add(OidcConstants.Discovery.RequestObjectSigningAlgorithmsSupported, Options.SupportedRequestObjectSigningAlgorithms);
 
             if (Options.Endpoints.EnableJwtRequestUri)
             {

--- a/identity-server/src/IdentityServer/ResponseHandling/Default/DiscoveryResponseGenerator.cs
+++ b/identity-server/src/IdentityServer/ResponseHandling/Default/DiscoveryResponseGenerator.cs
@@ -326,9 +326,13 @@ public class DiscoveryResponseGenerator : IDiscoveryResponseGenerator
                 types.Add(OidcConstants.EndpointAuthenticationMethods.TlsClientAuth);
                 types.Add(OidcConstants.EndpointAuthenticationMethods.SelfSignedTlsClientAuth);
             }
-
             entries.Add(OidcConstants.Discovery.TokenEndpointAuthenticationMethodsSupported, types);
-            entries.Add(OidcConstants.Discovery.TokenEndpointAuthSigningAlgorithmsSupported, Options.AllowedJwtAlgorithms);
+
+            if (types.Contains(OidcConstants.EndpointAuthenticationMethods.PrivateKeyJwt))
+            {
+                entries.Add(OidcConstants.Discovery.TokenEndpointAuthSigningAlgorithmsSupported,
+                    Options.AllowedJwtAlgorithms);
+            }
         }
 
         var signingCredentials = await Keys.GetAllSigningCredentialsAsync();
@@ -345,6 +349,7 @@ public class DiscoveryResponseGenerator : IDiscoveryResponseGenerator
         {
             entries.Add(OidcConstants.Discovery.RequestParameterSupported, true);
 
+            // TODO
             entries.Add(OidcConstants.Discovery.RequestObjectSigningAlgorithmsSupported, new[]
             {
                 SecurityAlgorithms.RsaSha256,

--- a/identity-server/src/IdentityServer/Validation/Default/JwtRequestValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/Default/JwtRequestValidator.cs
@@ -173,7 +173,7 @@ public class JwtRequestValidator : IJwtRequestValidator
             RequireExpirationTime = true,
 
             ClockSkew = Options.JwtValidationClockSkew,
-            ValidAlgorithms = Options.AllowedJwtAlgorithms
+            ValidAlgorithms = Options.SupportedRequestObjectSigningAlgorithms
         };
 
         var strictJarValidation = context.StrictJarValidation.HasValue ? context.StrictJarValidation.Value : Options.StrictJarValidation;

--- a/identity-server/src/IdentityServer/Validation/Default/PrivateKeyJwtSecretValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/Default/PrivateKeyJwtSecretValidator.cs
@@ -120,7 +120,7 @@ public class PrivateKeyJwtSecretValidator : ISecretValidator
             RequireExpirationTime = true,
 
             ClockSkew = _options.JwtValidationClockSkew,
-            ValidAlgorithms = _options.AllowedJwtAlgorithms
+            ValidAlgorithms = _options.SupportedClientAssertionSigningAlgorithms
         };
 
         var issuer = await _issuerNameService.GetCurrentAsync();
@@ -128,7 +128,7 @@ public class PrivateKeyJwtSecretValidator : ISecretValidator
         if (enforceStrictAud)
         {
             // New strict audience validation requires that the audience be the issuer identifier, disallows multiple
-            // audiences in an array, and even disallows wrapping even a single audience in an array 
+            // audiences in an array, and even disallows wrapping even a single audience in an array
             tokenValidationParameters.AudienceValidator = (audiences, token, parameters) =>
             {
                 // There isn't a particularly nice way to distinguish between a claim that is a single string wrapped in
@@ -205,7 +205,7 @@ public class PrivateKeyJwtSecretValidator : ISecretValidator
         return success;
     }
 
-    // AudiencesMatch and AudiencesMatchIgnoringTrailingSlash are based on code from 
+    // AudiencesMatch and AudiencesMatchIgnoringTrailingSlash are based on code from
     // https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/bef98ca10ae55603ce6d37dfb7cd5af27791527c/src/Microsoft.IdentityModel.Tokens/Validators.cs#L158-L193
     private bool AudiencesMatch(string tokenAudience, string validAudience)
     {

--- a/identity-server/src/IdentityServer/Validation/Default/TokenValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/Default/TokenValidator.cs
@@ -279,8 +279,7 @@ internal class TokenValidator : ITokenValidator
             ValidIssuer = await _issuerNameService.GetCurrentAsync(),
             IssuerSigningKeys = validationKeys.Select(k => k.Key),
             ValidateLifetime = validateLifetime,
-            ClockSkew = _options.JwtValidationClockSkew,
-            ValidAlgorithms = _options.AllowedJwtAlgorithms
+            ClockSkew = _options.JwtValidationClockSkew
         };
 
         if (audience.IsPresent())

--- a/identity-server/src/IdentityServer/Validation/Models/ValidatedRequest.cs
+++ b/identity-server/src/IdentityServer/Validation/Models/ValidatedRequest.cs
@@ -13,7 +13,7 @@ using Duende.IdentityServer.Models;
 namespace Duende.IdentityServer.Validation;
 
 /// <summary>
-/// Base class for a validate authorize or token request
+/// Base class for a validated authorize or token request
 /// </summary>
 public class ValidatedRequest
 {

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Authorize/JwtRequestAuthorizeTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Authorize/JwtRequestAuthorizeTests.cs
@@ -913,7 +913,7 @@ public class JwtRequestAuthorizeTests
     [Trait("Category", Category)]
     public async Task authorize_should_reject_jwt_request_if_signed_by_algorithm_not_allowed_by_configuration()
     {
-        _mockPipeline.Options.AllowedJwtAlgorithms = ["ES256"];
+        _mockPipeline.Options.SupportedRequestObjectSigningAlgorithms = ["ES256"];
         var requestJwt = CreateRequestJwt(
             issuer: _client.ClientId,
             audience: IdentityServerPipeline.BaseUrl,

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Discovery/DiscoveryEndpointTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Discovery/DiscoveryEndpointTests.cs
@@ -2,7 +2,6 @@
 // See LICENSE in the project root for license information.
 
 using System.Text.Json;
-using Duende.IdentityModel;
 using Duende.IdentityModel.Client;
 using Duende.IdentityServer;
 using Duende.IdentityServer.Configuration;
@@ -76,122 +75,8 @@ public class DiscoveryEndpointTests
         algorithmsSupported.ShouldContain(SecurityAlgorithms.EcdsaSha256);
     }
 
-    [Fact]
-    public async Task
-        Token_endpoint_authentication_algorithms_supported_should_not_be_present_if_private_key_jwt_is_not_configured()
-    {
-        var pipeline = new IdentityServerPipeline();
-        pipeline.Initialize();
-        pipeline.Options.SupportedClientAssertionSigningAlgorithms = [SecurityAlgorithms.RsaSha256];
 
-        var disco = await pipeline.BackChannelClient
-            .GetDiscoveryDocumentAsync("https://server/.well-known/openid-configuration");
 
-        // Verify assumptions
-        disco.IsError.ShouldBeFalse();
-        disco.TokenEndpointAuthenticationMethodsSupported.ShouldNotContain("private_key_jwt");
-        // we don't even support client_secret_jwt, but per spec, if you DO, you must include the algs supported
-        disco.TokenEndpointAuthenticationMethodsSupported.ShouldNotContain("client_secret_jwt");
-
-        // Assert that we got no signing algs.
-        disco.TokenEndpointAuthenticationSigningAlgorithmsSupported.ShouldBeEmpty();
-    }
-
-    [Fact]
-    public async Task Token_endpoint_authentication_algorithms_supported_should_match_configuration()
-    {
-        var pipeline = new IdentityServerPipeline();
-        pipeline.OnPostConfigureServices += svcs =>
-            svcs.AddIdentityServerBuilder().AddJwtBearerClientAuthentication();
-        pipeline.Initialize();
-        pipeline.Options.SupportedClientAssertionSigningAlgorithms =
-        [
-            SecurityAlgorithms.RsaSsaPssSha256,
-            SecurityAlgorithms.EcdsaSha256
-        ];
-
-        var disco = await pipeline.BackChannelClient
-            .GetDiscoveryDocumentAsync("https://server/.well-known/openid-configuration");
-        disco.IsError.ShouldBeFalse();
-
-        var algorithmsSupported = disco.TokenEndpointAuthenticationSigningAlgorithmsSupported;
-
-        algorithmsSupported.Count().ShouldBe(2);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSsaPssSha256);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.EcdsaSha256);
-    }
-
-    [Fact]
-    public async Task Request_object_signing_alg_values_supported_should_match_configuration()
-    {
-        var pipeline = new IdentityServerPipeline();
-
-        pipeline.Initialize();
-        pipeline.Options.SupportedRequestObjectSigningAlgorithms =
-        [
-            SecurityAlgorithms.RsaSsaPssSha256,
-            SecurityAlgorithms.EcdsaSha256
-        ];
-
-        var result = await pipeline.BackChannelClient.GetDiscoveryDocumentAsync("https://server/.well-known/openid-configuration");
-        var algorithmsSupported = result.TryGetStringArray("request_object_signing_alg_values_supported");
-
-        algorithmsSupported.Count().ShouldBe(2);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSsaPssSha256);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.EcdsaSha256);
-    }
-
-    [Fact]
-    public async Task Default_request_object_signing_alg_values_supported_should_be_rs_ps_es_hmac()
-    {
-        var pipeline = new IdentityServerPipeline();
-        pipeline.Initialize();
-
-        var result = await pipeline.BackChannelClient.GetDiscoveryDocumentAsync("https://server/.well-known/openid-configuration");
-        var algorithmsSupported = result.TryGetStringArray("request_object_signing_alg_values_supported");
-
-        algorithmsSupported.Count().ShouldBe(12);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSha256);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSha384);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSha512);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSsaPssSha384);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSsaPssSha512);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSsaPssSha256);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.EcdsaSha256);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.EcdsaSha384);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.EcdsaSha512);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.HmacSha256);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.HmacSha384);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.HmacSha512);
-    }
-
-    [Fact]
-    public async Task Default_token_endpoint_auth_signing_alg_values_supported_should_be_rs_ps_es_hmac()
-    {
-        var pipeline = new IdentityServerPipeline();
-        pipeline.OnPostConfigureServices += svcs =>
-            svcs.AddIdentityServerBuilder().AddJwtBearerClientAuthentication();
-        pipeline.Initialize();
-
-        var result = await pipeline.BackChannelClient.GetDiscoveryDocumentAsync("https://server/.well-known/openid-configuration");
-
-        result.IsError.ShouldBeFalse();
-        var algorithmsSupported = result.TokenEndpointAuthenticationSigningAlgorithmsSupported;
-
-        algorithmsSupported.Count().ShouldBe(12);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSha256);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSha384);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSha512);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSsaPssSha384);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSsaPssSha512);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSsaPssSha256);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.EcdsaSha256);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.EcdsaSha384);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.EcdsaSha512);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.HmacSha256);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.HmacSha384);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.HmacSha512);
-    }
 
     [Fact]
     [Trait("Category", Category)]
@@ -446,47 +331,5 @@ public class DiscoveryEndpointTests
 
         var result = await pipeline.BackChannelClient.GetDiscoveryDocumentAsync("https://server/.well-known/openid-configuration");
         result.MtlsEndpointAliases.PushedAuthorizationRequestEndpoint.ShouldNotBeNull();
-    }
-
-    [Fact]
-    [Trait("Category", Category)]
-    public async Task dpop_signing_algorithms_supported_respects_configuration()
-    {
-        var pipeline = new IdentityServerPipeline();
-        pipeline.Initialize();
-
-        var supportedAlgorithms = new List<string>
-        {
-            SecurityAlgorithms.RsaSha256,
-            SecurityAlgorithms.EcdsaSha256
-        };
-        pipeline.Options.DPoP.SupportedDPoPSigningAlgorithms = supportedAlgorithms;
-
-        var result = await pipeline.BackChannelClient.GetDiscoveryDocumentAsync("https://server/.well-known/openid-configuration");
-
-        var supportedAlgorithmsFromResponse = result.TryGetStringArray(OidcConstants.Discovery.DPoPSigningAlgorithmsSupported);
-        supportedAlgorithmsFromResponse.ShouldBe(supportedAlgorithms);
-    }
-
-
-    [Fact]
-    public async Task Default_dpop_signing_alg_values_supported_should_be_rs_ps_es()
-    {
-        var pipeline = new IdentityServerPipeline();
-        pipeline.Initialize();
-
-        var result = await pipeline.BackChannelClient.GetDiscoveryDocumentAsync("https://server/.well-known/openid-configuration");
-        var algorithmsSupported = result.TryGetStringArray("dpop_signing_alg_values_supported");
-
-        algorithmsSupported.Count().ShouldBe(9);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSha256);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSha384);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSha512);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSsaPssSha384);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSsaPssSha512);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSsaPssSha256);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.EcdsaSha256);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.EcdsaSha384);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.EcdsaSha512);
     }
 }

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Discovery/DiscoveryEndpointTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Discovery/DiscoveryEndpointTests.cs
@@ -102,7 +102,9 @@ public class DiscoveryEndpointTests
     [Fact]
     public async Task Token_endpoint_authentication_algorithms_supported_should_match_configuration()
     {
-        var pipeline = new IdentityServerPipeline();
+        var pipeline = new IdentityServerPipeline(); // The pipeline includes private_key_jwt client auth by default
+        pipeline.OnPostConfigureServices += svcs =>
+            svcs.AddIdentityServerBuilder().AddJwtBearerClientAuthentication();
         pipeline.Initialize();
         pipeline.Options.AllowedJwtAlgorithms =
         [

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Discovery/DiscoveryEndpointTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Discovery/DiscoveryEndpointTests.cs
@@ -80,6 +80,28 @@ public class DiscoveryEndpointTests
     }
 
     [Fact]
+    public async Task Token_endpoint_authentication_algorithms_supported_should_match_configuration()
+    {
+        var pipeline = new IdentityServerPipeline();
+        pipeline.Initialize();
+        pipeline.Options.AllowedJwtAlgorithms =
+        [
+            SecurityAlgorithms.RsaSsaPssSha256,
+            SecurityAlgorithms.EcdsaSha256
+        ];
+
+        var disco = await pipeline.BackChannelClient
+            .GetDiscoveryDocumentAsync("https://server/.well-known/openid-configuration");
+        disco.IsError.ShouldBeFalse();
+
+        var algorithmsSupported = disco.TokenEndpointAuthenticationSigningAlgorithmsSupported;
+
+        algorithmsSupported.Count().ShouldBe(2);
+        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSsaPssSha256);
+        algorithmsSupported.ShouldContain(SecurityAlgorithms.EcdsaSha256);
+    }
+
+    [Fact]
     [Trait("Category", Category)]
     public async Task Jwks_entries_should_countain_crv()
     {

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Discovery/DiscoveryEndpointTests_dpop_signing_algs_supported.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Discovery/DiscoveryEndpointTests_dpop_signing_algs_supported.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using System.Text.Json;
+using Duende.IdentityModel;
+using Duende.IdentityModel.Client;
+using IntegrationTests.Common;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
+
+namespace IntegrationTests.Endpoints.Discovery;
+
+public class DiscoveryEndpointTests_dpop_signing_alg_values_supported
+{
+    private const string Category = "Discovery endpoint - dpop_signing_alg_values_supported";
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task dpop_signing_alg_values_supported_should_match_configuration()
+    {
+        var pipeline = new IdentityServerPipeline();
+        pipeline.Initialize();
+
+        var supportedAlgorithms = new List<string>
+        {
+            SecurityAlgorithms.RsaSha256,
+            SecurityAlgorithms.EcdsaSha256
+        };
+        pipeline.Options.DPoP.SupportedDPoPSigningAlgorithms = supportedAlgorithms;
+
+        var result =
+            await pipeline.BackChannelClient.GetDiscoveryDocumentAsync(
+                "https://server/.well-known/openid-configuration");
+
+        var supportedAlgorithmsFromResponse =
+            result.TryGetStringArray(OidcConstants.Discovery.DPoPSigningAlgorithmsSupported);
+        supportedAlgorithmsFromResponse.ShouldBe(supportedAlgorithms);
+    }
+
+    [Fact]
+    public async Task dpop_signing_alg_values_supported_should_default_to_rs_ps_es()
+    {
+        var pipeline = new IdentityServerPipeline();
+        pipeline.Initialize();
+
+        var result =
+            await pipeline.BackChannelClient.GetDiscoveryDocumentAsync(
+                "https://server/.well-known/openid-configuration");
+        var algorithmsSupported = result.TryGetStringArray("dpop_signing_alg_values_supported");
+
+        algorithmsSupported.Count().ShouldBe(9);
+        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSha256);
+        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSha384);
+        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSha512);
+        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSsaPssSha384);
+        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSsaPssSha512);
+        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSsaPssSha256);
+        algorithmsSupported.ShouldContain(SecurityAlgorithms.EcdsaSha256);
+        algorithmsSupported.ShouldContain(SecurityAlgorithms.EcdsaSha384);
+        algorithmsSupported.ShouldContain(SecurityAlgorithms.EcdsaSha512);
+    }
+
+    [Theory]
+    [MemberData(nameof(NullOrEmptySupportedAlgorithms))]
+    public async Task dpop_signing_alg_values_supported_should_not_be_present_if_option_is_null_or_empty(ICollection<string> algorithms)
+    {
+        var pipeline = new IdentityServerPipeline();
+        pipeline.OnPostConfigureServices += svcs =>
+            svcs.AddIdentityServerBuilder().AddJwtBearerClientAuthentication();
+        pipeline.Initialize();
+        pipeline.Options.DPoP.SupportedDPoPSigningAlgorithms = algorithms;
+
+        var result = await pipeline.BackChannelClient
+            .GetAsync("https://server/.well-known/openid-configuration");
+        var json = await result.Content.ReadAsStringAsync();
+        var data = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json);
+
+        data.ShouldNotContainKey(OidcConstants.Discovery.DPoPSigningAlgorithmsSupported);
+    }
+
+    public static IEnumerable<object[]> NullOrEmptySupportedAlgorithms() =>
+        new List<object[]>
+        {
+            new object[] { Enumerable.Empty<string>() },
+            new object[] { null }
+        };
+}

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Discovery/DiscoveryEndpointTests_token_endpoint_auth_signing_algs_supported.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Discovery/DiscoveryEndpointTests_token_endpoint_auth_signing_algs_supported.cs
@@ -1,0 +1,120 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using System.Text.Json;
+using Duende.IdentityModel;
+using Duende.IdentityModel.Client;
+using IntegrationTests.Common;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
+
+namespace IntegrationTests.Endpoints.Discovery;
+
+public class DiscoveryEndpointTests_token_endpoint_auth_signing_alg_values_supported
+{
+    private const string Category = "Discovery endpoint - token_endpoint_auth_signing_alg_values_supported";
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task token_endpoint_auth_signing_alg_values_supported_should_match_configuration()
+    {
+        var pipeline = new IdentityServerPipeline();
+        pipeline.OnPostConfigureServices += svcs =>
+            svcs.AddIdentityServerBuilder().AddJwtBearerClientAuthentication();
+        pipeline.Initialize();
+        pipeline.Options.SupportedClientAssertionSigningAlgorithms =
+        [
+            SecurityAlgorithms.RsaSsaPssSha256,
+            SecurityAlgorithms.EcdsaSha256
+        ];
+
+        var disco = await pipeline.BackChannelClient
+            .GetDiscoveryDocumentAsync("https://server/.well-known/openid-configuration");
+        disco.IsError.ShouldBeFalse();
+
+        var algorithmsSupported = disco.TokenEndpointAuthenticationSigningAlgorithmsSupported;
+
+        algorithmsSupported.Count().ShouldBe(2);
+        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSsaPssSha256);
+        algorithmsSupported.ShouldContain(SecurityAlgorithms.EcdsaSha256);
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task token_endpoint_auth_signing_alg_values_supported_should_default_to_rs_ps_es_hmac()
+    {
+        var pipeline = new IdentityServerPipeline();
+        pipeline.OnPostConfigureServices += svcs =>
+            svcs.AddIdentityServerBuilder().AddJwtBearerClientAuthentication();
+        pipeline.Initialize();
+
+        var result =
+            await pipeline.BackChannelClient.GetDiscoveryDocumentAsync(
+                "https://server/.well-known/openid-configuration");
+
+        result.IsError.ShouldBeFalse();
+        var algorithmsSupported = result.TokenEndpointAuthenticationSigningAlgorithmsSupported;
+
+        algorithmsSupported.Count().ShouldBe(12);
+        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSha256);
+        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSha384);
+        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSha512);
+        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSsaPssSha384);
+        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSsaPssSha512);
+        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSsaPssSha256);
+        algorithmsSupported.ShouldContain(SecurityAlgorithms.EcdsaSha256);
+        algorithmsSupported.ShouldContain(SecurityAlgorithms.EcdsaSha384);
+        algorithmsSupported.ShouldContain(SecurityAlgorithms.EcdsaSha512);
+        algorithmsSupported.ShouldContain(SecurityAlgorithms.HmacSha256);
+        algorithmsSupported.ShouldContain(SecurityAlgorithms.HmacSha384);
+        algorithmsSupported.ShouldContain(SecurityAlgorithms.HmacSha512);
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task token_endpoint_auth_signing_alg_values_supported_should_not_be_present_if_private_key_jwt_is_not_configured()
+    {
+        var pipeline = new IdentityServerPipeline();
+        pipeline.Initialize();
+        pipeline.Options.SupportedClientAssertionSigningAlgorithms = [SecurityAlgorithms.RsaSha256];
+
+        var disco = await pipeline.BackChannelClient
+            .GetDiscoveryDocumentAsync("https://server/.well-known/openid-configuration");
+
+        // Verify assumptions
+        disco.IsError.ShouldBeFalse();
+        disco.TokenEndpointAuthenticationMethodsSupported.ShouldNotContain("private_key_jwt");
+        // we don't even support client_secret_jwt, but per spec, if you DO, you must include the algs supported
+        disco.TokenEndpointAuthenticationMethodsSupported.ShouldNotContain("client_secret_jwt");
+
+        // Assert that we got no signing algs.
+        disco.TokenEndpointAuthenticationSigningAlgorithmsSupported.ShouldBeEmpty();
+    }
+
+    [Theory]
+    [MemberData(nameof(NullOrEmptySupportedAlgorithms))]
+    [Trait("Category", Category)]
+    public async Task token_endpoint_auth_signing_alg_values_supported_should_not_be_present_if_option_is_null_or_empty(
+        ICollection<string> algorithms)
+    {
+        var pipeline = new IdentityServerPipeline();
+        pipeline.OnPostConfigureServices += svcs =>
+            svcs.AddIdentityServerBuilder().AddJwtBearerClientAuthentication();
+        pipeline.Initialize();
+        pipeline.Options.SupportedClientAssertionSigningAlgorithms = algorithms;
+
+        var result = await pipeline.BackChannelClient
+            .GetAsync("https://server/.well-known/openid-configuration");
+        var json = await result.Content.ReadAsStringAsync();
+        var data = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json);
+
+        data.ShouldNotContainKey(OidcConstants.Discovery.TokenEndpointAuthSigningAlgorithmsSupported);
+    }
+
+    public static IEnumerable<object[]> NullOrEmptySupportedAlgorithms() =>
+        new List<object[]>
+        {
+            new object[] { Enumerable.Empty<string>() },
+            new object[] { null }
+        };
+}

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Discovery/DiscoveryEndpoint_request_object_auth_signing_algs_supported.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Discovery/DiscoveryEndpoint_request_object_auth_signing_algs_supported.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using System.Text.Json;
+using Duende.IdentityModel.Client;
+using IntegrationTests.Common;
+using Microsoft.IdentityModel.Tokens;
+
+namespace IntegrationTests.Endpoints.Discovery;
+
+public class DiscoveryEndpoint_request_object_auth_signing_algs_supported_Tests
+{
+    private const string Category = "Discovery endpoint - request_object_signing_algs_supported";
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task request_object_signing_alg_values_supported_should_match_configuration()
+    {
+        var pipeline = new IdentityServerPipeline();
+
+        pipeline.Initialize();
+        pipeline.Options.SupportedRequestObjectSigningAlgorithms =
+        [
+            SecurityAlgorithms.RsaSsaPssSha256,
+            SecurityAlgorithms.EcdsaSha256
+        ];
+
+        var result =
+            await pipeline.BackChannelClient.GetDiscoveryDocumentAsync(
+                "https://server/.well-known/openid-configuration");
+        var algorithmsSupported = result.TryGetStringArray("request_object_signing_alg_values_supported");
+
+        algorithmsSupported.Count().ShouldBe(2);
+        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSsaPssSha256);
+        algorithmsSupported.ShouldContain(SecurityAlgorithms.EcdsaSha256);
+    }
+
+    [Theory]
+    [MemberData(nameof(NullOrEmptySupportedAlgorithms))]
+    [Trait("Category", Category)]
+    public async Task request_object_signing_alg_values_supported_should_not_be_present_if_option_is_null_or_empty(
+        ICollection<string> algorithms)
+    {
+        var pipeline = new IdentityServerPipeline();
+        pipeline.Initialize();
+        pipeline.Options.SupportedRequestObjectSigningAlgorithms = algorithms;
+
+        var result = await pipeline.BackChannelClient
+            .GetAsync("https://server/.well-known/openid-configuration");
+        var json = await result.Content.ReadAsStringAsync();
+        var data = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json);
+
+        data.ShouldNotContainKey("request_object_signing_alg_values_supported");
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task request_object_signing_alg_values_supported_should_default_to_rs_ps_es_hmac()
+    {
+        var pipeline = new IdentityServerPipeline();
+        pipeline.Initialize();
+
+        var result =
+            await pipeline.BackChannelClient.GetDiscoveryDocumentAsync(
+                "https://server/.well-known/openid-configuration");
+        var algorithmsSupported = result.TryGetStringArray("request_object_signing_alg_values_supported");
+
+        algorithmsSupported.Count().ShouldBe(12);
+        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSha256);
+        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSha384);
+        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSha512);
+        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSsaPssSha384);
+        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSsaPssSha512);
+        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSsaPssSha256);
+        algorithmsSupported.ShouldContain(SecurityAlgorithms.EcdsaSha256);
+        algorithmsSupported.ShouldContain(SecurityAlgorithms.EcdsaSha384);
+        algorithmsSupported.ShouldContain(SecurityAlgorithms.EcdsaSha512);
+        algorithmsSupported.ShouldContain(SecurityAlgorithms.HmacSha256);
+        algorithmsSupported.ShouldContain(SecurityAlgorithms.HmacSha384);
+        algorithmsSupported.ShouldContain(SecurityAlgorithms.HmacSha512);
+    }
+
+    public static IEnumerable<object[]> NullOrEmptySupportedAlgorithms() =>
+        new List<object[]>
+        {
+            new object[] { Enumerable.Empty<string>() },
+            new object[] { null }
+        };
+}

--- a/identity-server/test/IdentityServer.UnitTests/Validation/AccessTokenValidation.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Validation/AccessTokenValidation.cs
@@ -269,19 +269,19 @@ public class AccessTokenValidation
 
     [Fact]
     [Trait("Category", Category)]
-    public async Task Jwt_created_with_signing_algorithm_not_allowed_by_identity_server_settings_is_considered_invalid()
+    public async Task Unrelated_supported_signing_algorithm_options_are_not_enforced()
     {
         var signer = Factory.CreateDefaultTokenCreator();
         var token = TokenFactory.CreateAccessToken(new Client { ClientId = "roclient" }, "valid", 600, "read", "write");
         var jwt = await signer.CreateTokenAsync(token);
 
         var options = TestIdentityServerOptions.Create();
-        options.AllowedJwtAlgorithms = ["Test"];
+        options.SupportedRequestObjectSigningAlgorithms = ["Test"];
+        options.SupportedClientAssertionSigningAlgorithms = ["Test"];
         var validator = Factory.CreateTokenValidator(options: options);
         var result = await validator.ValidateAccessTokenAsync(jwt);
 
-        result.IsError.ShouldBeTrue();
-        result.Error.ShouldBe(OidcConstants.ProtectedResourceErrors.InvalidToken);
+        result.IsError.ShouldBeFalse();
     }
 
     [Fact]

--- a/identity-server/test/IdentityServer.UnitTests/Validation/Secrets/PrivateKeyJwtSecretValidation.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Validation/Secrets/PrivateKeyJwtSecretValidation.cs
@@ -473,7 +473,7 @@ public class PrivateKeyJwtSecretValidation
             Type = IdentityServerConstants.ParsedSecretTypes.JwtBearer
         };
 
-        _options.AllowedJwtAlgorithms = ["Test"];
+        _options.SupportedClientAssertionSigningAlgorithms = ["Test"];
 
         var result = await _validator.ValidateAsync(client.ClientSecrets, secret);
 


### PR DESCRIPTION
- Removed AllowedJwtAlgorithms
- Added SupportedClientAssertionSigningAlgorithms, which controls allowed algs for private_key_jwt
- Added SupportedRequestObjectSigningAlgorithms, which controls allowed algs for JAR
- No alg validation is now done in TokenValidator, instead we rely on the fact that we are validating tokens signed by IdentityServer, and that its signing keys (and their algorithms) are configurable.