### PR TITLE
Assembly Info Diagnostic Entry Tweaks

### DIFF
--- a/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/AssemblyInfoDiagnosticEntry.cs
+++ b/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/AssemblyInfoDiagnosticEntry.cs
@@ -9,6 +9,27 @@ namespace Duende.IdentityServer.Licensing.V2.Diagnostics.DiagnosticEntries;
 
 internal class AssemblyInfoDiagnosticEntry : IDiagnosticEntry
 {
+    private readonly IReadOnlyList<Predicate<string>> _defaultInclusions =
+    [
+        x => x.StartsWith("Duende."),
+        x => x == "Microsoft.AspNetCore",
+        x => x.StartsWith("Microsoft.AspNetCore.Authentication."),
+        x => x.StartsWith("Microsoft.IdentityModel."),
+        x => x.StartsWith("System.IdentityModel."),
+        x => x.StartsWith("System.IdentityModel"),
+        x => x.StartsWith("Microsoft.EntityFrameworkCore"),
+        x => x.StartsWith("Rsk"),
+        x => x.StartsWith("Skoruba.IdentityServer"),
+        x => x.StartsWith("Skoruba.Duende"),
+        x => x.StartsWith("Npgsql"),
+        x => x.StartsWith("Azure"),
+        x => x.StartsWith("Microsoft.Azure")
+    ];
+
+    private readonly IReadOnlyList<Predicate<string>> _inclusions;
+
+    public AssemblyInfoDiagnosticEntry(IReadOnlyList<Predicate<string>> inclusions = null) => _inclusions = inclusions ?? _defaultInclusions;
+
     public Task WriteAsync(Utf8JsonWriter writer)
     {
         var assemblies = GetAssemblyInfo();
@@ -16,7 +37,7 @@ internal class AssemblyInfoDiagnosticEntry : IDiagnosticEntry
         writer.WriteNumber("AssemblyCount", assemblies.Count);
 
         writer.WriteStartArray("Assemblies");
-        foreach (var assembly in assemblies)
+        foreach (var assembly in assemblies.Where(assembly => _inclusions.Any(predicate => predicate(assembly.FullName))))
         {
             writer.WriteStartObject();
             writer.WriteString("Name", assembly.GetName().Name);

--- a/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/AssemblyInfoDiagnosticEntry.cs
+++ b/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/AssemblyInfoDiagnosticEntry.cs
@@ -2,6 +2,7 @@
 // See LICENSE in the project root for license information.
 
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Runtime.Loader;
 using System.Text.Json;
 
@@ -34,6 +35,7 @@ internal class AssemblyInfoDiagnosticEntry : IDiagnosticEntry
     {
         var assemblies = GetAssemblyInfo();
         writer.WriteStartObject("AssemblyInfo");
+        writer.WriteString("DotnetVersion", RuntimeInformation.FrameworkDescription);
         writer.WriteNumber("AssemblyCount", assemblies.Count);
 
         writer.WriteStartArray("Assemblies");

--- a/identity-server/test/IdentityServer.UnitTests/Licensing/v2/DiagnosticEntries/AssemblyInfoDiagnosticEntryTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Licensing/v2/DiagnosticEntries/AssemblyInfoDiagnosticEntryTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
+using System.Runtime.InteropServices;
 using System.Text.Json;
 using Duende.IdentityServer.Licensing.V2.Diagnostics.DiagnosticEntries;
 
@@ -34,5 +35,16 @@ public class AssemblyInfoDiagnosticEntryTests
         var assemblyInfo = result.RootElement.GetProperty("AssemblyInfo");
         var assemblies = assemblyInfo.GetProperty("Assemblies").EnumerateArray();
         assemblies.ShouldAllBe(x => x.GetProperty("Name").GetString().StartsWith("Duende."));
+    }
+
+    [Fact]
+    public async Task Should_Include_Dotnet_Version()
+    {
+        var subject = new AssemblyInfoDiagnosticEntry();
+
+        var result = await DiagnosticEntryTestHelper.WriteEntryToJson(subject);
+
+        var assemblyInfo = result.RootElement.GetProperty("AssemblyInfo");
+        assemblyInfo.GetProperty("DotnetVersion").GetString().ShouldBe(RuntimeInformation.FrameworkDescription);
     }
 }

--- a/identity-server/test/IdentityServer.UnitTests/Licensing/v2/DiagnosticEntries/AssemblyInfoDiagnosticEntryTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Licensing/v2/DiagnosticEntries/AssemblyInfoDiagnosticEntryTests.cs
@@ -9,7 +9,7 @@ namespace IdentityServer.UnitTests.Licensing.V2.DiagnosticEntries;
 public class AssemblyInfoDiagnosticEntryTests
 {
     [Fact]
-    public async Task WriteAsync_ShouldWriteAssemblyInfo()
+    public async Task Should_Write_Assembly_Info()
     {
         var subject = new AssemblyInfoDiagnosticEntry();
 
@@ -22,5 +22,17 @@ public class AssemblyInfoDiagnosticEntryTests
         var firstEntry = assemblies.EnumerateArray().First();
         firstEntry.GetProperty("Name").ValueKind.ShouldBe(JsonValueKind.String);
         firstEntry.GetProperty("Version").ValueKind.ShouldBe(JsonValueKind.String);
+    }
+
+    [Fact]
+    public async Task Should_Honor_Assembly_Filter()
+    {
+        var subject = new AssemblyInfoDiagnosticEntry([x => x.StartsWith("Duende.")]);
+
+        var result = await DiagnosticEntryTestHelper.WriteEntryToJson(subject);
+
+        var assemblyInfo = result.RootElement.GetProperty("AssemblyInfo");
+        var assemblies = assemblyInfo.GetProperty("Assemblies").EnumerateArray();
+        assemblies.ShouldAllBe(x => x.GetProperty("Name").GetString().StartsWith("Duende."));
     }
 }


### PR DESCRIPTION
**What issue does this PR address?**
* Adds filtering to the assembly info diagnostic entry to restrict the list included to the most relevant assemblies for support
* Adds dotnet version to the assembly info diagnostic entry


**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
