### PR TITLE
Re-introduce interface for Frontendstore. 

### DIFF
--- a/bff/src/Bff/BffBuilder.cs
+++ b/bff/src/Bff/BffBuilder.cs
@@ -49,7 +49,11 @@ public sealed class BffBuilder(IServiceCollection services)
         Services.AddHybridCache();
 
         Services.AddTransient<IStartupFilter, ConfigureBffStartupFilter>();
-        Services.AddSingleton<LocalFrontendStore>();
+
+        // Register the frontend collection, which will be used to store and retrieve frontends
+        Services.AddSingleton<FrontendCollection>();
+        // Add a public accessible interface to the frontend collection, so our users can access it
+        Services.AddSingleton<IFrontendCollection>((sp) => sp.GetRequiredService<FrontendCollection>());
 
         Services.AddTransient<SelectedFrontend>();
         Services.AddTransient<FrontendSelector>();

--- a/bff/src/Bff/DynamicFrontends/IFrontendCollection.cs
+++ b/bff/src/Bff/DynamicFrontends/IFrontendCollection.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+namespace Duende.Bff.DynamicFrontends;
+
+/// <summary>
+/// Interface that allows adding, updating, and removing frontends in the BFF system.
+///
+/// Notes:
+///  - Implementations are expected to be thread-safe.
+///  - This interface is used to manage the collection of frontends dynamically, allowing for runtime updates.
+///  - Any changes are not expected to be persisted across application restarts; they are transient and in-memory.
+///  - This is not an extensibility point and implementors of this library cannot replace it with a different implementation.
+/// </summary>
+public interface IFrontendCollection
+{
+    void AddOrUpdate(BffFrontend frontend);
+    void Remove(BffFrontendName frontendName);
+    IReadOnlyList<BffFrontend> GetAll();
+}

