### PR TITLE
Remove pop from the names of token counts in diagnostics

### DIFF
--- a/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/TokenIssueCountDiagnosticEntry.cs
+++ b/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/TokenIssueCountDiagnosticEntry.cs
@@ -13,10 +13,10 @@ internal class TokenIssueCountDiagnosticEntry : IDiagnosticEntry
     private long _jwtTokenIssued;
     private long _referenceTokenIssued;
     private long _refreshTokenIssued;
-    private long _jwtPoPDPoPTokenIssued;
-    private long _referencePoPDPoPTokenIssued;
-    private long _jwtPoPmTLSTokenIssued;
-    private long _referencePoPmTLSTokenIssued;
+    private long _jwtDPoPTokenIssued;
+    private long _referenceDPoPTokenIssued;
+    private long _jwtMTLSTokenIssued;
+    private long _referenceMTLSTokenIssued;
     private long _idTokenIssued;
 
     private long _implicitGrantTypeFlows;
@@ -53,10 +53,10 @@ internal class TokenIssueCountDiagnosticEntry : IDiagnosticEntry
 
         writer.WriteNumber("Jwt", _jwtTokenIssued);
         writer.WriteNumber("Reference", _referenceTokenIssued);
-        writer.WriteNumber("JwtPoPDPoP", _jwtPoPDPoPTokenIssued);
-        writer.WriteNumber("ReferencePoPDPoP", _referencePoPDPoPTokenIssued);
-        writer.WriteNumber("JwtPoPmTLS", _jwtPoPmTLSTokenIssued);
-        writer.WriteNumber("ReferencePoPmTLS", _referencePoPmTLSTokenIssued);
+        writer.WriteNumber("JwtDPoP", _jwtDPoPTokenIssued);
+        writer.WriteNumber("ReferenceDPoP", _referenceDPoPTokenIssued);
+        writer.WriteNumber("JwtMTLS", _jwtMTLSTokenIssued);
+        writer.WriteNumber("ReferenceMTLS", _referenceMTLSTokenIssued);
         writer.WriteNumber("Refresh", _refreshTokenIssued);
         writer.WriteNumber("Id", _idTokenIssued);
         writer.WriteNumber(GrantType.Implicit, _implicitGrantTypeFlows);
@@ -128,16 +128,16 @@ internal class TokenIssueCountDiagnosticEntry : IDiagnosticEntry
                     Interlocked.Increment(ref _referenceTokenIssued);
                     break;
                 case ProofType.DPoP when accessTokenType == AccessTokenType.Jwt:
-                    Interlocked.Increment(ref _jwtPoPDPoPTokenIssued);
+                    Interlocked.Increment(ref _jwtDPoPTokenIssued);
                     break;
                 case ProofType.DPoP when accessTokenType == AccessTokenType.Reference:
-                    Interlocked.Increment(ref _referencePoPDPoPTokenIssued);
+                    Interlocked.Increment(ref _referenceDPoPTokenIssued);
                     break;
                 case ProofType.ClientCertificate when accessTokenType == AccessTokenType.Jwt:
-                    Interlocked.Increment(ref _jwtPoPmTLSTokenIssued);
+                    Interlocked.Increment(ref _jwtMTLSTokenIssued);
                     break;
                 case ProofType.ClientCertificate when accessTokenType == AccessTokenType.Reference:
-                    Interlocked.Increment(ref _referencePoPmTLSTokenIssued);
+                    Interlocked.Increment(ref _referenceMTLSTokenIssued);
                     break;
             }
         }

--- a/identity-server/test/IdentityServer.UnitTests/Licensing/v2/DiagnosticEntries/TokenIssueCountDiagnosticEntryTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Licensing/v2/DiagnosticEntries/TokenIssueCountDiagnosticEntryTests.cs
@@ -38,7 +38,7 @@ public class TokenIssueCountDiagnosticEntryTests
 
         var result = await DiagnosticEntryTestHelper.WriteEntryToJson(_subject);
 
-        result.RootElement.GetProperty("TokenIssueCounts").GetProperty("JwtPoPDPoP").GetInt64().ShouldBe(1);
+        result.RootElement.GetProperty("TokenIssueCounts").GetProperty("JwtDPoP").GetInt64().ShouldBe(1);
     }
 
     [Fact]
@@ -48,7 +48,7 @@ public class TokenIssueCountDiagnosticEntryTests
 
         var result = await DiagnosticEntryTestHelper.WriteEntryToJson(_subject);
 
-        result.RootElement.GetProperty("TokenIssueCounts").GetProperty("ReferencePoPDPoP").GetInt64().ShouldBe(1);
+        result.RootElement.GetProperty("TokenIssueCounts").GetProperty("ReferenceDPoP").GetInt64().ShouldBe(1);
     }
 
     [Fact]
