### PR TITLE
Fix the sliding cookie configuration when using frontend tests

### DIFF
--- a/bff/src/Bff/BffBuilder.cs
+++ b/bff/src/Bff/BffBuilder.cs
@@ -97,7 +97,6 @@ public sealed class BffBuilder(IServiceCollection services)
         // .AddRemoteApis() from BFF.Yarp
         Services.TryAddSingleton<IRemoteRouteHandler, RemoteRouteHandlingDisabled>();
 
-
         return this;
     }
 

--- a/bff/src/Bff/DynamicFrontends/BffConfigureCookieOptions.cs
+++ b/bff/src/Bff/DynamicFrontends/BffConfigureCookieOptions.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Options;
 namespace Duende.Bff.DynamicFrontends;
 
 internal class BffConfigureCookieOptions(
+    TimeProvider timeProvider,
     IOptions<BffConfiguration> bffConfiguration,
     IOptions<BffOptions> bffOptions,
     SelectedFrontend selectedFrontend
@@ -20,6 +21,9 @@ internal class BffConfigureCookieOptions(
 
     public void Configure(string? name, CookieAuthenticationOptions options)
     {
+        // Normally, this is added by AuthenticationBuilder.PostConfigureAuthenticationSchemeOptions
+        // but this is private API, so we need to do it ourselves.
+        options.TimeProvider = timeProvider;
         if (selectedFrontend.TryGet(out var frontEnd))
         {
 

--- a/bff/src/Bff/DynamicFrontends/BffConfigureOpenIdConnectOptions.cs
+++ b/bff/src/Bff/DynamicFrontends/BffConfigureOpenIdConnectOptions.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Options;
 namespace Duende.Bff.DynamicFrontends;
 
 internal class BffConfigureOpenIdConnectOptions(
+    TimeProvider timeProvider,
     SelectedFrontend selectedFrontend,
     IOptions<BffConfiguration> bffConfiguration,
     IOptions<BffOptions> bffOptions
@@ -17,6 +18,9 @@ internal class BffConfigureOpenIdConnectOptions(
 
     public void Configure(string? name, OpenIdConnectOptions options)
     {
+        // Normally, this is added by AuthenticationBuilder.PostConfigureAuthenticationSchemeOptions
+        // but this is private API, so we need to do it ourselves.
+        options.TimeProvider = timeProvider;
         var defaultOptionsValue = bffOptions.Value;
         var bffConfigurationValue = bffConfiguration.Value;
 

--- a/bff/src/Bff/SessionManagement/Configuration/PostConfigureApplicationCookieTicketStore.cs
+++ b/bff/src/Bff/SessionManagement/Configuration/PostConfigureApplicationCookieTicketStore.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
+using Duende.Bff.DynamicFrontends;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Http;
@@ -12,6 +13,7 @@ namespace Duende.Bff.SessionManagement.Configuration;
 /// Cookie configuration for the user session plumbing
 /// </summary>
 internal class PostConfigureApplicationCookieTicketStore(
+    SelectedFrontend selectedFrontend,
     IHttpContextAccessor httpContextAccessor,
     IOptions<AuthenticationOptions> options)
     : IPostConfigureOptions<CookieAuthenticationOptions>
@@ -22,7 +24,9 @@ internal class PostConfigureApplicationCookieTicketStore(
     /// <inheritdoc />
     public void PostConfigure(string? name, CookieAuthenticationOptions options)
     {
-        if (name == _scheme)
+        var isDefaultScheme = name == _scheme;
+        var isForBffFrontend = selectedFrontend.TryGet(out var frontend) && name == frontend.CookieSchemeName;
+        if (isDefaultScheme || isForBffFrontend)
         {
             options.SessionStore = new TicketStoreShim(httpContextAccessor);
         }

--- a/bff/src/Bff/SessionManagement/Configuration/PostConfigureSlidingExpirationCheck.cs
+++ b/bff/src/Bff/SessionManagement/Configuration/PostConfigureSlidingExpirationCheck.cs
@@ -2,6 +2,7 @@
 // See LICENSE in the project root for license information.
 
 using Duende.Bff.Configuration;
+using Duende.Bff.DynamicFrontends;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.Extensions.Logging;
@@ -13,6 +14,7 @@ namespace Duende.Bff.SessionManagement.Configuration;
 /// Cookie configuration to suppress sliding the cookie on the ~/bff/user endpoint if requested.
 /// </summary>
 internal class PostConfigureSlidingExpirationCheck(
+    SelectedFrontend selectedFrontend,
     IOptions<BffOptions> bffOptions,
     IOptions<AuthenticationOptions> authOptions,
     ILogger<PostConfigureSlidingExpirationCheck> logger)
@@ -24,7 +26,11 @@ internal class PostConfigureSlidingExpirationCheck(
     /// <inheritdoc />
     public void PostConfigure(string? name, CookieAuthenticationOptions options)
     {
-        if (name == _scheme)
+
+        var isDefaultScheme = name == _scheme;
+        var isForBffFrontend = selectedFrontend.TryGet(out var frontend) && name == frontend.CookieSchemeName;
+
+        if (isDefaultScheme || isForBffFrontend)
         {
             options.Events.OnCheckSlidingExpiration = CreateCallback(options.Events.OnCheckSlidingExpiration);
         }

--- a/bff/test/Bff.Tests/TestInfra/TestData.cs
+++ b/bff/test/Bff.Tests/TestInfra/TestData.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using Duende.Bff.AccessTokenManagement;
 using Duende.Bff.DynamicFrontends;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.Extensions.Time.Testing;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
 
@@ -41,6 +42,11 @@ public class TestData
     public TimeSpan? MaxAge = TimeSpan.FromDays(10);
     public RequiredTokenType RequiredTokenType = RequiredTokenType.UserOrClient;
     public Uri CallbackPath => new Uri("/" + PropertyName(), UriKind.Relative);
+
+    public FakeTimeProvider Clock = new FakeTimeProvider(DateTimeOffset.UtcNow);
+
+    public DateTimeOffset CurrentTime => Clock.GetUtcNow();
+
     public Type TokenRetrieverType = typeof(TestTokenRetriever);
 
     public Resource Resource = Resource.Parse(PropertyName());

--- a/bff/test/Bff.Tests/TestInfra/TestDataBuilder.cs
+++ b/bff/test/Bff.Tests/TestInfra/TestDataBuilder.cs
@@ -4,6 +4,7 @@
 using System.Security.Claims;
 using Duende.Bff.Configuration;
 using Duende.Bff.DynamicFrontends;
+using Duende.Bff.SessionManagement.SessionStore;
 using Duende.IdentityModel;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Yarp.ReverseProxy.Configuration;
@@ -168,4 +169,6 @@ public class TestDataBuilder(TestData the)
             SameSite = SameSiteMode.Strict
         },
     };
+
+    public UserSessionsFilter UserSessionsFilter() => new() { SubjectId = The.Sub };
 }

--- a/bff/test/Bff.Tests/TestInfra/TestHost.cs
+++ b/bff/test/Bff.Tests/TestInfra/TestHost.cs
@@ -75,6 +75,8 @@ public class TestHost(TestHostContext context, Uri baseAddress) : IAsyncDisposab
 
     protected virtual void ConfigureServices(IServiceCollection services)
     {
+        services.AddSingleton<TimeProvider>(The.Clock);
+
         services.AddAuthentication();
         services.AddAuthorization();
         services.AddRouting();


### PR DESCRIPTION
**What issue does this PR address?**
The sliding cookie tests were still in the 'old' testing style.

Turns out that the new frontend style of wiring things wasn't working for sliding cookies. So now the tests explicitly run the 'old' and the 'new' style of wiring things up. This will likely be the pattern I'll use for future tests also, because I want to make sure you can still use V3 style (explicit auth wireup) and v4 style (automatic wireup)

Also, it turns out that, if you do AddScheme, aspnet core also adds a specific post configuration middleware:

https://github.com/dotnet/aspnetcore/blob/main/src/Security/Authentication/Core/src/AuthenticationBuilder.cs#L52

We have to do the same in our dynamic scheme wireup. (basically, it only adds the timeprovider, but still, quite important)

**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
