### PR TITLE
Client Info Diagnostic Entry

### DIFF
--- a/identity-server/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/identity-server/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -215,6 +215,7 @@ public static class IdentityServerBuilderExtensionsCore
         builder.Services.AddSingleton<IDiagnosticEntry, AssemblyInfoDiagnosticEntry>();
         builder.Services.AddSingleton<IDiagnosticEntry, AuthSchemeInfoDiagnosticEntry>();
         builder.Services.AddSingleton<IDiagnosticEntry, RegisteredImplementationsDiagnosticEntry>();
+        builder.Services.AddSingleton<IDiagnosticEntry, IdentityServerOptionsDiagnosticEntry>();
         builder.Services.AddSingleton<DiagnosticSummary>();
         builder.Services.AddHostedService<DiagnosticHostedService>();
 

--- a/identity-server/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/identity-server/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -214,6 +214,7 @@ public static class IdentityServerBuilderExtensionsCore
 
         builder.Services.AddSingleton<IDiagnosticEntry, AssemblyInfoDiagnosticEntry>();
         builder.Services.AddSingleton<IDiagnosticEntry, AuthSchemeInfoDiagnosticEntry>();
+        builder.Services.AddSingleton<IDiagnosticEntry, RegisteredImplementationsDiagnosticEntry>();
         builder.Services.AddSingleton<DiagnosticSummary>();
         builder.Services.AddHostedService<DiagnosticHostedService>();
 

--- a/identity-server/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/identity-server/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -216,6 +216,7 @@ public static class IdentityServerBuilderExtensionsCore
         builder.Services.AddSingleton<IDiagnosticEntry, AuthSchemeInfoDiagnosticEntry>();
         builder.Services.AddSingleton<IDiagnosticEntry, RegisteredImplementationsDiagnosticEntry>();
         builder.Services.AddSingleton<IDiagnosticEntry, IdentityServerOptionsDiagnosticEntry>();
+        builder.Services.AddSingleton<IDiagnosticEntry, DataProtectionDiagnosticEntry>();
         builder.Services.AddSingleton<DiagnosticSummary>();
         builder.Services.AddHostedService<DiagnosticHostedService>();
 

--- a/identity-server/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/identity-server/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -217,6 +217,7 @@ public static class IdentityServerBuilderExtensionsCore
         builder.Services.AddSingleton<IDiagnosticEntry, RegisteredImplementationsDiagnosticEntry>();
         builder.Services.AddSingleton<IDiagnosticEntry, IdentityServerOptionsDiagnosticEntry>();
         builder.Services.AddSingleton<IDiagnosticEntry, DataProtectionDiagnosticEntry>();
+        builder.Services.AddSingleton<IDiagnosticEntry, TokenIssueCountDiagnosticEntry>();
         builder.Services.AddSingleton<DiagnosticSummary>();
         builder.Services.AddHostedService<DiagnosticHostedService>();
 

--- a/identity-server/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/identity-server/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -213,6 +213,7 @@ public static class IdentityServerBuilderExtensionsCore
         builder.Services.AddSingleton<LicenseExpirationChecker>();
 
         builder.Services.AddSingleton<IDiagnosticEntry, AssemblyInfoDiagnosticEntry>();
+        builder.Services.AddSingleton<IDiagnosticEntry, AuthSchemeInfoDiagnosticEntry>();
         builder.Services.AddSingleton<DiagnosticSummary>();
         builder.Services.AddHostedService<DiagnosticHostedService>();
 

--- a/identity-server/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/identity-server/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -218,6 +218,7 @@ public static class IdentityServerBuilderExtensionsCore
         builder.Services.AddSingleton<IDiagnosticEntry, IdentityServerOptionsDiagnosticEntry>();
         builder.Services.AddSingleton<IDiagnosticEntry, DataProtectionDiagnosticEntry>();
         builder.Services.AddSingleton<IDiagnosticEntry, TokenIssueCountDiagnosticEntry>();
+        builder.Services.AddSingleton<IDiagnosticEntry, ClientInfoDiagnosticEntry>();
         builder.Services.AddSingleton<DiagnosticSummary>();
         builder.Services.AddHostedService<DiagnosticHostedService>();
 

--- a/identity-server/src/IdentityServer/Endpoints/AuthorizeEndpointBase.cs
+++ b/identity-server/src/IdentityServer/Endpoints/AuthorizeEndpointBase.cs
@@ -241,7 +241,7 @@ internal abstract class AuthorizeEndpointBase : IEndpointHandler
                 response.Request.GrantType,
                 response.Request.AuthorizeRequestType,
                 response.AccessToken.IsPresent(),
-                response.Request.AccessTokenType,
+                response.AccessToken.IsPresent() ? response.Request.AccessTokenType : null,
                 false,
                 ProofType.None,
                 response.IdentityToken.IsPresent());

--- a/identity-server/src/IdentityServer/Endpoints/AuthorizeEndpointBase.cs
+++ b/identity-server/src/IdentityServer/Endpoints/AuthorizeEndpointBase.cs
@@ -239,7 +239,12 @@ internal abstract class AuthorizeEndpointBase : IEndpointHandler
             Telemetry.Metrics.TokenIssued(
                 response.Request.ClientId,
                 response.Request.GrantType,
-                response.Request.AuthorizeRequestType);
+                response.Request.AuthorizeRequestType,
+                response.AccessToken.IsPresent(),
+                response.Request.AccessTokenType,
+                false,
+                ProofType.None,
+                response.IdentityToken.IsPresent());
             return _events.RaiseAsync(new TokenIssuedSuccessEvent(response));
         }
 

--- a/identity-server/src/IdentityServer/Endpoints/TokenEndpoint.cs
+++ b/identity-server/src/IdentityServer/Endpoints/TokenEndpoint.cs
@@ -139,7 +139,10 @@ internal class TokenEndpoint : IEndpointHandler
         var response = await _responseGenerator.ProcessAsync(requestResult);
 
         await _events.RaiseAsync(new TokenIssuedSuccessEvent(response, requestResult));
-        Telemetry.Metrics.TokenIssued(clientResult.Client.ClientId, requestResult.ValidatedRequest.GrantType, null);
+
+        Telemetry.Metrics.TokenIssued(clientResult.Client.ClientId, requestResult.ValidatedRequest.GrantType, null,
+            response.AccessToken.IsPresent(), requestResult.ValidatedRequest.AccessTokenType, response.RefreshToken.IsPresent(),
+            requestResult.ValidatedRequest.ProofType, response.IdentityToken.IsPresent());
         LogTokens(response, requestResult);
 
         // return result

--- a/identity-server/src/IdentityServer/Endpoints/TokenEndpoint.cs
+++ b/identity-server/src/IdentityServer/Endpoints/TokenEndpoint.cs
@@ -141,7 +141,7 @@ internal class TokenEndpoint : IEndpointHandler
         await _events.RaiseAsync(new TokenIssuedSuccessEvent(response, requestResult));
 
         Telemetry.Metrics.TokenIssued(clientResult.Client.ClientId, requestResult.ValidatedRequest.GrantType, null,
-            response.AccessToken.IsPresent(), requestResult.ValidatedRequest.AccessTokenType, response.RefreshToken.IsPresent(),
+            response.AccessToken.IsPresent(), response.AccessTokenType.IsPresent() ? requestResult.ValidatedRequest.AccessTokenType : null, response.RefreshToken.IsPresent(),
             requestResult.ValidatedRequest.ProofType, response.IdentityToken.IsPresent());
         LogTokens(response, requestResult);
 

--- a/identity-server/src/IdentityServer/Extensions/IClientStoreExtensions.cs
+++ b/identity-server/src/IdentityServer/Extensions/IClientStoreExtensions.cs
@@ -22,6 +22,7 @@ public static class IClientStoreExtensions
         var client = await store.FindClientByIdAsync(clientId);
         if (client != null && client.Enabled)
         {
+            //Telemetry.Metrics.ClientLoaded(client);
             return client;
         }
 

--- a/identity-server/src/IdentityServer/Extensions/IClientStoreExtensions.cs
+++ b/identity-server/src/IdentityServer/Extensions/IClientStoreExtensions.cs
@@ -22,7 +22,7 @@ public static class IClientStoreExtensions
         var client = await store.FindClientByIdAsync(clientId);
         if (client != null && client.Enabled)
         {
-            //Telemetry.Metrics.ClientLoaded(client);
+            Telemetry.Metrics.ClientLoaded(clientId);
             return client;
         }
 

--- a/identity-server/src/IdentityServer/Infrastructure/RemovePropertyModifier.cs
+++ b/identity-server/src/IdentityServer/Infrastructure/RemovePropertyModifier.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using System.Text.Json.Serialization.Metadata;
+
+namespace Duende.IdentityServer.Infrastructure;
+
+public class RemovePropertyModifier<T>(List<string> propertiesToRemove)
+{
+    public void ModifyTypeInfo(JsonTypeInfo typeInfo)
+    {
+        if (typeInfo.Type != typeof(T))
+        {
+            return;
+        }
+
+        var propsToKeep = typeInfo.Properties.Where(propertyInfo => !propertiesToRemove.Contains(propertyInfo.Name)).ToArray();
+
+        typeInfo.Properties.Clear();
+        foreach (var prop in propsToKeep)
+        {
+            typeInfo.Properties.Add(prop);
+        }
+    }
+}

--- a/identity-server/src/IdentityServer/Licensing/V2/AtomicCounter.cs
+++ b/identity-server/src/IdentityServer/Licensing/V2/AtomicCounter.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+namespace Duende.IdentityServer.Licensing.V2;
+
+internal class AtomicCounter
+{
+    private long _count;
+    public void Increment() => Interlocked.Increment(ref _count);
+    public long Count => _count;
+}