@@ -58,7 +58,7 @@ public class TokenIssueCountDiagnosticEntryTests
 
         var result = await DiagnosticEntryTestHelper.WriteEntryToJson(_subject);
 
-        result.RootElement.GetProperty("TokenIssueCounts").GetProperty("JwtPoPmTLS").GetInt64().ShouldBe(1);
+        result.RootElement.GetProperty("TokenIssueCounts").GetProperty("JwtMTLS").GetInt64().ShouldBe(1);
     }
 
     [Fact]
@@ -68,7 +68,7 @@ public class TokenIssueCountDiagnosticEntryTests
 
         var result = await DiagnosticEntryTestHelper.WriteEntryToJson(_subject);
 
-        result.RootElement.GetProperty("TokenIssueCounts").GetProperty("ReferencePoPmTLS").GetInt64().ShouldBe(1);
+        result.RootElement.GetProperty("TokenIssueCounts").GetProperty("ReferenceMTLS").GetInt64().ShouldBe(1);
     }
 
     [Fact]
@@ -101,7 +101,7 @@ public class TokenIssueCountDiagnosticEntryTests
 
         var tokenIssueCounts = result.RootElement.GetProperty("TokenIssueCounts");
         tokenIssueCounts.GetProperty("Jwt").GetInt64().ShouldBe(1);
-        tokenIssueCounts.GetProperty("JwtPoPDPoP").GetInt64().ShouldBe(1);
+        tokenIssueCounts.GetProperty("JwtDPoP").GetInt64().ShouldBe(1);
         tokenIssueCounts.GetProperty("Refresh").GetInt64().ShouldBe(1);
     }
 
@@ -115,10 +115,10 @@ public class TokenIssueCountDiagnosticEntryTests
         var tokenIssueCounts = result.RootElement.GetProperty("TokenIssueCounts");
         tokenIssueCounts.GetProperty("Jwt").GetInt64().ShouldBe(0);
         tokenIssueCounts.GetProperty("Reference").GetInt64().ShouldBe(0);
-        tokenIssueCounts.GetProperty("JwtPoPDPoP").GetInt64().ShouldBe(0);
-        tokenIssueCounts.GetProperty("JwtPoPmTLS").GetInt64().ShouldBe(0);
-        tokenIssueCounts.GetProperty("ReferencePoPDPoP").GetInt64().ShouldBe(0);
-        tokenIssueCounts.GetProperty("ReferencePoPmTLS").GetInt64().ShouldBe(0);
+        tokenIssueCounts.GetProperty("JwtDPoP").GetInt64().ShouldBe(0);
+        tokenIssueCounts.GetProperty("JwtMTLS").GetInt64().ShouldBe(0);
+        tokenIssueCounts.GetProperty("ReferenceDPoP").GetInt64().ShouldBe(0);
+        tokenIssueCounts.GetProperty("ReferenceMTLS").GetInt64().ShouldBe(0);
         tokenIssueCounts.GetProperty("Refresh").GetInt64().ShouldBe(0);
         tokenIssueCounts.GetProperty("Id").GetInt64().ShouldBe(0);
     }
@@ -190,10 +190,10 @@ public class TokenIssueCountDiagnosticEntryTests
         var tokenIssueCounts = result.RootElement.GetProperty("TokenIssueCounts");
         tokenIssueCounts.GetProperty("Jwt").GetInt64().ShouldBe(0);
         tokenIssueCounts.GetProperty("Reference").GetInt64().ShouldBe(0);
-        tokenIssueCounts.GetProperty("JwtPoPDPoP").GetInt64().ShouldBe(0);
-        tokenIssueCounts.GetProperty("JwtPoPmTLS").GetInt64().ShouldBe(0);
-        tokenIssueCounts.GetProperty("ReferencePoPDPoP").GetInt64().ShouldBe(0);
-        tokenIssueCounts.GetProperty("ReferencePoPmTLS").GetInt64().ShouldBe(0);
+        tokenIssueCounts.GetProperty("JwtDPoP").GetInt64().ShouldBe(0);
+        tokenIssueCounts.GetProperty("JwtMTLS").GetInt64().ShouldBe(0);
+        tokenIssueCounts.GetProperty("ReferenceDPoP").GetInt64().ShouldBe(0);
+        tokenIssueCounts.GetProperty("ReferenceMTLS").GetInt64().ShouldBe(0);
         tokenIssueCounts.GetProperty("Refresh").GetInt64().ShouldBe(0);
     }
 


### PR DESCRIPTION
Minor rename but I thought "PoPDPoP" was kinda silly...