--- a/bff/src/Bff/DynamicFrontends/Internal/ConfigureBffStartupFilter.cs
+++ b/bff/src/Bff/DynamicFrontends/Internal/ConfigureBffStartupFilter.cs
@@ -38,7 +38,7 @@ internal class ConfigureBffStartupFilter : IStartupFilter
 
     private static void ConfigureOpenIdConfigurationCacheExpiration(IApplicationBuilder app)
     {
-        var frontendStore = app.ApplicationServices.GetRequiredService<LocalFrontendStore>();
+        var frontendStore = app.ApplicationServices.GetRequiredService<FrontendCollection>();
         var optionsMonitor = app.ApplicationServices.GetRequiredService<IOptionsMonitorCache<OpenIdConnectOptions>>();
 
         frontendStore.OnFrontendChanged +=

--- a/bff/src/Bff/DynamicFrontends/Internal/FrontendCollection.cs
+++ b/bff/src/Bff/DynamicFrontends/Internal/FrontendCollection.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 
 namespace Duende.Bff.DynamicFrontends.Internal;
 
-internal class LocalFrontendStore : IDisposable
+internal class FrontendCollection : IDisposable, IFrontendCollection
 {
     private readonly object _syncRoot = new();
 
@@ -22,7 +22,7 @@ internal class LocalFrontendStore : IDisposable
 
     public event Action<BffFrontend> OnFrontendChanged = (_) => { };
 
-    public LocalFrontendStore(
+    public FrontendCollection(
         IOptionsMonitor<BffConfiguration> bffConfiguration,
         IEnumerable<BffFrontend>? frontendsConfiguredDuringStartup = null)
     {

--- a/bff/src/Bff/DynamicFrontends/Internal/FrontendSelector.cs
+++ b/bff/src/Bff/DynamicFrontends/Internal/FrontendSelector.cs
@@ -8,12 +8,12 @@ using Microsoft.Extensions.Logging;
 
 namespace Duende.Bff.DynamicFrontends.Internal;
 
-internal class FrontendSelector(LocalFrontendStore frontendStore, ILogger<FrontendSelector> logger)
+internal class FrontendSelector(FrontendCollection frontendCollection, ILogger<FrontendSelector> logger)
 {
     public bool TrySelectFrontend(HttpRequest request, [NotNullWhen(true)] out BffFrontend? selectedFrontend)
     {
         selectedFrontend = null;
-        var frontends = frontendStore.GetAll();
+        var frontends = frontendCollection.GetAll();
 
         if (frontends.Count == 0)
         {

--- a/bff/src/Bff/DynamicFrontends/Internal/IndexHtmlHttpClient.cs
+++ b/bff/src/Bff/DynamicFrontends/Internal/IndexHtmlHttpClient.cs
@@ -23,7 +23,7 @@ internal class IndexHtmlHttpClient : IIndexHtmlClient, IAsyncDisposable
         IHttpClientFactory clientFactory,
         SelectedFrontend selectedFrontend,
         HybridCache cache,
-        LocalFrontendStore frontendStore,
+        FrontendCollection frontendCollection,
         ILogger<IndexHtmlHttpClient> logger,
         IIndexHtmlTransformer? transformer = null)
     {
@@ -33,7 +33,7 @@ internal class IndexHtmlHttpClient : IIndexHtmlClient, IAsyncDisposable
         _cache = cache;
         _transformer = transformer;
 
-        frontendStore.OnFrontendChanged += async changedFrontend =>
+        frontendCollection.OnFrontendChanged += async changedFrontend =>
         {
             try
             {

--- a/bff/test/Bff.Tests/Configuration/BffBuilderTests.cs
+++ b/bff/test/Bff.Tests/Configuration/BffBuilderTests.cs
@@ -29,7 +29,7 @@ public class BffBuilderTests
             .AddFrontends(frontend1, frontend2);
 
         var provider = services.BuildServiceProvider();
-        var frontends = provider.GetRequiredService<LocalFrontendStore>().GetAll();
+        var frontends = provider.GetRequiredService<FrontendCollection>().GetAll();
         frontends.Count.ShouldBe(2);
         frontends.ShouldContain(frontend1);
         frontends.ShouldContain(frontend2);
@@ -49,7 +49,7 @@ public class BffBuilderTests
             .AddFrontends(frontend2);
 
         var provider = services.BuildServiceProvider();
-        var frontends = provider.GetRequiredService<LocalFrontendStore>().GetAll();
+        var frontends = provider.GetRequiredService<FrontendCollection>().GetAll();
         frontends.Count.ShouldBe(2);
         frontends.ShouldContain(frontend1);
         frontends.ShouldContain(frontend2);
@@ -71,7 +71,7 @@ public class BffBuilderTests
         var services = new ServiceCollection();
         services.AddBff().LoadConfiguration(configuration);
         var provider = services.BuildServiceProvider();
-        var frontends = provider.GetRequiredService<LocalFrontendStore>().GetAll();
+        var frontends = provider.GetRequiredService<FrontendCollection>().GetAll();
         frontends.Count.ShouldBe(1);
 
         var found = frontends.First(x => x.Name == The.FrontendName);
@@ -120,7 +120,7 @@ public class BffBuilderTests
         var services = new ServiceCollection();
         services.AddBff().LoadConfiguration(configuration);
         var provider = services.BuildServiceProvider();
-        var frontends = provider.GetRequiredService<LocalFrontendStore>().GetAll();
+        var frontends = provider.GetRequiredService<FrontendCollection>().GetAll();
         frontends.Count.ShouldBe(1);
 
         var found = frontends.First(x => x.Name == The.FrontendName);
@@ -161,7 +161,7 @@ public class BffBuilderTests
         services.AddSingleton<IHttpContextAccessor, FakeHttpContextAccessor>(); // We need the http context to set the scope
         services.AddBff().LoadConfiguration(configuration);
         var provider = services.BuildServiceProvider();
-        var frontends = provider.GetRequiredService<LocalFrontendStore>().GetAll();
+        var frontends = provider.GetRequiredService<FrontendCollection>().GetAll();
         frontends.Count.ShouldBe(1);
 
         var found = frontends.First(x => x.Name == The.FrontendName);
@@ -210,7 +210,7 @@ public class BffBuilderTests
         services.AddSingleton<IHttpContextAccessor, FakeHttpContextAccessor>(); // We need the http context to set the scope
         services.AddBff().LoadConfiguration(configuration);
         var provider = services.BuildServiceProvider();
-        var frontends = provider.GetRequiredService<LocalFrontendStore>().GetAll();
+        var frontends = provider.GetRequiredService<FrontendCollection>().GetAll();
         frontends.Count.ShouldBe(1);
 
         var found = frontends.First(x => x.Name == The.FrontendName);
@@ -266,7 +266,7 @@ public class BffBuilderTests
         var services = new ServiceCollection();
         services.AddBff().LoadConfiguration(configuration);
         var provider = services.BuildServiceProvider();
-        var frontends = provider.GetRequiredService<LocalFrontendStore>().GetAll();
+        var frontends = provider.GetRequiredService<FrontendCollection>().GetAll();
         frontends.Count.ShouldBe(1);
 
         var found = frontends.First(x => x.Name == The.FrontendName);
@@ -300,7 +300,7 @@ public class BffBuilderTests
         var services = new ServiceCollection();
         services.AddBff().LoadConfiguration(configFile.Configuration);
         var provider = services.BuildServiceProvider();
-        var frontends = provider.GetRequiredService<LocalFrontendStore>().GetAll();
+        var frontends = provider.GetRequiredService<FrontendCollection>().GetAll();
         frontends.Count.ShouldBe(2);
 
         configFile.Save(new BffConfiguration()
@@ -312,7 +312,7 @@ public class BffBuilderTests
             }
         });
 
-        frontends = provider.GetRequiredService<LocalFrontendStore>().GetAll();
+        frontends = provider.GetRequiredService<FrontendCollection>().GetAll();
         frontends.Count.ShouldBe(2);
 
         var found = frontends.ToArray();
@@ -351,7 +351,7 @@ public class BffBuilderTests
         optionsCache.TryAdd("to_be_removed", new OpenIdConnectOptions());
         optionsCache.TryAdd("to_be_updated", new OpenIdConnectOptions());
 
-        var frontends = provider.GetRequiredService<LocalFrontendStore>().GetAll();
+        var frontends = provider.GetRequiredService<FrontendCollection>().GetAll();
 
         configFile.Save(new BffConfiguration()
         {
@@ -362,7 +362,7 @@ public class BffBuilderTests
             }
         });
 
-        frontends = provider.GetRequiredService<LocalFrontendStore>().GetAll();
+        frontends = provider.GetRequiredService<FrontendCollection>().GetAll();
         frontends.Count.ShouldBe(2);
 
         optionsCache.TryRemove("to_be_removed")

--- a/bff/test/Bff.Tests/MultiFrontend/FrontendSelectorTests.cs
+++ b/bff/test/Bff.Tests/MultiFrontend/FrontendSelectorTests.cs
@@ -12,7 +12,7 @@ namespace Duende.Bff.Tests.MultiFrontend;
 
 public class FrontendSelectorTests
 {
-    private readonly LocalFrontendStore _frontendStore =
+    private readonly FrontendCollection _frontendCollection =
         new(bffConfiguration: TestOptionsMonitor.Create(new BffConfiguration()));
 
     private readonly FrontendSelector _selector;
@@ -27,8 +27,8 @@ public class FrontendSelectorTests
         var loggerFactory = new LoggerFactory([testLoggerProvider]);
 
 
-        _frontendStore.AddOrUpdate(NeverMatchingFrontEnd());
-        _selector = new FrontendSelector(_frontendStore, loggerFactory.CreateLogger<FrontendSelector>());
+        _frontendCollection.AddOrUpdate(NeverMatchingFrontEnd());
+        _selector = new FrontendSelector(_frontendCollection, loggerFactory.CreateLogger<FrontendSelector>());
     }
 
     private BffFrontend NeverMatchingFrontEnd() => new BffFrontend
@@ -56,8 +56,8 @@ public class FrontendSelectorTests
     public void TryMapFrontend_Will_return_first()
     {
         // Arrange
-        _frontendStore.AddOrUpdate(CreateFrontend(BffFrontendName.Parse("test-frontend1")));
-        _frontendStore.AddOrUpdate(CreateFrontend(BffFrontendName.Parse("test-frontend2")));
+        _frontendCollection.AddOrUpdate(CreateFrontend(BffFrontendName.Parse("test-frontend1")));
+        _frontendCollection.AddOrUpdate(CreateFrontend(BffFrontendName.Parse("test-frontend2")));
 
         // Act
         var result = _selector.TrySelectFrontend(CreateHttpRequest("https://test.com"), out var selectedFrontend);
@@ -74,7 +74,7 @@ public class FrontendSelectorTests
         // Arrange
         var frontend = CreateFrontend(The.FrontendName,
             origin: Origin.Parse("https://test.com"));
-        _frontendStore.AddOrUpdate(frontend);
+        _frontendCollection.AddOrUpdate(frontend);
 
         // Act
         var result = _selector.TrySelectFrontend(CreateHttpRequest("https://test.com"), out var selectedFrontend);
@@ -91,7 +91,7 @@ public class FrontendSelectorTests
         // Arrange
         var frontend = CreateFrontend(The.FrontendName,
             path: "/path1");
-        _frontendStore.AddOrUpdate(frontend);
+        _frontendCollection.AddOrUpdate(frontend);
 
         // Act
         var request = CreateHttpRequest("https://test.com/path1/subpath");
@@ -109,7 +109,7 @@ public class FrontendSelectorTests
         // Arrange
         var frontend = CreateFrontend(The.FrontendName,
             path: "/lower_case_path");
-        _frontendStore.AddOrUpdate(frontend);
+        _frontendCollection.AddOrUpdate(frontend);
 
         // Act
         var request = CreateHttpRequest("https://test.com/LOWER_CASE_PATH/subpath");
@@ -130,7 +130,7 @@ public class FrontendSelectorTests
         var frontend = CreateFrontend(The.FrontendName,
             origin: Origin.Parse("https://test.com"),
             path: "/path1");
-        _frontendStore.AddOrUpdate(frontend);
+        _frontendCollection.AddOrUpdate(frontend);
 
         // Act
         var request = CreateHttpRequest("https://test.com/path1/subpath");
@@ -148,7 +148,7 @@ public class FrontendSelectorTests
         // Arrange
         var frontend = CreateFrontend(The.FrontendName,
             path: "/path1");
-        _frontendStore.AddOrUpdate(frontend);
+        _frontendCollection.AddOrUpdate(frontend);
 
         // Act
         var request = CreateHttpRequest("https://any-domain.com/path1/subpath");
@@ -171,8 +171,8 @@ public class FrontendSelectorTests
             origin: Origin.Parse("https://test.com"),
             path: "/path1");
 
-        _frontendStore.AddOrUpdate(frontendGeneral);
-        _frontendStore.AddOrUpdate(frontendSpecific);
+        _frontendCollection.AddOrUpdate(frontendGeneral);
+        _frontendCollection.AddOrUpdate(frontendSpecific);
 
         // Act
         var request = CreateHttpRequest("https://test.com/path1/subpath");
@@ -194,8 +194,8 @@ public class FrontendSelectorTests
         var frontendSpecific = CreateFrontend(BffFrontendName.Parse("specific-frontend"),
             path: "/path/subpath");
 
-        _frontendStore.AddOrUpdate(frontendGeneral);
-        _frontendStore.AddOrUpdate(frontendSpecific);
+        _frontendCollection.AddOrUpdate(frontendGeneral);
+        _frontendCollection.AddOrUpdate(frontendSpecific);
 
         // Act
         var request = CreateHttpRequest("https://test.com/path/subpath/detail");
@@ -215,7 +215,7 @@ public class FrontendSelectorTests
             origin: Origin.Parse("https://test.com"),
             path: "/path1");
 
-        _frontendStore.AddOrUpdate(frontend);
+        _frontendCollection.AddOrUpdate(frontend);
 
         // Act
         var request = CreateHttpRequest("https://different.com/different-path");
@@ -235,8 +235,8 @@ public class FrontendSelectorTests
 
         var defaultFrontend = CreateFrontend(BffFrontendName.Parse("default-frontend"));
 
-        _frontendStore.AddOrUpdate(specificFrontend);
-        _frontendStore.AddOrUpdate(defaultFrontend);
+        _frontendCollection.AddOrUpdate(specificFrontend);
+        _frontendCollection.AddOrUpdate(defaultFrontend);
 
         // Act
         var request = CreateHttpRequest("https://different.com");

--- a/bff/test/Bff.Tests/MultiFrontend/LocalFrontEndStoreTests.cs
+++ b/bff/test/Bff.Tests/MultiFrontend/LocalFrontEndStoreTests.cs
@@ -34,10 +34,10 @@ public class LocalFrontEndStoreTests
         result.ShouldBeEquivalentTo(_frontendsConfiguredDuringStartup.AsReadOnly());
     }
 
-    private LocalFrontendStore BuildCache()
+    private FrontendCollection BuildCache()
     {
         // No longer inject OptionsCache
-        var cache = new LocalFrontendStore(_bffConfigurationOptionsMonitor, _frontendsConfiguredDuringStartup);
+        var cache = new FrontendCollection(_bffConfigurationOptionsMonitor, _frontendsConfiguredDuringStartup);
         return cache;
     }
 

--- a/bff/test/Bff.Tests/PublicApiVerificationTests.VerifyPublicApi_Bff.verified.txt
+++ b/bff/test/Bff.Tests/PublicApiVerificationTests.VerifyPublicApi_Bff.verified.txt
@@ -440,6 +440,12 @@ namespace Duende.Bff.DynamicFrontends
         public Duende.Bff.DynamicFrontends.Origin? MatchingOrigin { get; init; }
         public string? MatchingPath { get; init; }
     }
+    public interface IFrontendCollection
+    {
+        void AddOrUpdate(Duende.Bff.DynamicFrontends.BffFrontend frontend);
+        System.Collections.Generic.IReadOnlyList<Duende.Bff.DynamicFrontends.BffFrontend> GetAll();
+        void Remove(Duende.Bff.DynamicFrontends.BffFrontendName frontendName);
+    }
     public interface IIndexHtmlClient
     {
         System.Threading.Tasks.Task<string?> GetIndexHtmlAsync(System.Threading.CancellationToken ct = default);

--- a/bff/test/Bff.Tests/TestInfra/BffTestHost.cs
+++ b/bff/test/Bff.Tests/TestInfra/BffTestHost.cs
@@ -73,7 +73,7 @@ public class BffTestHost(TestHostContext context) : TestHost(context, new Uri("h
         private set => _browserClient = value;
     }
 
-    public void AddOrUpdateFrontend(BffFrontend frontend) => Resolve<LocalFrontendStore>().AddOrUpdate(frontend);
+    public void AddOrUpdateFrontend(BffFrontend frontend) => Resolve<FrontendCollection>().AddOrUpdate(frontend);
 }
 
 public class CallbackForwarderHttpClientFactory(Func<ForwarderHttpClientContext, HttpMessageInvoker> callback)


### PR DESCRIPTION
**What issue does this PR address?**
This PR (re) exposes the capability for implementors of this library to add / remove frontends at runtime. Also, it felt better to call this FrontendCollection, which I think more clearly indicates that it doesn't persist any changes made to it. 

I had several options to perform this change:

1. Make the LocalFrontendStore sealed and public with an internal constructor. You only get an add / remove method publicly. 
2. Re-introduce an interface, but don't allow you to override it in the container. Might be easier for testing. 
3. Allow you to register something that's observable. For example an ObservableCollection<Frontend>. 

I decided to go for option 2. 

Initially, the simplest option would be to go for option 1. However, after consideration, if our users want to create their own database backing stores, then they would not have a good way to unit test this logic without wiring up the entire system. The internal constructor would prevent them from creating their own collection. 

So, option 2 seems to be the simplest. 
Note, internally I'm still directly relying on the frontend collection everywhere. 

**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