--- a/identity-server/src/IdentityServer/Licensing/V2/AtomicCounter.cs
+++ b/identity-server/src/IdentityServer/Licensing/V2/AtomicCounter.cs
@@ -3,9 +3,11 @@
 
 namespace Duende.IdentityServer.Licensing.V2;
 
-internal class AtomicCounter
+internal class AtomicCounter(int initialCount = 0)
 {
-    private long _count;
+    private long _count = initialCount;
+
     public void Increment() => Interlocked.Increment(ref _count);
+
     public long Count => _count;
 }

--- a/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/AuthSchemeInfoDiagnosticEntry.cs
+++ b/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/AuthSchemeInfoDiagnosticEntry.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using System.Text.Json;
+using Microsoft.AspNetCore.Authentication;
+
+namespace Duende.IdentityServer.Licensing.V2.Diagnostics.DiagnosticEntries;
+
+internal class AuthSchemeInfoDiagnosticEntry(IAuthenticationSchemeProvider authenticationSchemeProvider) : IDiagnosticEntry
+{
+    public async Task WriteAsync(Utf8JsonWriter writer)
+    {
+        var schemes = await authenticationSchemeProvider.GetAllSchemesAsync();
+
+        writer.WriteStartObject("AuthSchemeInfo");
+        writer.WriteStartArray("Schemes");
+        foreach (var scheme in schemes)
+        {
+            writer.WriteStartObject();
+            writer.WriteString(scheme.Name, scheme.HandlerType.FullName ?? "Unknown");
+            writer.WriteEndObject();
+        }
+        writer.WriteEndArray();
+        writer.WriteEndObject();
+    }
+}

