### PR TITLE
Slow down cleanup job frequency in development

### DIFF
--- a/identity-server/hosts/EntityFramework-dotnet9/IdentityServerExtensions.cs
+++ b/identity-server/hosts/EntityFramework-dotnet9/IdentityServerExtensions.cs
@@ -26,7 +26,6 @@ internal static class IdentityServerExtensions
             options.Authentication.CoordinateClientLifetimesWithUserSession = true;
             options.ServerSideSessions.UserDisplayNameClaimType = JwtClaimTypes.Name;
             options.ServerSideSessions.RemoveExpiredSessions = true;
-            options.ServerSideSessions.RemoveExpiredSessionsFrequency = TimeSpan.FromSeconds(10);
             options.ServerSideSessions.ExpiredSessionsTriggerBackchannelLogout = true;
             options.Endpoints.EnablePushedAuthorizationEndpoint = true;
 
@@ -65,7 +64,7 @@ internal static class IdentityServerExtensions
                 // this enables automatic token cleanup. this is optional.
                 options.EnableTokenCleanup = true;
                 options.RemoveConsumedTokens = true;
-                options.TokenCleanupInterval = 10; // interval in seconds
+                options.TokenCleanupInterval = 180; // interval in seconds
             })
             .AddAppAuthRedirectUriValidator()
             .AddServerSideSessions()

--- a/identity-server/hosts/EntityFramework/IdentityServerExtensions.cs
+++ b/identity-server/hosts/EntityFramework/IdentityServerExtensions.cs
@@ -26,7 +26,6 @@ internal static class IdentityServerExtensions
             options.Authentication.CoordinateClientLifetimesWithUserSession = true;
             options.ServerSideSessions.UserDisplayNameClaimType = JwtClaimTypes.Name;
             options.ServerSideSessions.RemoveExpiredSessions = true;
-            options.ServerSideSessions.RemoveExpiredSessionsFrequency = TimeSpan.FromSeconds(10);
             options.ServerSideSessions.ExpiredSessionsTriggerBackchannelLogout = true;
             options.Endpoints.EnablePushedAuthorizationEndpoint = true;
 
@@ -65,7 +64,6 @@ internal static class IdentityServerExtensions
                 // this enables automatic token cleanup. this is optional.
                 options.EnableTokenCleanup = true;
                 options.RemoveConsumedTokens = true;
-                options.TokenCleanupInterval = 10; // interval in seconds
             })
             .AddAppAuthRedirectUriValidator()
             .AddServerSideSessions()


### PR DESCRIPTION
There is no need to run the session and grant cleanup jobs every few seconds unless you are working on those features specifically. The jobs generate noise in the logs when they are run too frequently.
