### PR TITLE
remove custom signin-bff url

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,7 +18,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.Certificate" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.16" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.Certificate" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.3" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.1" />

--- a/bff/hosts/Hosts.IdentityServer/Config.cs
+++ b/bff/hosts/Hosts.IdentityServer/Config.cs
@@ -74,7 +74,7 @@ public static class Config
                         GrantType.ClientCredentials,
                         OidcConstants.GrantTypes.TokenExchange
                     },
-                    RedirectUris = { $"{bffMultiFrontendUrl}bff-signin" },
+                    RedirectUris = { $"{bffMultiFrontendUrl}signin-oidc" },
                     FrontChannelLogoutUri = $"{bffMultiFrontendUrl}signout-oidc",
                     PostLogoutRedirectUris = { $"{bffMultiFrontendUrl}signout-callback-oidc" },
 
@@ -96,7 +96,7 @@ public static class Config
                         GrantType.ClientCredentials,
                         OidcConstants.GrantTypes.TokenExchange
                     },
-                    RedirectUris = { $"{bffMultiFrontendUrl}from-config/bff-signin" },
+                    RedirectUris = { $"{bffMultiFrontendUrl}from-config/signin-oidc" },
                     FrontChannelLogoutUri = $"{bffMultiFrontendUrl}from-config/signout-oidc",
                     PostLogoutRedirectUris = { $"{bffMultiFrontendUrl}from-config/signout-callback-oidc" },
 

--- a/bff/src/Bff/Constants.cs
+++ b/bff/src/Bff/Constants.cs
@@ -107,8 +107,6 @@ public static class Constants
         /// Diagnostics path
         /// </summary>
         public const string Diagnostics = "/diagnostics";
-
-        public const string SigninUrl = "/bff-signin";
     }
 
     /// <summary>

--- a/bff/src/Bff/DynamicFrontends/BffConfigureOpenIdConnectOptions.cs
+++ b/bff/src/Bff/DynamicFrontends/BffConfigureOpenIdConnectOptions.cs
@@ -39,12 +39,6 @@ internal class BffConfigureOpenIdConnectOptions(
             return;
         }
 
-        // Make sure we have a default for the callback path. 
-        if (options.CallbackPath == defaultCallbackPath)
-        {
-            options.CallbackPath = Constants.ManagementEndpoints.SigninUrl;
-        }
-
         options.SignInScheme = frontEnd.CookieSchemeName;
         options.SignOutScheme = frontEnd.CookieSchemeName;
 

--- a/bff/test/Bff.Tests/PublicApiVerificationTests.VerifyPublicApi_Bff.verified.txt
+++ b/bff/test/Bff.Tests/PublicApiVerificationTests.VerifyPublicApi_Bff.verified.txt
@@ -219,7 +219,6 @@ namespace Duende.Bff
             public const string Diagnostics = "/diagnostics";
             public const string Login = "/login";
             public const string Logout = "/logout";
-            public const string SigninUrl = "/bff-signin";
             [System.Obsolete("use /login?prompt=create")]
             public const string SilentLogin = "/silent-login";
             public const string SilentLoginCallback = "/silent-login-callback";

--- a/bff/test/Bff.Tests/TestInfra/IdentityServerTestHost.cs
+++ b/bff/test/Bff.Tests/TestInfra/IdentityServerTestHost.cs
@@ -134,11 +134,6 @@ public class IdentityServerTestHost : TestHost
         var clientSecret = options.ClientSecret ?? The.ClientSecret;
         callbackPath ??= options.CallbackPath;
 
-        if (callbackPath == "/signin-oidc")
-        {
-            callbackPath = Constants.ManagementEndpoints.SigninUrl;
-        }
-
         var redirectUri = new Uri(baseUri, (frontend.SelectionCriteria.MatchingPath ?? string.Empty) + callbackPath);
 
         var client = new Client()


### PR DESCRIPTION
**What issue does this PR address?**
Initially, the BFF used a custom signin url to distinguish between the v3 and v4 style authentication. 

The Microsoft openid connect library automatically initializes this to /signin-oidc. 

Turns out, this causes issues for people who want to stick to the default url. Also, it turns out that with the latest v4 bits, this custom url is no longer needed because frontend selection already has taken place at this point. 

**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
