### PR TITLE
IS Non-Aspire Default Config

### DIFF
--- a/identity-server/aspire/AppHost/Properties/launchSettings.json
+++ b/identity-server/aspire/AppHost/Properties/launchSettings.json
@@ -10,7 +10,8 @@
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
         "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21262",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22228"
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22228",
+        "IS_ASPIRE": "true"
       }
     }
   }

--- a/identity-server/aspire/ServiceDefaults/Extensions.cs
+++ b/identity-server/aspire/ServiceDefaults/Extensions.cs
@@ -33,6 +33,8 @@ public static class Extensions
             http.AddServiceDiscovery();
         });
 
+        builder.Configuration.Add(new FallbackNonAspireContextConfigurationSource());
+
         return builder;
     }
 

--- a/identity-server/aspire/ServiceDefaults/FallbackIsHostConfigurationSource.cs
+++ b/identity-server/aspire/ServiceDefaults/FallbackIsHostConfigurationSource.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using Microsoft.Extensions.Configuration;
+
+namespace Microsoft.Extensions.Hosting;
+
+/// <summary>
+/// Sets up a fallback configuration source for the "is-host" setting
+/// and settings necessary for API service discovery.
+/// </summary>
+public class FallbackNonAspireContextConfigurationSource : IConfigurationSource
+{
+    public IConfigurationProvider Build(IConfigurationBuilder builder)
+    {
+        var isRunningUnderAspire = builder is ConfigurationManager configManager && configManager["IS_ASPIRE"] != null;
+        return new FallbackNonAspireContextConfigurationProvider(isRunningUnderAspire);
+    }
+}
+
+public class FallbackNonAspireContextConfigurationProvider(bool isRunningUnderAspire) : ConfigurationProvider
+{
+    public override void Load()
+    {
+        if (isRunningUnderAspire)
+        {
+            return;
+        }
+
+        Data = new Dictionary<string, string?>
+        {
+            { "is-host", "https://localhost:5001" },
+            { "Services:dpop-api:https", "https://localhost:6003"},
+            { "Services:mtls-api:https", "https://localhost:6004"},
+            { "Services:resource-based-api:https", "https://localhost:6002" },
+            { "Services:simple-api:https", "https://localhost:6001" }
+        };
+    }
+}


### PR DESCRIPTION
**What issue does this PR address?**
Added custom configuration source with default values for when clients, APIs, and hosts are running outside the context of Aspire.


**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
