### PR TITLE
Add null-check for client before coordinating session lifecycle

### DIFF
--- a/identity-server/src/IdentityServer/Services/Default/DefaultSessionCoordinationService.cs
+++ b/identity-server/src/IdentityServer/Services/Default/DefaultSessionCoordinationService.cs
@@ -137,14 +137,17 @@ public class DefaultSessionCoordinationService : ISessionCoordinationService
         {
             var client = await ClientStore.FindClientByIdAsync(clientId); // i don't think we care if it's an enabled client at this point
 
-            var shouldCoordinate =
-                client.CoordinateLifetimeWithUserSession == true ||
-                (Options.Authentication.CoordinateClientLifetimesWithUserSession && client.CoordinateLifetimeWithUserSession != false);
-
-            if (shouldCoordinate)
+            if (client != null)
             {
-                // this implies they should also be contacted for backchannel logout below
-                clientsToCoordinate.Add(clientId);
+                var shouldCoordinate =
+                    client.CoordinateLifetimeWithUserSession == true ||
+                    (Options.Authentication.CoordinateClientLifetimesWithUserSession && client.CoordinateLifetimeWithUserSession != false);
+
+                if (shouldCoordinate)
+                {
+                    // this implies they should also be contacted for backchannel logout below
+                    clientsToCoordinate.Add(clientId);
+                }
             }
         }
 

--- a/identity-server/test/IdentityServer.UnitTests/Services/Default/DefaultSessionCoordinationServiceTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Services/Default/DefaultSessionCoordinationServiceTests.cs
@@ -1,0 +1,39 @@
+using System.Threading.Tasks;
+using Duende.IdentityServer.Configuration;
+using Duende.IdentityServer.Models;
+using Duende.IdentityServer.Services;
+using Duende.IdentityServer.Stores;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using UnitTests.Endpoints.EndSession;
+using Xunit;
+
+namespace UnitTests.Services.Default;
+
+public class DefaultSessionCoordinationServiceTests
+{
+    public DefaultSessionCoordinationService Service;
+
+    [Fact]
+    public async Task Handles_missing_client_null_reference()
+    {
+        var stubBackChannelLogoutClient = new StubBackChannelLogoutClient();
+        Service = new DefaultSessionCoordinationService(
+            new IdentityServerOptions(),
+            new InMemoryPersistedGrantStore(),
+            new InMemoryClientStore([]),
+            stubBackChannelLogoutClient,
+            new NullLogger<DefaultSessionCoordinationService>());
+        
+        await Service.ProcessExpirationAsync(new UserSession
+        {
+            ClientIds = ["not_found"],
+            SessionId = "1",
+            SubjectId = "1"
+        });
+        
+        stubBackChannelLogoutClient
+            .SendLogoutsWasCalled
+            .ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
Make sure to do a null check on `client` in `ProcessExpirationAsync` to stop possible null reference exceptions when the client is not found.