### PR TITLE
Set HTTP activity name on routing

### DIFF
--- a/identity-server/CHANGELOG.md
+++ b/identity-server/CHANGELOG.md
@@ -16,6 +16,8 @@
   - The default implementation, `DefaultUiLocalsService.cs`, delegates to the `CookieRequestCultureProvider` if it is present and any of the values passed in the
 `ui_locales` parameter match a supported UI culture.
   - If the default implementation does not meet your needs, `IUiLocalesService` can be implemented and registered with DI.
+- Set the DisplayName of the activity associated with the incoming HttpRequest when IdentityServer routes are matched by @josephdecock
+  This makes the IdentityServer route names appear in OTel traces.
 
 ## Bug Fixes
 - Reject Pushed Authorization Requests with parameters duplicated in a JAR by @wcabus

--- a/identity-server/src/IdentityServer/Hosting/IdentityServerMiddleware.cs
+++ b/identity-server/src/IdentityServer/Hosting/IdentityServerMiddleware.cs
@@ -10,6 +10,7 @@ using Duende.IdentityServer.Logging;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Services;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -101,6 +102,12 @@ public class IdentityServerMiddleware
                 Telemetry.Metrics.IncreaseActiveRequests(endpointType, requestPath);
                 try
                 {
+                    var httpActivity = context.Features.Get<IHttpActivityFeature>();
+                    if (httpActivity != null)
+                    {
+                        httpActivity.Activity.DisplayName = $"{context.Request.Method} {requestPath}";
+                    }
+
                     using var activity = Tracing.BasicActivitySource.StartActivity("IdentityServerProtocolRequest");
                     activity?.SetTag(Tracing.Properties.EndpointType, endpointType);
 

--- a/identity-server/src/IdentityServer/Hosting/IdentityServerMiddleware.cs
+++ b/identity-server/src/IdentityServer/Hosting/IdentityServerMiddleware.cs
@@ -97,7 +97,9 @@ public class IdentityServerMiddleware
             if (endpoint != null)
             {
                 var endpointType = endpoint.GetType().FullName;
-                var requestPath = context.Request.Path.ToString();
+                var requestPath = context.Items.TryGetValue(MutualTlsEndpointMiddleware.OriginalPath, out var item) ?
+                    item?.ToString() :
+                    context.Request.Path.ToString();
 
                 Telemetry.Metrics.IncreaseActiveRequests(endpointType, requestPath);
                 try

--- a/identity-server/src/IdentityServer/Hosting/MutualTlsEndpointMiddleware.cs
+++ b/identity-server/src/IdentityServer/Hosting/MutualTlsEndpointMiddleware.cs
@@ -17,6 +17,8 @@ namespace Duende.IdentityServer.Hosting;
 /// </summary>
 public class MutualTlsEndpointMiddleware
 {
+    public const string OriginalPath = "Duende.IdentityServer.MutualTlsEndpointMiddleware.OriginalPath";
+
     private readonly SanitizedLogger<MutualTlsEndpointMiddleware> _sanitizedLogger;
     private readonly RequestDelegate _next;
     private readonly IdentityServerOptions _options;
@@ -111,6 +113,11 @@ public class MutualTlsEndpointMiddleware
 
                 _sanitizedLogger.LogDebug("Rewriting MTLS request from: {oldPath} to: {newPath}",
                     context.Request.Path.ToString(), path);
+
+                // Capture the original path before any modifications. This is useful in other parts of the
+                // pipeline, that may want to include this context.
+                context.Items[OriginalPath] = context.Request.Path;
+
                 context.Request.Path = path;
             }
         }

--- a/identity-server/test/IdentityServer.IntegrationTests/Common/MockHttpActivityFeature.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Common/MockHttpActivityFeature.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using System.Diagnostics;
+using Microsoft.AspNetCore.Http.Features;
+
+namespace IntegrationTests.Common;
+
+/// <summary>
+/// A simple implementation of <see cref="IHttpActivityFeature"/> for testing purposes.
+/// </summary>
+public class MockHttpActivityFeature : IHttpActivityFeature
+{
+    public Activity Activity { get; set; } = new("TestRequest");
+}

--- a/identity-server/test/IdentityServer.IntegrationTests/Common/MockTestActivityMiddleware.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Common/MockTestActivityMiddleware.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using System.Diagnostics;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+
+namespace IntegrationTests.Common;
+
+/// <summary>
+/// A middleware that adds a <see cref="MockHttpActivityFeature"/> to the pipeline and makes it available for
+/// inspection.
+/// </summary>
+public class MockTestActivityMiddleware
+{
+    public Activity CapturedActivity { get; private set; }
+
+    public Task Handle(HttpContext context, RequestDelegate next)
+    {
+        var activity = new Activity("TestRequest");
+        var feature = new MockHttpActivityFeature { Activity = activity };
+        context.Features.Set<IHttpActivityFeature>(feature);
+
+        activity.Start();
+        CapturedActivity = activity;
+
+        try
+        {
+            return next(context);
+        }
+        finally
+        {
+            activity.Stop();
+        }
+    }
+}


### PR DESCRIPTION
Set the http activity's display name when IdentityServer routes to it. This makes OTel traces easier to read because the incoming HTTP request will display where it is headed.