--- a/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/ClientInfoDiagnosticEntry.cs
+++ b/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/ClientInfoDiagnosticEntry.cs
@@ -1,0 +1,115 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+#nullable enable
+using System.Collections.Concurrent;
+using System.Diagnostics.Metrics;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using Duende.IdentityServer.Infrastructure;
+using Duende.IdentityServer.Models;
+using Duende.IdentityServer.Stores;
+using Microsoft.Extensions.Logging;
+
+namespace Duende.IdentityServer.Licensing.V2.Diagnostics.DiagnosticEntries;
+
+internal class ClientInfoDiagnosticEntry : IDiagnosticEntry
+{
+    private static readonly RemovePropertyModifier<Client> RemoveSecretsModifier = new(
+    [
+        nameof(Client.ClientSecrets)
+    ]);
+    private readonly JsonSerializerOptions _serializerOptions = new()
+    {
+        TypeInfoResolver = new DefaultJsonTypeInfoResolver
+        {
+            Modifiers = { RemoveSecretsModifier.ModifyTypeInfo }
+        },
+        WriteIndented = false
+    };
+
+    private readonly IClientStore _clientStore;
+    private readonly ILogger<ClientInfoDiagnosticEntry> _logger;
+    private readonly ConcurrentDictionary<string, Client> _clients = new();
+    private readonly MeterListener _meterListener;
+
+    public ClientInfoDiagnosticEntry(IClientStore clientStore, ILogger<ClientInfoDiagnosticEntry> logger)
+    {
+        _clientStore = clientStore;
+        _logger = logger;
+        _meterListener = new MeterListener();
+
+        _meterListener.InstrumentPublished += (instrument, listener) =>
+        {
+            if (instrument.Name == Telemetry.Metrics.Counters.ClientLoaded)
+            {
+                listener.EnableMeasurementEvents(instrument);
+            }
+        };
+
+        _meterListener.SetMeasurementEventCallback<long>(HandleClientMeasurementRecorded);
+
+        _meterListener.Start();
+    }
+
+    public Task WriteAsync(Utf8JsonWriter writer)
+    {
+        writer.WriteStartObject("Clients");
+
+        foreach (var (clientId, client) in _clients)
+        {
+            writer.WritePropertyName(clientId);
+            JsonSerializer.Serialize(writer, client, _serializerOptions);
+        }
+
+        writer.WriteEndObject();
+
+        return Task.CompletedTask;
+    }
+
+    private void HandleClientMeasurementRecorded(Instrument instrument, long measurement, ReadOnlySpan<KeyValuePair<string, object?>> tags, object? state)
+    {
+        if (instrument.Name != Telemetry.Metrics.Counters.ClientLoaded)
+        {
+            return;
+        }
+
+        string? clientId = null;
+        foreach (var tag in tags)
+        {
+            if (tag is { Key: Telemetry.Metrics.Tags.Client, Value: string id })
+            {
+                clientId = id;
+            }
+        }
+
+        if (clientId != null && !_clients.ContainsKey(clientId))
+        {
+            _ = LoadClientAsync(clientId);
+        }
+    }
+
+    private async Task LoadClientAsync(string clientId)
+    {
+        try
+        {
+            if (_clients.ContainsKey(clientId))
+            {
+                return;
+            }
+
+            //It's important to use FindClientByIdAsync here since we are responding to a measurement event
+            //which is triggered by the use of FindEnabledClientByIdAsync. We also do not care if the client
+            //is enabled or not at this point. If it was loaded, we want to see it in the diagnostics.
+            var client = await _clientStore.FindClientByIdAsync(clientId);
+            if (client != null)
+            {
+                _clients.TryAdd(clientId, client);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error adding client {ClientId} to diagnostics", clientId);
+        }
+    }
+}

--- a/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/DataProtectionDiagnosticEntry.cs
+++ b/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/DataProtectionDiagnosticEntry.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using System.Text.Json;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.DataProtection.KeyManagement;
+using Microsoft.Extensions.Options;
+
+namespace Duende.IdentityServer.Licensing.V2.Diagnostics.DiagnosticEntries;
+
+internal class DataProtectionDiagnosticEntry(IOptions<DataProtectionOptions> dataProtectionOptions, IOptions<KeyManagementOptions> keyManagementOptions) : IDiagnosticEntry
+{
+    public Task WriteAsync(Utf8JsonWriter writer)
+    {
+        writer.WriteStartObject("DataProtectionConfiguration");
+        writer.WriteString("ApplicationDiscriminator", dataProtectionOptions?.Value?.ApplicationDiscriminator ?? "Not Configured");
+        writer.WriteString("XmlEncryptor", keyManagementOptions?.Value.XmlEncryptor?.GetType().FullName ?? "Not Configured");
+        writer.WriteString("XmlRepository", keyManagementOptions?.Value.XmlRepository?.GetType().FullName ?? "Not Configured");
+        writer.WriteEndObject();
+
+        return Task.CompletedTask;
+    }
+}

--- a/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/IdentityServerOptionsDiagnosticEntry.cs
+++ b/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/IdentityServerOptionsDiagnosticEntry.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using Duende.IdentityServer.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Duende.IdentityServer.Licensing.V2.Diagnostics.DiagnosticEntries;
+
+internal class IdentityServerOptionsDiagnosticEntry(IOptions<IdentityServerOptions> options) : IDiagnosticEntry
+{
+    private readonly JsonSerializerOptions _serializerOptions = new()
+    {
+        TypeInfoResolver = new DefaultJsonTypeInfoResolver
+        {
+            Modifiers = { RemoveLicenseKeyModifier }
+        },
+        WriteIndented = false
+    };
+
+    public Task WriteAsync(Utf8JsonWriter writer)
+    {
+        writer.WritePropertyName("IdentityServerOptions");
+
+        JsonSerializer.Serialize(writer, options.Value, _serializerOptions);
+
+        return Task.CompletedTask;
+    }
+
+    private static void RemoveLicenseKeyModifier(JsonTypeInfo typeInfo)
+    {
+        if (typeInfo.Type != typeof(IdentityServerOptions))
+        {
+            return;
+        }
+
+        var propsToKeep = typeInfo.Properties
+            .Where(prop => prop.Name != nameof(IdentityServerOptions.LicenseKey))
+            .ToArray();
+
+        typeInfo.Properties.Clear();
+        foreach (var prop in propsToKeep)
+        {
+            typeInfo.Properties.Add(prop);
+        }
+    }
+}

--- a/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/RegisteredImplementationsDiagnosticEntry.cs
+++ b/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/RegisteredImplementationsDiagnosticEntry.cs
@@ -1,0 +1,107 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using System.Text.Json;
+using Duende.IdentityServer.Services;
+using Duende.IdentityServer.Stores;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Duende.IdentityServer.Licensing.V2.Diagnostics.DiagnosticEntries;
+
+internal class RegisteredImplementationsDiagnosticEntry(IServiceProvider serviceProvider) : IDiagnosticEntry
+{
+    public Task WriteAsync(Utf8JsonWriter writer)
+    {
+        using var scope = serviceProvider.CreateScope();
+
+        writer.WriteStartObject("RegisteredServices");
+
+        writer.WriteStartArray("Services");
+
+        //services
+        InspectService<IBackchannelAuthenticationInteractionService>(nameof(IBackchannelAuthenticationInteractionService), writer, scope);
+        InspectService<IBackchannelAuthenticationThrottlingService>(nameof(IBackchannelAuthenticationThrottlingService), writer, scope);
+        InspectService<IBackchannelAuthenticationUserNotificationService>(nameof(IBackchannelAuthenticationUserNotificationService), writer, scope);
+        InspectService<IBackChannelLogoutService>(nameof(IBackChannelLogoutService), writer, scope);
+        InspectService(typeof(ICache<>), "ICache", writer, scope); //TODO: replace with nameof operator when C# 14 is available with support for nameof operator on open generic types
+        InspectService<IClaimsService>(nameof(IClaimsService), writer, scope);
+        InspectService<IConsentService>(nameof(IConsentService), writer, scope);
+        InspectService<IDeviceFlowCodeService>(nameof(IDeviceFlowCodeService), writer, scope);
+        InspectService<IDeviceFlowInteractionService>(nameof(IDeviceFlowCodeService), writer, scope);
+        InspectService<IDeviceFlowThrottlingService>(nameof(IDeviceFlowThrottlingService), writer, scope);
+        InspectService<IEventService>(nameof(IEventService), writer, scope);
+        InspectService<IEventSink>(nameof(IEventSink), writer, scope);
+        InspectService<IHandleGenerationService>(nameof(IHandleGenerationService), writer, scope);
+        InspectService<IIdentityServerInteractionService>(nameof(IIdentityServerInteractionService), writer, scope);
+        InspectService<IIssuerNameService>(nameof(IIssuerNameService), writer, scope);
+        InspectService<IKeyMaterialService>(nameof(IKeyMaterialService), writer, scope);
+        InspectService<ILogoutNotificationService>(nameof(ILogoutNotificationService), writer, scope);
+        InspectService<IPersistedGrantService>(nameof(IPersistedGrantService), writer, scope);
+        InspectService<IProfileService>(nameof(IProfileService), writer, scope);
+        InspectService<IPushedAuthorizationSerializer>(nameof(IPushedAuthorizationSerializer), writer, scope);
+        InspectService<IPushedAuthorizationService>(nameof(IPushedAuthorizationService), writer, scope);
+        InspectService<IRefreshTokenService>(nameof(IRefreshTokenService), writer, scope);
+        InspectService<IReplayCache>(nameof(IReplayCache), writer, scope);
+        InspectService<IReturnUrlParser>(nameof(IReturnUrlParser), writer, scope);
+        InspectService<IServerUrls>(nameof(IServerUrls), writer, scope);
+        InspectService<ISessionCoordinationService>(nameof(ISessionCoordinationService), writer, scope);
+        InspectService<ISessionManagementService>(nameof(ISessionManagementService), writer, scope);
+        InspectService<ITokenCreationService>(nameof(ITokenCreationService), writer, scope);
+        InspectService<ITokenService>(nameof(ITokenService), writer, scope);
+        InspectService<IUserCodeGenerator>(nameof(IUserCodeGenerator), writer, scope);
+        InspectService<IUserCodeService>(nameof(IUserCodeService), writer, scope);
+        InspectService<IUserSession>(nameof(IUserSession), writer, scope);
+
+        //stores
+        InspectService<IAuthorizationCodeStore>(nameof(IAuthorizationCodeStore), writer, scope);
+        InspectService<IAuthorizationParametersMessageStore>(nameof(IAuthorizationParametersMessageStore), writer, scope);
+        InspectService<IClientStore>(nameof(IClientStore), writer, scope);
+        InspectService<IConsentMessageStore>(nameof(IConsentMessageStore), writer, scope);
+        InspectService<IDeviceFlowStore>(nameof(IDeviceFlowStore), writer, scope);
+        InspectService<IIdentityProviderStore>(nameof(IIdentityProviderStore), writer, scope);
+        InspectService(typeof(IMessageStore<>), "IMessageStore", writer, scope); //TODO: replace with nameof operator when C# 14 is available with support for nameof operator on open generic types
+        InspectService<IPersistedGrantStore>(nameof(IPersistedGrantStore), writer, scope);
+        InspectService<IPushedAuthorizationRequestStore>(nameof(IPushedAuthorizationRequestStore), writer, scope);
+        InspectService<IReferenceTokenStore>(nameof(IReferenceTokenStore), writer, scope);
+        InspectService<IResourceStore>(nameof(IResourceStore), writer, scope);
+        InspectService<IServerSideSessionsMarker>(nameof(IServerSideSessionsMarker), writer, scope);
+        InspectService<IServerSideSessionStore>(nameof(IServerSideSessionStore), writer, scope);
+        InspectService<IServerSideTicketStore>(nameof(IServerSideTicketStore), writer, scope);
+        InspectService<ISigningCredentialStore>(nameof(ISigningCredentialStore), writer, scope);
+        InspectService<ISigningKeyStore>(nameof(ISigningKeyStore), writer, scope);
+        InspectService<IUserConsentStore>(nameof(IUserConsentStore), writer, scope);
+        InspectService<IValidationKeysStore>(nameof(IValidationKeysStore), writer, scope);
+
+        writer.WriteEndArray();
+
+        writer.WriteEndObject();
+
+        return Task.CompletedTask;
+    }
+
+    private void InspectService<T>(string serviceName, Utf8JsonWriter writer, IServiceScope scope) where T : class => InspectService(typeof(T), serviceName, writer, scope);
+
+    private void InspectService(Type targetType, string serviceName, Utf8JsonWriter writer, IServiceScope scope)
+    {
+        writer.WriteStartObject();
+
+        writer.WriteStartObject(serviceName);
+        var service = scope.ServiceProvider.GetService(targetType);
+        if (service != null)
+        {
+            var type = service.GetType();
+            writer.WriteString("TypeName", type.FullName);
+            writer.WriteString("Assembly", type.Assembly.GetName().Name);
+            writer.WriteString("AssemblyVersion", type.Assembly.GetName().Version?.ToString());
+        }
+        else
+        {
+            writer.WriteString("TypeName", "Not Registered");
+            writer.WriteString("Assembly", "Not Registered");
+            writer.WriteString("AssemblyVersion", "Not Registered");
+        }
+
+        writer.WriteEndObject();
+        writer.WriteEndObject();
+    }
+}

--- a/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/TokenIssueCountDiagnosticEntry.cs
+++ b/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/TokenIssueCountDiagnosticEntry.cs
@@ -1,0 +1,135 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+#nullable enable
+using System.Collections.Concurrent;
+using System.Diagnostics.Metrics;
+using System.Text.Json;
+using Duende.IdentityServer.Models;
+
+namespace Duende.IdentityServer.Licensing.V2.Diagnostics.DiagnosticEntries;
+
+internal class TokenIssueCountDiagnosticEntry : IDiagnosticEntry
+{
+    private readonly ConcurrentDictionary<string, AtomicCounter> _tokenCounts;
+    private readonly MeterListener _meterListener;
+
+    public TokenIssueCountDiagnosticEntry()
+    {
+        _tokenCounts = new ConcurrentDictionary<string, AtomicCounter>([
+            new("Jwt", new AtomicCounter()),
+            new ("Reference", new AtomicCounter()),
+            new ("Refresh", new AtomicCounter()),
+            new("JwtPoPDPoP", new AtomicCounter()),
+            new("ReferencePoPDPoP", new AtomicCounter()),
+            new("JwtPoPmTLS", new AtomicCounter()),
+            new("ReferencePoPmTLS", new AtomicCounter()),
+            new("Id", new AtomicCounter())
+        ]);
+        _meterListener = new MeterListener();
+
+        _meterListener.InstrumentPublished += (instrument, listener) =>
+        {
+            if (instrument.Name == Telemetry.Metrics.Counters.TokenIssued)
+            {
+                listener.EnableMeasurementEvents(instrument);
+            }
+        };
+
+        _meterListener.SetMeasurementEventCallback<long>(HandleLongMeasurementRecorded);
+
+        _meterListener.Start();
+    }
+
+    public Task WriteAsync(Utf8JsonWriter writer)
+    {
+        writer.WritePropertyName("TokenIssueCounts");
+        writer.WriteStartObject();
+
+        foreach (var (tokenType, counter) in _tokenCounts)
+        {
+            writer.WriteNumber(tokenType, counter.Count);
+        }
+
+        writer.WriteEndObject();
+
+        return Task.CompletedTask;
+    }
+
+    private void HandleLongMeasurementRecorded(Instrument instrument, long value, ReadOnlySpan<KeyValuePair<string, object?>> tags, object? state)
+    {
+        if (instrument.Name != Telemetry.Metrics.Counters.TokenIssued)
+        {
+            return;
+        }
+
+        var accessTokenIssued = false;
+        var accessTokenType = AccessTokenType.Jwt;
+        var refreshTokenIssued = false;
+        var proofType = ProofType.None;
+        var identityTokenIssued = false;
+
+        foreach (var tag in tags)
+        {
+            switch (tag.Key)
+            {
+                case Telemetry.Metrics.Tags.AccessTokenType:
+                    if (!Enum.TryParse(tag.Value?.ToString(), out accessTokenType))
+                    {
+                        accessTokenType = AccessTokenType.Jwt;
+                    }
+                    break;
+                case Telemetry.Metrics.Tags.RefreshTokenIssued:
+                    bool.TryParse(tag.Value?.ToString(), out refreshTokenIssued);
+                    break;
+                case Telemetry.Metrics.Tags.ProofType:
+                    if (!Enum.TryParse(tag.Value?.ToString(), out proofType))
+                    {
+                        proofType = ProofType.None;
+                    }
+                    break;
+                case Telemetry.Metrics.Tags.AccessTokenIssued:
+                    bool.TryParse(tag.Value?.ToString(), out accessTokenIssued);
+                    break;
+                case Telemetry.Metrics.Tags.IdTokenIssued:
+                    bool.TryParse(tag.Value?.ToString(), out identityTokenIssued);
+                    break;
+            }
+        }
+
+        if (accessTokenIssued)
+        {
+            switch (proofType)
+            {
+                case ProofType.None when accessTokenType == AccessTokenType.Jwt:
+                    _tokenCounts["Jwt"].Increment();
+                    break;
+                case ProofType.None when accessTokenType == AccessTokenType.Reference:
+                    _tokenCounts["Reference"].Increment();
+                    break;
+                case ProofType.DPoP when accessTokenType == AccessTokenType.Jwt:
+                    _tokenCounts["JwtPoPDPoP"].Increment();
+                    break;
+                case ProofType.DPoP when accessTokenType == AccessTokenType.Reference:
+                    _tokenCounts["ReferencePoPDPoP"].Increment();
+                    break;
+                case ProofType.ClientCertificate when accessTokenType == AccessTokenType.Jwt:
+                    _tokenCounts["JwtPoPmTLS"].Increment();
+                    break;
+                case ProofType.ClientCertificate when accessTokenType == AccessTokenType.Reference:
+                    _tokenCounts["ReferencePoPmTLS"].Increment();
+                    break;
+            }
+        }
+
+        if (refreshTokenIssued)
+        {
+            _tokenCounts["Refresh"].Increment();
+        }
+
+        if (identityTokenIssued)
+        {
+            _tokenCounts["Id"].Increment();
+        }
+    }
+}

--- a/identity-server/src/Telemetry/Telemetry.cs
+++ b/identity-server/src/Telemetry/Telemetry.cs
@@ -466,12 +466,12 @@ public static class Telemetry
         /// <param name="grantType">Grant Type</param>
         /// <param name="requestType">Type of authorization request</param>
         /// <param name="accessTokenIssued">Whether an access token was issued</param>
-        /// <param name="accessTokenType">The type of access token issued (JWT or Reference)</param>
+        /// <param name="accessTokenType">The type of access token issued (Null if no access token was issued, otherwise JWT or Reference)</param>
         /// <param name="refreshTokenIssued">Whether a refresh token was issued</param>
         /// <param name="proofType">The proof type used (None, ClientCertificate, or DPoP)</param>
         /// <param name="idTokenIssued">Whether an id token was issued</param>
         public static void TokenIssued(string clientId, string grantType, AuthorizeRequestType? requestType,
-            bool accessTokenIssued, AccessTokenType accessTokenType, bool refreshTokenIssued, ProofType proofType, bool idTokenIssued)
+            bool accessTokenIssued, AccessTokenType? accessTokenType, bool refreshTokenIssued, ProofType proofType, bool idTokenIssued)
         {
             Success(clientId);
             TokenIssuedCounter.Add(1,

--- a/identity-server/src/Telemetry/Telemetry.cs
+++ b/identity-server/src/Telemetry/Telemetry.cs
@@ -37,6 +37,7 @@ public static class Telemetry
             public const string ApiSecretValidation = "tokenservice.api.secret_validation";
             public const string BackchannelAuthentication = "tokenservice.backchannel_authentication";
             public const string ClientConfigValidation = "tokenservice.client.config_validation";
+            public const string ClientLoaded = "tokenservice.client.loaded";
             public const string ClientSecretValidation = "tokenservice.client.secret_validation";
             public const string DeviceAuthentication = "tokenservice.device_authentication";
             public const string DynamicIdentityProviderValidation = "tokenservice.dynamic_identityprovider.validation";
@@ -231,6 +232,22 @@ public static class Telemetry
         {
             Success(clientId);
             ClientValidationCounter.Add(1, tag: new(Tags.Client, clientId));
+        }
+
+        /// <summary>
+        /// Client loaded counter
+        /// </summary>
+        public static Counter<long> ClientLoadedCounter =
+            Meter.CreateCounter<long>(Counters.ClientLoaded);
+
+        /// <summary>
+        /// Helper method to increase <see cref="ClientLoadedCounter"/>
+        /// </summary>
+        /// <param name="clientId">Id of the client which was successfully loaded</param>
+        public static void ClientLoaded(string clientId)
+        {
+            Success(clientId);
+            ClientLoadedCounter.Add(1, tag: new(Tags.Client, clientId));
         }
 
         /// <summary>

--- a/identity-server/src/Telemetry/Telemetry.cs
+++ b/identity-server/src/Telemetry/Telemetry.cs
@@ -442,6 +442,23 @@ public static class Telemetry
         public static readonly Counter<long> TokenIssuedCounter =
             Meter.CreateCounter<long>(Counters.TokenIssued);
 
+
+        /// <summary>
+        /// Helper method to increase <see cref="TokenIssuedCounter"/>
+        /// </summary>
+        /// <param name="clientId">Client Id</param>
+        /// <param name="grantType">Grant Type</param>
+        /// <param name="requestType">Type of authorization request</param>
+        [Obsolete("This overload will be removed in a future version. Use the overload with accessTokenIssued, accessTokenType, refreshTokenIssued, proofType, and idTokenIssued parameters instead.")]
+        public static void TokenIssued(string clientId, string grantType, AuthorizeRequestType? requestType)
+        {
+            Success(clientId);
+            TokenIssuedCounter.Add(1,
+                new(Tags.Client, clientId),
+                new(Tags.GrantType, grantType),
+                new(Tags.AuthorizeRequestType, requestType));
+        }
+
         /// <summary>
         /// Helper method to increase <see cref="TokenIssuedCounter"/>
         /// </summary>
@@ -449,9 +466,9 @@ public static class Telemetry
         /// <param name="grantType">Grant Type</param>
         /// <param name="requestType">Type of authorization request</param>
         /// <param name="accessTokenIssued">Whether an access token was issued</param>
-        /// <param name="accessTokenType">The type of access token issued</param>
+        /// <param name="accessTokenType">The type of access token issued (JWT or Reference)</param>
         /// <param name="refreshTokenIssued">Whether a refresh token was issued</param>
-        /// <param name="proofType">The proof type used</param>
+        /// <param name="proofType">The proof type used (None, ClientCertificate, or DPoP)</param>
         /// <param name="idTokenIssued">Whether an id token was issued</param>
         public static void TokenIssued(string clientId, string grantType, AuthorizeRequestType? requestType,
             bool accessTokenIssued, AccessTokenType accessTokenType, bool refreshTokenIssued, ProofType proofType, bool idTokenIssued)

--- a/identity-server/src/Telemetry/Telemetry.cs
+++ b/identity-server/src/Telemetry/Telemetry.cs
@@ -3,6 +3,7 @@
 
 
 using System.Diagnostics.Metrics;
+using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Validation;
 
 namespace Duende.IdentityServer;
@@ -65,6 +66,11 @@ public static class Telemetry
             public const string Scheme = "scheme";
             public const string Result = "result";
             public const string Type = "type";
+            public const string AccessTokenIssued = "access_token_issued";
+            public const string AccessTokenType = "access_token_type";
+            public const string RefreshTokenIssued = "refresh_token_issued";
+            public const string ProofType = "proof_type";
+            public const string IdTokenIssued = "id_token_issued";
         }
 
         /// <summary>
@@ -442,13 +448,24 @@ public static class Telemetry
         /// <param name="clientId">Client Id</param>
         /// <param name="grantType">Grant Type</param>
         /// <param name="requestType">Type of authorization request</param>
-        public static void TokenIssued(string clientId, string grantType, AuthorizeRequestType? requestType)
+        /// <param name="accessTokenIssued">Whether an access token was issued</param>
+        /// <param name="accessTokenType">The type of access token issued</param>
+        /// <param name="refreshTokenIssued">Whether a refresh token was issued</param>
+        /// <param name="proofType">The proof type used</param>
+        /// <param name="idTokenIssued">Whether an id token was issued</param>
+        public static void TokenIssued(string clientId, string grantType, AuthorizeRequestType? requestType,
+            bool accessTokenIssued, AccessTokenType accessTokenType, bool refreshTokenIssued, ProofType proofType, bool idTokenIssued)
         {
             Success(clientId);
             TokenIssuedCounter.Add(1,
                 new(Tags.Client, clientId),
                 new(Tags.GrantType, grantType),
-                new(Tags.AuthorizeRequestType, requestType));
+                new(Tags.AuthorizeRequestType, requestType),
+                new(Tags.AccessTokenIssued, accessTokenIssued),
+                new(Tags.AccessTokenType, accessTokenType),
+                new(Tags.RefreshTokenIssued, refreshTokenIssued),
+                new(Tags.ProofType, proofType),
+                new(Tags.IdTokenIssued, idTokenIssued));
         }
 
         /// <summary>

