### PR TITLE
Remove assemblyCount from diagnostics

### DIFF
--- a/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/AssemblyInfoDiagnosticEntry.cs
+++ b/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/AssemblyInfoDiagnosticEntry.cs
@@ -44,7 +44,6 @@ internal class AssemblyInfoDiagnosticEntry : IDiagnosticEntry
         var assemblies = GetAssemblyInfo();
         writer.WriteStartObject("AssemblyInfo");
         writer.WriteString("DotnetVersion", RuntimeInformation.FrameworkDescription);
-        writer.WriteNumber("AssemblyCount", assemblies.Count);
 
         writer.WriteStartArray("Assemblies");
         foreach (var assembly in assemblies.Where(assembly => assembly.GetName().Name != null &&

--- a/identity-server/test/IdentityServer.UnitTests/Licensing/v2/DiagnosticEntries/AssemblyInfoDiagnosticEntryTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Licensing/v2/DiagnosticEntries/AssemblyInfoDiagnosticEntryTests.cs
@@ -17,7 +17,6 @@ public class AssemblyInfoDiagnosticEntryTests
         var result = await DiagnosticEntryTestHelper.WriteEntryToJson(subject);
 
         var assemblyInfo = result.RootElement.GetProperty("AssemblyInfo");
-        assemblyInfo.GetProperty("AssemblyCount").ValueKind.ShouldBe(JsonValueKind.Number);
         var assemblies = assemblyInfo.GetProperty("Assemblies");
         assemblies.ValueKind.ShouldBe(JsonValueKind.Array);
         var firstEntry = assemblies.EnumerateArray().First();


### PR DESCRIPTION
We're now filtering the loaded assemblies, so the number doesn't match the list in the diagnostics. Doesn't seem to be much diagnostic value in either number, so I'm just removing it.
