### PR TITLE
Make sure benchmark setup doesn't include units

### DIFF
--- a/bff/performance/Bff.Benchmarks/BenchmarkBase.cs
+++ b/bff/performance/Bff.Benchmarks/BenchmarkBase.cs
@@ -2,11 +2,37 @@
 // See LICENSE in the project root for license information.
 
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Exporters.Csv;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Reports;
+using Perfolizer.Horology;
+using Perfolizer.Metrology;
 
 namespace Bff.Benchmarks;
 
-[ShortRunJob]
+[Config(typeof(BenchmarkConfig))]
 public class BenchmarkBase
 {
 
+}
+
+public class BenchmarkConfig : ManualConfig
+{
+    public BenchmarkConfig()
+    {
+        var exporter = new CsvExporter(
+            CsvSeparator.CurrentCulture,
+            new SummaryStyle(
+                cultureInfo: System.Globalization.CultureInfo.InvariantCulture,
+                printUnitsInHeader: false,
+                printUnitsInContent: false,
+                timeUnit: TimeUnit.Microsecond,
+                sizeUnit: SizeUnit.KB
+            ));
+
+        AddJob(Job.ShortRun);
+
+        AddExporter(exporter);
+    }
 }

--- a/bff/performance/Bff.Benchmarks/Program.cs
+++ b/bff/performance/Bff.Benchmarks/Program.cs
@@ -1,10 +1,8 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
+using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Running;
 
 
-public class Program
-{
-    static void Main(string[] args) => BenchmarkRunner.Run(typeof(Program).Assembly);
-}
+BenchmarkRunner.Run(typeof(Program).Assembly, ManualConfig.CreateMinimumViable());


### PR DESCRIPTION
**What issue does this PR address?**
Previously, the benchmark output contained units (in ms). This caused issues when sending the data to influxdb.

**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