--- a/identity-server/test/IdentityServer.UnitTests/Infrastructure/RemovePropertyModifierTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Infrastructure/RemovePropertyModifierTests.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using Duende.IdentityServer.Infrastructure;
+
+namespace IdentityServer.UnitTests.Infrastructure;
+
+public class RemovePropertyModifierTests
+{
+    [Fact]
+    public void ShouldRemoveSpecifiedProperties()
+    {
+        var testObject = new TestClass { Property1 = "Value1", Property2 = "Value2", Property3 = "Value3" };
+        var modifier = new RemovePropertyModifier<TestClass>([nameof(TestClass.Property1)]);
+        var serializerOptions = new JsonSerializerOptions
+        {
+            TypeInfoResolver = new DefaultJsonTypeInfoResolver
+            {
+                Modifiers = { modifier.ModifyTypeInfo }
+            }
+        };
+
+        var result = JsonSerializer.Serialize(testObject, serializerOptions);
+
+        var json = JsonDocument.Parse(result);
+        json.RootElement.TryGetProperty("Property1", out _).ShouldBeFalse();
+        json.RootElement.TryGetProperty("Property2", out var property2).ShouldBeTrue();
+        property2.GetString().ShouldBe(testObject.Property2);
+        json.RootElement.TryGetProperty("Property3", out var property3).ShouldBeTrue();
+        property3.GetString().ShouldBe(testObject.Property3);
+    }
+
+    private class TestClass
+    {
+        public string Property1 { get; init; }
+        public string Property2 { get; init; }
+        public string Property3 { get; init; }
+    }
+}

--- a/identity-server/test/IdentityServer.UnitTests/Licensing/v2/DiagnosticEntries/AssemblyInfoDiagnosticEntryTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Licensing/v2/DiagnosticEntries/AssemblyInfoDiagnosticEntryTests.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
-using System.Buffers;
-using System.Text;
 using System.Text.Json;
 using Duende.IdentityServer.Licensing.V2.Diagnostics.DiagnosticEntries;
 
@@ -14,17 +12,10 @@ public class AssemblyInfoDiagnosticEntryTests
     public async Task WriteAsync_ShouldWriteAssemblyInfo()
     {
         var subject = new AssemblyInfoDiagnosticEntry();
-        var bufferWriter = new ArrayBufferWriter<byte>();
-        await using var writer = new Utf8JsonWriter(bufferWriter, new JsonWriterOptions { Indented = false });
-        writer.WriteStartObject();
 
-        await subject.WriteAsync(writer);
+        var result = await DiagnosticEntryTestHelper.WriteEntryToJson(subject);
 
-        writer.WriteEndObject();
-        await writer.FlushAsync();
-        var json = Encoding.UTF8.GetString(bufferWriter.WrittenSpan);
-        var jsonDocument = JsonDocument.Parse(json);
-        var assemblyInfo = jsonDocument.RootElement.GetProperty("AssemblyInfo");
+        var assemblyInfo = result.RootElement.GetProperty("AssemblyInfo");
         assemblyInfo.GetProperty("AssemblyCount").ValueKind.ShouldBe(JsonValueKind.Number);
         var assemblies = assemblyInfo.GetProperty("Assemblies");
         assemblies.ValueKind.ShouldBe(JsonValueKind.Array);

--- a/identity-server/test/IdentityServer.UnitTests/Licensing/v2/DiagnosticEntries/AuthSchemeInfoDiagnosticEntryTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Licensing/v2/DiagnosticEntries/AuthSchemeInfoDiagnosticEntryTests.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using Duende.IdentityServer.Licensing.V2.Diagnostics.DiagnosticEntries;
+using Microsoft.AspNetCore.Authentication;
+using UnitTests.Common;
+
+namespace IdentityServer.UnitTests.Licensing.V2.DiagnosticEntries;
+
+public class AuthSchemeInfoDiagnosticEntryTests
+{
+
+    private readonly MockAuthenticationSchemeProvider _mockAuthenticationSchemeProvider;
+    private readonly AuthSchemeInfoDiagnosticEntry _subject;
+
+    public AuthSchemeInfoDiagnosticEntryTests()
+    {
+        _mockAuthenticationSchemeProvider = new MockAuthenticationSchemeProvider();
+        _subject = new AuthSchemeInfoDiagnosticEntry(_mockAuthenticationSchemeProvider);
+    }
+
+    [Fact]
+    public async Task WriteAsync_ShouldWriteAuthSchemeInfo()
+    {
+        var testAuthenticationScheme = new AuthenticationScheme("TestScheme", "Test Scheme", typeof(MockAuthenticationHandler));
+        _mockAuthenticationSchemeProvider.RemoveScheme("scheme");
+        _mockAuthenticationSchemeProvider.AddScheme(testAuthenticationScheme);
+
+        var result = await DiagnosticEntryTestHelper.WriteEntryToJson(_subject);
+
+        var authSchemeInfo = result.RootElement.GetProperty("AuthSchemeInfo");
+        var authSchemes = authSchemeInfo.GetProperty("Schemes");
+        var firstEntry = authSchemes.EnumerateArray().First();
+        firstEntry.GetProperty("TestScheme").GetString().ShouldBe("UnitTests.Common.MockAuthenticationHandler");
+    }
+
+    [Fact]
+    public async Task WriteAsync_ShouldWriteAllRegisteredAuthSchemes()
+    {
+        _mockAuthenticationSchemeProvider.RemoveScheme("scheme");
+        _mockAuthenticationSchemeProvider.AddScheme(new AuthenticationScheme("FirstTestScheme", "First Test Scheme", typeof(MockAuthenticationHandler)));
+        _mockAuthenticationSchemeProvider.AddScheme(new AuthenticationScheme("SecondTestScheme", "Second Test Scheme", typeof(MockAuthenticationHandler)));
+
+        var result = await DiagnosticEntryTestHelper.WriteEntryToJson(_subject);
+
+        var authSchemeInfo = result.RootElement.GetProperty("AuthSchemeInfo");
+        var authSchemes = authSchemeInfo.GetProperty("Schemes");
+        authSchemes.GetArrayLength().ShouldBe(2);
+    }
+}

--- a/identity-server/test/IdentityServer.UnitTests/Licensing/v2/DiagnosticEntries/ClientInfoDiagnosticEntryTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Licensing/v2/DiagnosticEntries/ClientInfoDiagnosticEntryTests.cs
@@ -1,0 +1,140 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+#nullable enable
+using Duende.IdentityServer.Licensing.V2.Diagnostics.DiagnosticEntries;
+using Duende.IdentityServer.Models;
+using Duende.IdentityServer.Stores;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace IdentityServer.UnitTests.Licensing.V2.DiagnosticEntries;
+
+public class ClientInfoDiagnosticEntryTests
+{
+    [Fact]
+    public async Task Handles_No_Clients_Loaded()
+    {
+        var clientStore = new InMemoryClientStore([]);
+        var logger = new NullLogger<ClientInfoDiagnosticEntry>();
+        var subject = new ClientInfoDiagnosticEntry(clientStore, logger);
+
+        var result = await DiagnosticEntryTestHelper.WriteEntryToJson(subject);
+
+        result.RootElement.GetProperty("Clients").EnumerateObject().Count().ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task Does_Not_Write_Client_Secrets()
+    {
+        var client = new Client
+        {
+            ClientId = "test-client",
+            ClientName = "Test Client",
+            ClientSecrets = new List<Secret> { new Secret("secret".Sha256()) }
+        };
+        var resetEvent = new AutoResetEvent(false);
+        var clientStore = new TestingClientStore([client], resetEvent);
+        var logger = new NullLogger<ClientInfoDiagnosticEntry>();
+        var subject = new ClientInfoDiagnosticEntry(clientStore, logger);
+
+        Duende.IdentityServer.Telemetry.Metrics.ClientLoaded(client.ClientId);
+
+        resetEvent.WaitOne();
+
+        var result = await DiagnosticEntryTestHelper.WriteEntryToJson(subject);
+
+        var clientsElement = result.RootElement.GetProperty("Clients");
+        clientsElement.TryGetProperty("test-client", out var clientElement).ShouldBeTrue();
+        clientElement.GetProperty("ClientName").GetString().ShouldBe("Test Client");
+        clientElement.TryGetProperty("ClientSecrets", out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task Handles_Single_Client_Loaded()
+    {
+        var client = new Client
+        {
+            ClientId = "test-client",
+            ClientName = "Test Client"
+        };
+        var resetEvent = new AutoResetEvent(false);
+        var clientStore = new TestingClientStore([client], resetEvent);
+        var logger = new NullLogger<ClientInfoDiagnosticEntry>();
+        var subject = new ClientInfoDiagnosticEntry(clientStore, logger);
+
+        Duende.IdentityServer.Telemetry.Metrics.ClientLoaded(client.ClientId);
+
+        resetEvent.WaitOne();
+
+        var result = await DiagnosticEntryTestHelper.WriteEntryToJson(subject);
+
+        result.RootElement.GetProperty("Clients").TryGetProperty("test-client", out _).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Handles_Multiple_Clients_Loaded()
+    {
+        var client1 = new Client
+        {
+            ClientId = "test-client-1",
+            ClientName = "Test Client 1"
+        };
+        var client2 = new Client
+        {
+            ClientId = "test-client-2",
+            ClientName = "Test Client 2"
+        };
+        var resetEvent = new AutoResetEvent(false);
+        var clientStore = new TestingClientStore([client1, client2], resetEvent);
+        var logger = new NullLogger<ClientInfoDiagnosticEntry>();
+        var subject = new ClientInfoDiagnosticEntry(clientStore, logger);
+
+        Duende.IdentityServer.Telemetry.Metrics.ClientLoaded(client1.ClientId);
+        resetEvent.WaitOne();
+
+        Duende.IdentityServer.Telemetry.Metrics.ClientLoaded(client2.ClientId);
+        resetEvent.WaitOne();
+
+        var result = await DiagnosticEntryTestHelper.WriteEntryToJson(subject);
+
+        result.RootElement.GetProperty("Clients").TryGetProperty("test-client-1", out _).ShouldBeTrue();
+        result.RootElement.GetProperty("Clients").TryGetProperty("test-client-2", out _).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Handles_Same_Client_Loaded_Multiple_Times()
+    {
+        var client = new Client
+        {
+            ClientId = "test-client",
+            ClientName = "Test Client"
+        };
+        var resetEvent = new AutoResetEvent(false);
+        var clientStore = new TestingClientStore([client], resetEvent);
+        var logger = new NullLogger<ClientInfoDiagnosticEntry>();
+        var subject = new ClientInfoDiagnosticEntry(clientStore, logger);
+
+        Duende.IdentityServer.Telemetry.Metrics.ClientLoaded(client.ClientId);
+
+        resetEvent.WaitOne();
+
+        Duende.IdentityServer.Telemetry.Metrics.ClientLoaded(client.ClientId);
+
+        var result = await DiagnosticEntryTestHelper.WriteEntryToJson(subject);
+
+        result.RootElement.GetProperty("Clients").TryGetProperty("test-client", out _).ShouldBeTrue();
+    }
+
+    private class TestingClientStore(IEnumerable<Client> clients, AutoResetEvent resetEvent) : IClientStore
+    {
+        private readonly IClientStore _inner = new InMemoryClientStore(clients);
+
+        public async Task<Client?> FindClientByIdAsync(string clientId)
+        {
+            var client = await _inner.FindClientByIdAsync(clientId);
+            resetEvent.Set();
+
+            return client;
+        }
+    }
+}

--- a/identity-server/test/IdentityServer.UnitTests/Licensing/v2/DiagnosticEntries/DataProtectionDiagnosticEntryTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Licensing/v2/DiagnosticEntries/DataProtectionDiagnosticEntryTests.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using System.Xml.Linq;
+using Duende.IdentityServer.Licensing.V2.Diagnostics.DiagnosticEntries;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.DataProtection.KeyManagement;
+using Microsoft.AspNetCore.DataProtection.Repositories;
+using Microsoft.AspNetCore.DataProtection.XmlEncryption;
+using Microsoft.Extensions.Options;
+
+namespace IdentityServer.UnitTests.Licensing.V2.DiagnosticEntries;
+
+public class DataProtectionDiagnosticEntryTests
+{
+    [Fact]
+    public async Task WriteAsync_WithConfiguredOptions_ShouldWriteCorrectValues()
+    {
+        var dataProtectionOptions = Options.Create(new DataProtectionOptions
+        {
+            ApplicationDiscriminator = "TestApplication"
+        });
+        var keyManagementOptions = Options.Create(new KeyManagementOptions
+        {
+            XmlEncryptor = new TestXmlEncryptor(),
+            XmlRepository = new TestXmlRepository()
+        });
+        var subject = new DataProtectionDiagnosticEntry(dataProtectionOptions, keyManagementOptions);
+
+        var result = await DiagnosticEntryTestHelper.WriteEntryToJson(subject);
+
+        var dataProtectionConfiguration = result.RootElement.GetProperty("DataProtectionConfiguration");
+        dataProtectionConfiguration.GetProperty("ApplicationDiscriminator").GetString().ShouldBe("TestApplication");
+        dataProtectionConfiguration.GetProperty("XmlEncryptor").GetString().ShouldBe(typeof(TestXmlEncryptor).FullName);
+        dataProtectionConfiguration.GetProperty("XmlRepository").GetString().ShouldBe(typeof(TestXmlRepository).FullName);
+    }
+
+    [Fact]
+    public async Task WriteAsync_WithDefaultOptions_ShouldWriteDefaultValues()
+    {
+        var subject = new DataProtectionDiagnosticEntry(
+            Options.Create(new DataProtectionOptions()),
+            Options.Create(new KeyManagementOptions()));
+
+        var result = await DiagnosticEntryTestHelper.WriteEntryToJson(subject);
+
+        var dataProtectionConfiguration = result.RootElement.GetProperty("DataProtectionConfiguration");
+        dataProtectionConfiguration.GetProperty("ApplicationDiscriminator").GetString().ShouldBe("Not Configured");
+        dataProtectionConfiguration.GetProperty("XmlEncryptor").GetString().ShouldBe("Not Configured");
+        dataProtectionConfiguration.GetProperty("XmlRepository").GetString().ShouldBe("Not Configured");
+    }
+
+    private class TestXmlEncryptor : IXmlEncryptor
+    {
+        public EncryptedXmlInfo Encrypt(XElement plaintextElement) => new EncryptedXmlInfo(plaintextElement, typeof(TestXmlEncryptor));
+    }
+
+    private class TestXmlRepository : IXmlRepository
+    {
+        public IReadOnlyCollection<XElement> GetAllElements() => Array.Empty<XElement>();
+
+        public void StoreElement(XElement element, string friendlyName)
+        {
+        }
+    }
+}

--- a/identity-server/test/IdentityServer.UnitTests/Licensing/v2/DiagnosticEntries/DiagnosticEntryTestHelper.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Licensing/v2/DiagnosticEntries/DiagnosticEntryTestHelper.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using System.Buffers;
+using System.Text;
+using System.Text.Json;
+using Duende.IdentityServer.Licensing.V2.Diagnostics;
+
+namespace IdentityServer.UnitTests.Licensing.V2.DiagnosticEntries;
+
+internal static class DiagnosticEntryTestHelper
+{
+    public static async Task<JsonDocument> WriteEntryToJson(IDiagnosticEntry subject)
+    {
+        var bufferWriter = new ArrayBufferWriter<byte>();
+
+        await using var writer = new Utf8JsonWriter(bufferWriter, new JsonWriterOptions { Indented = false });
+        writer.WriteStartObject();
+
+        await subject.WriteAsync(writer);
+
+        writer.WriteEndObject();
+        await writer.FlushAsync();
+
+        var json = Encoding.UTF8.GetString(bufferWriter.WrittenSpan);
+
+        return JsonDocument.Parse(json);
+    }
+}

--- a/identity-server/test/IdentityServer.UnitTests/Licensing/v2/DiagnosticEntries/IdentityServerOptionsDiagnosticEntryTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Licensing/v2/DiagnosticEntries/IdentityServerOptionsDiagnosticEntryTests.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using Duende.IdentityModel.Client;
+using Duende.IdentityServer.Configuration;
+using Duende.IdentityServer.Licensing.V2.Diagnostics.DiagnosticEntries;
+using Microsoft.Extensions.Options;
+
+namespace IdentityServer.UnitTests.Licensing.V2.DiagnosticEntries;
+
+public class IdentityServerOptionsDiagnosticEntryTests
+{
+    [Fact]
+    public async Task WriteAsync_ShouldExcludeLicenseKey()
+    {
+        var options = new IdentityServerOptions
+        {
+            LicenseKey = "test-key"
+        };
+        var subject = new IdentityServerOptionsDiagnosticEntry(Options.Create(options));
+
+        var result = await DiagnosticEntryTestHelper.WriteEntryToJson(subject);
+
+        result.RootElement.GetProperty("IdentityServerOptions").TryGetProperty("LicenseKey", out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task WriteAsync_ShouldIncludeOtherProperties()
+    {
+        var options = new IdentityServerOptions
+        {
+            IssuerUri = "https://example.com",
+            LowerCaseIssuerUri = true,
+            AccessTokenJwtType = "jwt",
+            LogoutTokenJwtType = "logout",
+            EmitStaticAudienceClaim = true,
+            EmitScopesAsSpaceDelimitedStringInJwt = true,
+            EmitIssuerIdentificationResponseParameter = false,
+            EmitStateHash = true,
+            StrictJarValidation = true,
+            ValidateTenantOnAuthorization = true,
+            JwtValidationClockSkew = TimeSpan.FromMinutes(1),
+            AllowedJwtAlgorithms = ["SHA256", "SHA512"],
+            DiagnosticSummaryLogFrequency = TimeSpan.FromMinutes(30)
+        };
+        var subject = new IdentityServerOptionsDiagnosticEntry(Options.Create(options));
+
+        var result = await DiagnosticEntryTestHelper.WriteEntryToJson(subject);
+
+        var identityServerOptions = result.RootElement.GetProperty("IdentityServerOptions");
+        identityServerOptions.GetProperty("IssuerUri").GetString().ShouldBe("https://example.com");
+        identityServerOptions.GetProperty("LowerCaseIssuerUri").GetBoolean().ShouldBeTrue();
+        identityServerOptions.GetProperty("AccessTokenJwtType").GetString().ShouldBe("jwt");
+        identityServerOptions.GetProperty("LogoutTokenJwtType").GetString().ShouldBe("logout");
+        identityServerOptions.GetProperty("EmitStaticAudienceClaim").GetBoolean().ShouldBeTrue();
+        identityServerOptions.GetProperty("EmitScopesAsSpaceDelimitedStringInJwt").GetBoolean().ShouldBeTrue();
+        identityServerOptions.GetProperty("EmitIssuerIdentificationResponseParameter").GetBoolean().ShouldBeFalse();
+        identityServerOptions.GetProperty("EmitStateHash").GetBoolean().ShouldBeTrue();
+        identityServerOptions.GetProperty("StrictJarValidation").GetBoolean().ShouldBeTrue();
+        identityServerOptions.GetProperty("ValidateTenantOnAuthorization").GetBoolean().ShouldBeTrue();
+        identityServerOptions.TryGetProperty("Endpoints", out _).ShouldBeTrue();
+        identityServerOptions.TryGetProperty("Discovery", out _).ShouldBeTrue();
+        identityServerOptions.TryGetProperty("Authentication", out _).ShouldBeTrue();
+        identityServerOptions.TryGetProperty("Events", out _).ShouldBeTrue();
+        identityServerOptions.TryGetProperty("InputLengthRestrictions", out _).ShouldBeTrue();
+        identityServerOptions.TryGetProperty("UserInteraction", out _).ShouldBeTrue();
+        identityServerOptions.TryGetProperty("Caching", out _).ShouldBeTrue();
+        identityServerOptions.TryGetProperty("Cors", out _).ShouldBeTrue();
+        identityServerOptions.TryGetProperty("Csp", out _).ShouldBeTrue();
+        identityServerOptions.TryGetProperty("Validation", out _).ShouldBeTrue();
+        identityServerOptions.TryGetProperty("DeviceFlow", out _).ShouldBeTrue();
+        identityServerOptions.TryGetProperty("Ciba", out _).ShouldBeTrue();
+        identityServerOptions.TryGetProperty("Logging", out _).ShouldBeTrue();
+        identityServerOptions.TryGetProperty("MutualTls", out _).ShouldBeTrue();
+        identityServerOptions.TryGetProperty("KeyManagement", out _).ShouldBeTrue();
+        identityServerOptions.TryGetProperty("PersistentGrants", out _).ShouldBeTrue();
+        identityServerOptions.TryGetProperty("DPoP", out _).ShouldBeTrue();
+        identityServerOptions.GetProperty("JwtValidationClockSkew").GetString().ShouldBe(TimeSpan.FromMinutes(1).ToString());
+        var allowedJwtAlgorithms = identityServerOptions.TryGetStringArray("AllowedJwtAlgorithms");
+        allowedJwtAlgorithms.ShouldBe(["SHA256", "SHA512"]);
+        identityServerOptions.TryGetProperty("Preview", out _).ShouldBeTrue();
+        identityServerOptions.GetProperty("DiagnosticSummaryLogFrequency").GetString().ShouldBe(TimeSpan.FromMinutes(30).ToString());
+    }
+}

--- a/identity-server/test/IdentityServer.UnitTests/Licensing/v2/DiagnosticEntries/RegisteredImplementationsDiagnosticEntryTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Licensing/v2/DiagnosticEntries/RegisteredImplementationsDiagnosticEntryTests.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using Duende.IdentityServer.Licensing.V2.Diagnostics.DiagnosticEntries;
+using Duende.IdentityServer.Services;
+using Microsoft.Extensions.DependencyInjection;
+using UnitTests.Common;
+
+namespace IdentityServer.UnitTests.Licensing.V2.DiagnosticEntries;
+
+public class RegisteredImplementationsDiagnosticEntryTests
+{
+    [Fact]
+    public async Task WriteAsync_ShouldWriteRegisteredServicesInfo()
+    {
+        var serviceProvider = new ServiceCollection()
+            .AddSingleton<IProfileService, MockProfileService>()
+            .BuildServiceProvider();
+        var subject = new RegisteredImplementationsDiagnosticEntry(serviceProvider);
+
+        var result = await DiagnosticEntryTestHelper.WriteEntryToJson(subject);
+
+        var registeredServices = result.RootElement.GetProperty("RegisteredServices");
+        var services = registeredServices.GetProperty("Services");
+        var firstEntry = services.EnumerateArray().ToList().SingleOrDefault(entry => entry.TryGetProperty(nameof(IProfileService), out _));
+        var assemblyInfo = firstEntry.GetProperty(nameof(IProfileService));
+        var expectedTypeInfo = typeof(MockProfileService);
+        assemblyInfo.GetProperty("TypeName").GetString().ShouldBe(expectedTypeInfo.FullName);
+        assemblyInfo.GetProperty("Assembly").GetString().ShouldBe(expectedTypeInfo.Assembly.GetName().Name);
+        assemblyInfo.GetProperty("AssemblyVersion").GetString().ShouldBe(expectedTypeInfo.Assembly.GetName().Version?.ToString());
+    }
+
+    [Fact]
+    public async Task WriteAsync_HandlesNoServiceRegisteredForInterface()
+    {
+        var subject = new RegisteredImplementationsDiagnosticEntry(new ServiceCollection().BuildServiceProvider());
+
+        var result = await DiagnosticEntryTestHelper.WriteEntryToJson(subject);
+
+        var registeredServices = result.RootElement.GetProperty("RegisteredServices");
+        var services = registeredServices.GetProperty("Services");
+        var firstEntry = services.EnumerateArray().ToList().SingleOrDefault(entry => entry.TryGetProperty(nameof(IProfileService), out _));
+        var assemblyInfo = firstEntry.GetProperty(nameof(IProfileService));
+        assemblyInfo.GetProperty("TypeName").GetString().ShouldBe("Not Registered");
+        assemblyInfo.GetProperty("Assembly").GetString().ShouldBe("Not Registered");
+        assemblyInfo.GetProperty("AssemblyVersion").GetString().ShouldBe("Not Registered");
+    }
+}

--- a/identity-server/test/IdentityServer.UnitTests/Licensing/v2/DiagnosticEntries/TokenIssueCountDiagnosticEntryTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Licensing/v2/DiagnosticEntries/TokenIssueCountDiagnosticEntryTests.cs
@@ -105,6 +105,24 @@ public class TokenIssueCountDiagnosticEntryTests
     }
 
     [Fact]
+    public async Task Should_Handle_No_Token_Issued()
+    {
+        IssueToken("authorization_code", false, null, false, ProofType.None, false);
+
+        var result = await DiagnosticEntryTestHelper.WriteEntryToJson(_subject);
+
+        var tokenIssueCounts = result.RootElement.GetProperty("TokenIssueCounts");
+        tokenIssueCounts.GetProperty("Jwt").GetInt64().ShouldBe(0);
+        tokenIssueCounts.GetProperty("Reference").GetInt64().ShouldBe(0);
+        tokenIssueCounts.GetProperty("JwtPoPDPoP").GetInt64().ShouldBe(0);
+        tokenIssueCounts.GetProperty("JwtPoPmTLS").GetInt64().ShouldBe(0);
+        tokenIssueCounts.GetProperty("ReferencePoPDPoP").GetInt64().ShouldBe(0);
+        tokenIssueCounts.GetProperty("ReferencePoPmTLS").GetInt64().ShouldBe(0);
+        tokenIssueCounts.GetProperty("Refresh").GetInt64().ShouldBe(0);
+        tokenIssueCounts.GetProperty("Id").GetInt64().ShouldBe(0);
+    }
+
+    [Fact]
     public async Task Should_Handle_Initial_Grant_Type_Count()
     {
         IssueToken("authorization_code", true, AccessTokenType.Jwt, false, ProofType.None, false);
@@ -157,7 +175,7 @@ public class TokenIssueCountDiagnosticEntryTests
         tokenIssueCounts.GetProperty("Refresh").GetInt64().ShouldBe(0);
     }
 
-    private void IssueToken(string grantType, bool accessTokenIssued, AccessTokenType accessTokenType, bool refreshTokenIssued,
+    private void IssueToken(string grantType, bool accessTokenIssued, AccessTokenType? accessTokenType, bool refreshTokenIssued,
         ProofType proofType, bool idTokenIssued) =>
         Duende.IdentityServer.Telemetry.Metrics.TokenIssued("ClientId", grantType, null, accessTokenIssued, accessTokenType, refreshTokenIssued, proofType, idTokenIssued);
 }

--- a/identity-server/test/IdentityServer.UnitTests/Licensing/v2/DiagnosticEntries/TokenIssueCountDiagnosticEntryTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Licensing/v2/DiagnosticEntries/TokenIssueCountDiagnosticEntryTests.cs
@@ -13,7 +13,7 @@ public class TokenIssueCountDiagnosticEntryTests
     [Fact]
     public async Task Should_Count_JwtAccessToken()
     {
-        IssueToken(true, AccessTokenType.Jwt, false, ProofType.None, false);
+        IssueToken("authorization_code", true, AccessTokenType.Jwt, false, ProofType.None, false);
 
         var result = await DiagnosticEntryTestHelper.WriteEntryToJson(_subject);
 
@@ -23,7 +23,7 @@ public class TokenIssueCountDiagnosticEntryTests
     [Fact]
     public async Task Should_Count_JwtReferenceToken()
     {
-        IssueToken(true, AccessTokenType.Reference, false, ProofType.None, false);
+        IssueToken("authorization_code", true, AccessTokenType.Reference, false, ProofType.None, false);
 
         var result = await DiagnosticEntryTestHelper.WriteEntryToJson(_subject);
 
@@ -33,7 +33,7 @@ public class TokenIssueCountDiagnosticEntryTests
     [Fact]
     public async Task Should_Count_JwtDPoPToken()
     {
-        IssueToken(true, AccessTokenType.Jwt, false, ProofType.DPoP, false);
+        IssueToken("authorization_code", true, AccessTokenType.Jwt, false, ProofType.DPoP, false);
 
         var result = await DiagnosticEntryTestHelper.WriteEntryToJson(_subject);
 
@@ -43,7 +43,7 @@ public class TokenIssueCountDiagnosticEntryTests
     [Fact]
     public async Task Should_Count_ReferenceDPoPToken()
     {
-        IssueToken(true, AccessTokenType.Reference, false, ProofType.DPoP, false);
+        IssueToken("authorization_code", true, AccessTokenType.Reference, false, ProofType.DPoP, false);
 
         var result = await DiagnosticEntryTestHelper.WriteEntryToJson(_subject);
 
@@ -53,7 +53,7 @@ public class TokenIssueCountDiagnosticEntryTests
     [Fact]
     public async Task Should_Count_JwtMTlsToken()
     {
-        IssueToken(true, AccessTokenType.Jwt, false, ProofType.ClientCertificate, false);
+        IssueToken("authorization_code", true, AccessTokenType.Jwt, false, ProofType.ClientCertificate, false);
 
         var result = await DiagnosticEntryTestHelper.WriteEntryToJson(_subject);
 
@@ -63,7 +63,7 @@ public class TokenIssueCountDiagnosticEntryTests
     [Fact]
     public async Task Should_Count_ReferenceMTlsToken()
     {
-        IssueToken(true, AccessTokenType.Reference, false, ProofType.ClientCertificate, false);
+        IssueToken("authorization_code", true, AccessTokenType.Reference, false, ProofType.ClientCertificate, false);
 
         var result = await DiagnosticEntryTestHelper.WriteEntryToJson(_subject);
 
@@ -73,7 +73,7 @@ public class TokenIssueCountDiagnosticEntryTests
     [Fact]
     public async Task Should_Count_RefreshToken()
     {
-        IssueToken(false, AccessTokenType.Jwt, true, ProofType.None, false);
+        IssueToken("refresh_token", false, AccessTokenType.Jwt, true, ProofType.None, false);
 
         var result = await DiagnosticEntryTestHelper.WriteEntryToJson(_subject);
 
@@ -83,7 +83,7 @@ public class TokenIssueCountDiagnosticEntryTests
     [Fact]
     public async Task Should_Count_IdToken()
     {
-        IssueToken(false, AccessTokenType.Jwt, false, ProofType.None, true);
+        IssueToken("authorization_code", false, AccessTokenType.Jwt, false, ProofType.None, true);
 
         var result = await DiagnosticEntryTestHelper.WriteEntryToJson(_subject);
 
@@ -93,8 +93,8 @@ public class TokenIssueCountDiagnosticEntryTests
     [Fact]
     public async Task Should_Handle_Multiple_Token_Types()
     {
-        IssueToken(true, AccessTokenType.Jwt, true, ProofType.None, false);
-        IssueToken(true, AccessTokenType.Jwt, false, ProofType.DPoP, false);
+        IssueToken("authorization_code", true, AccessTokenType.Jwt, true, ProofType.None, false);
+        IssueToken("authorization_code", true, AccessTokenType.Jwt, false, ProofType.DPoP, false);
 
         var result = await DiagnosticEntryTestHelper.WriteEntryToJson(_subject);
 
@@ -102,6 +102,42 @@ public class TokenIssueCountDiagnosticEntryTests
         tokenIssueCounts.GetProperty("Jwt").GetInt64().ShouldBe(1);
         tokenIssueCounts.GetProperty("JwtPoPDPoP").GetInt64().ShouldBe(1);
         tokenIssueCounts.GetProperty("Refresh").GetInt64().ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task Should_Handle_Initial_Grant_Type_Count()
+    {
+        IssueToken("authorization_code", true, AccessTokenType.Jwt, false, ProofType.None, false);
+
+        var result = await DiagnosticEntryTestHelper.WriteEntryToJson(_subject);
+
+        var tokenIssueCounts = result.RootElement.GetProperty("TokenIssueCounts");
+        tokenIssueCounts.GetProperty("authorization_code").GetInt64().ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task Should_Handle_Multiple_Grant_Type_Counts()
+    {
+        IssueToken("authorization_code", true, AccessTokenType.Jwt, false, ProofType.None, false);
+        IssueToken("client_credentials", true, AccessTokenType.Jwt, false, ProofType.None, false);
+
+        var result = await DiagnosticEntryTestHelper.WriteEntryToJson(_subject);
+
+        var tokenIssueCounts = result.RootElement.GetProperty("TokenIssueCounts");
+        tokenIssueCounts.GetProperty("authorization_code").GetInt64().ShouldBe(1);
+        tokenIssueCounts.GetProperty("client_credentials").GetInt64().ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task Should_Handle_Multiple_Grant_Type_Counts_With_Grant_Type()
+    {
+        IssueToken("authorization_code", true, AccessTokenType.Jwt, false, ProofType.None, false);
+        IssueToken("authorization_code", true, AccessTokenType.Jwt, false, ProofType.None, false);
+
+        var result = await DiagnosticEntryTestHelper.WriteEntryToJson(_subject);
+
+        var tokenIssueCounts = result.RootElement.GetProperty("TokenIssueCounts");
+        tokenIssueCounts.GetProperty("authorization_code").GetInt64().ShouldBe(2);
     }
 
     [Fact]
@@ -121,7 +157,7 @@ public class TokenIssueCountDiagnosticEntryTests
         tokenIssueCounts.GetProperty("Refresh").GetInt64().ShouldBe(0);
     }
 
-    private void IssueToken(bool accessTokenIssued, AccessTokenType accessTokenType, bool refreshTokenIssued,
+    private void IssueToken(string grantType, bool accessTokenIssued, AccessTokenType accessTokenType, bool refreshTokenIssued,
         ProofType proofType, bool idTokenIssued) =>
-        Duende.IdentityServer.Telemetry.Metrics.TokenIssued("ClientId", "GrantType", null, accessTokenIssued, accessTokenType, refreshTokenIssued, proofType, idTokenIssued);
+        Duende.IdentityServer.Telemetry.Metrics.TokenIssued("ClientId", grantType, null, accessTokenIssued, accessTokenType, refreshTokenIssued, proofType, idTokenIssued);
 }

--- a/identity-server/test/IdentityServer.UnitTests/Licensing/v2/DiagnosticEntries/TokenIssueCountDiagnosticEntryTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Licensing/v2/DiagnosticEntries/TokenIssueCountDiagnosticEntryTests.cs
@@ -1,0 +1,127 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using Duende.IdentityServer.Licensing.V2.Diagnostics.DiagnosticEntries;
+using Duende.IdentityServer.Models;
+
+namespace IdentityServer.UnitTests.Licensing.V2.DiagnosticEntries;
+
+public class TokenIssueCountDiagnosticEntryTests
+{
+    private readonly TokenIssueCountDiagnosticEntry _subject = new();
+
+    [Fact]
+    public async Task Should_Count_JwtAccessToken()
+    {
+        IssueToken(true, AccessTokenType.Jwt, false, ProofType.None, false);
+
+        var result = await DiagnosticEntryTestHelper.WriteEntryToJson(_subject);
+
+        result.RootElement.GetProperty("TokenIssueCounts").GetProperty("Jwt").GetInt64().ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task Should_Count_JwtReferenceToken()
+    {
+        IssueToken(true, AccessTokenType.Reference, false, ProofType.None, false);
+
+        var result = await DiagnosticEntryTestHelper.WriteEntryToJson(_subject);
+
+        result.RootElement.GetProperty("TokenIssueCounts").GetProperty("Reference").GetInt64().ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task Should_Count_JwtDPoPToken()
+    {
+        IssueToken(true, AccessTokenType.Jwt, false, ProofType.DPoP, false);
+
+        var result = await DiagnosticEntryTestHelper.WriteEntryToJson(_subject);
+
+        result.RootElement.GetProperty("TokenIssueCounts").GetProperty("JwtPoPDPoP").GetInt64().ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task Should_Count_ReferenceDPoPToken()
+    {
+        IssueToken(true, AccessTokenType.Reference, false, ProofType.DPoP, false);
+
+        var result = await DiagnosticEntryTestHelper.WriteEntryToJson(_subject);
+
+        result.RootElement.GetProperty("TokenIssueCounts").GetProperty("ReferencePoPDPoP").GetInt64().ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task Should_Count_JwtMTlsToken()
+    {
+        IssueToken(true, AccessTokenType.Jwt, false, ProofType.ClientCertificate, false);
+
+        var result = await DiagnosticEntryTestHelper.WriteEntryToJson(_subject);
+
+        result.RootElement.GetProperty("TokenIssueCounts").GetProperty("JwtPoPmTLS").GetInt64().ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task Should_Count_ReferenceMTlsToken()
+    {
+        IssueToken(true, AccessTokenType.Reference, false, ProofType.ClientCertificate, false);
+
+        var result = await DiagnosticEntryTestHelper.WriteEntryToJson(_subject);
+
+        result.RootElement.GetProperty("TokenIssueCounts").GetProperty("ReferencePoPmTLS").GetInt64().ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task Should_Count_RefreshToken()
+    {
+        IssueToken(false, AccessTokenType.Jwt, true, ProofType.None, false);
+
+        var result = await DiagnosticEntryTestHelper.WriteEntryToJson(_subject);
+
+        result.RootElement.GetProperty("TokenIssueCounts").GetProperty("Refresh").GetInt64().ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task Should_Count_IdToken()
+    {
+        IssueToken(false, AccessTokenType.Jwt, false, ProofType.None, true);
+
+        var result = await DiagnosticEntryTestHelper.WriteEntryToJson(_subject);
+
+        result.RootElement.GetProperty("TokenIssueCounts").GetProperty("Id").GetInt64().ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task Should_Handle_Multiple_Token_Types()
+    {
+        IssueToken(true, AccessTokenType.Jwt, true, ProofType.None, false);
+        IssueToken(true, AccessTokenType.Jwt, false, ProofType.DPoP, false);
+
+        var result = await DiagnosticEntryTestHelper.WriteEntryToJson(_subject);
+
+        var tokenIssueCounts = result.RootElement.GetProperty("TokenIssueCounts");
+        tokenIssueCounts.GetProperty("Jwt").GetInt64().ShouldBe(1);
+        tokenIssueCounts.GetProperty("JwtPoPDPoP").GetInt64().ShouldBe(1);
+        tokenIssueCounts.GetProperty("Refresh").GetInt64().ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task Should_Ignore_Non_TokenIssued_Instruments()
+    {
+        Duende.IdentityServer.Telemetry.Metrics.TokenIssuedFailure("ClientId", "GrantType", null, "error");
+
+        var result = await DiagnosticEntryTestHelper.WriteEntryToJson(_subject);
+
+        var tokenIssueCounts = result.RootElement.GetProperty("TokenIssueCounts");
+        tokenIssueCounts.GetProperty("Jwt").GetInt64().ShouldBe(0);
+        tokenIssueCounts.GetProperty("Reference").GetInt64().ShouldBe(0);
+        tokenIssueCounts.GetProperty("JwtPoPDPoP").GetInt64().ShouldBe(0);
+        tokenIssueCounts.GetProperty("JwtPoPmTLS").GetInt64().ShouldBe(0);
+        tokenIssueCounts.GetProperty("ReferencePoPDPoP").GetInt64().ShouldBe(0);
+        tokenIssueCounts.GetProperty("ReferencePoPmTLS").GetInt64().ShouldBe(0);
+        tokenIssueCounts.GetProperty("Refresh").GetInt64().ShouldBe(0);
+    }
+
+    private void IssueToken(bool accessTokenIssued, AccessTokenType accessTokenType, bool refreshTokenIssued,
+        ProofType proofType, bool idTokenIssued) =>
+        Duende.IdentityServer.Telemetry.Metrics.TokenIssued("ClientId", "GrantType", null, accessTokenIssued, accessTokenType, refreshTokenIssued, proofType, idTokenIssued);
+}


### PR DESCRIPTION
**What issue does this PR address?**
Stacks on #2029 to add a diagnostic entry for a client info about loaded clients. This also includes a new telemetry event for when a client is loaded.


**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
