### PR TITLE
Reject Pushed Authorization Requests with parameters duplicated in a JAR

### DIFF
--- a/identity-server/CHANGELOG.md
+++ b/identity-server/CHANGELOG.md
@@ -2,5 +2,9 @@
 
 # 7.4.0-preview.1
 
+## Bug Fixes
+- Reject Pushed Authorization Requests with parameters duplicated in a JAR by @wcabus
+
 ## Code Quality
 - Fixed typo in XML doc for Client.CoordinateLifetimeWithUserSession by @wcabus
+

--- a/identity-server/test/IdentityServer.IntegrationTests/Common/IdentityServerPipeline.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Common/IdentityServerPipeline.cs
@@ -2,6 +2,7 @@
 // See LICENSE in the project root for license information.
 
 
+using System.IdentityModel.Tokens.Jwt;
 using System.Net;
 using System.Security.Claims;
 using System.Security.Cryptography.X509Certificates;
@@ -22,6 +23,8 @@ using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.Tokens;
+using JsonWebKey = Microsoft.IdentityModel.Tokens.JsonWebKey;
 
 namespace IntegrationTests.Common;
 
@@ -57,6 +60,7 @@ public class IdentityServerPipeline
 
     public IdentityServerOptions Options { get; set; }
     public List<Client> Clients { get; set; } = new List<Client>();
+    public Dictionary<string, JsonWebKey> ClientKeys { get; set; } = new Dictionary<string, JsonWebKey>();
     public List<IdentityResource> IdentityScopes { get; set; } = new List<IdentityResource>();
     public List<ApiResource> ApiResources { get; set; } = new List<ApiResource>();
     public List<ApiScope> ApiScopes { get; set; } = new List<ApiScope>();
@@ -436,6 +440,70 @@ public class IdentityServerPipeline
         if (extra != null)
         {
             foreach (var (key, value) in extra)
+            {
+                parameters[key] = value;
+            }
+        }
+
+        return await PushAuthorizationRequestAsync(parameters);
+    }
+
+    public async Task<(JsonDocument, HttpStatusCode)> PushAuthorizationRequestUsingJarAsync(
+        string clientId = "client2",
+        string clientSecret = "secret",
+        string responseType = "id_token",
+        string scope = "openid profile",
+        string redirectUri = "https://client2/callback",
+        string nonce = "123_nonce",
+        string state = "123_state",
+        DateTimeOffset? expires = null,
+        Dictionary<string, string> extraJwt = null,
+        Dictionary<string, string> extraForm = null
+    )
+    {
+        var jwtPayload = new Dictionary<string, string>
+        {
+            { "iss", clientId },
+            { "aud", BaseUrl },
+            { "exp", (expires ?? DateTimeOffset.UtcNow.AddMinutes(10)).ToUnixTimeSeconds().ToString() },
+            { "response_type", responseType },
+            { "client_id", clientId },
+            { "redirect_uri", redirectUri },
+            { "scope", scope },
+            { "state", state },
+            { "nonce", nonce }
+        };
+
+        if (extraJwt != null)
+        {
+            foreach (var (key, value) in extraJwt)
+            {
+                jwtPayload[key] = value;
+            }
+        }
+
+        if (!ClientKeys.TryGetValue(clientId, out var securityKey))
+        {
+            throw new InvalidOperationException("Client key not found");
+        }
+
+        var jwt = new JwtSecurityToken(
+            new JwtHeader(new SigningCredentials(securityKey, SecurityAlgorithms.RsaSha256)),
+            new JwtPayload(jwtPayload.Select(x => new Claim(x.Key, x.Value))));
+
+        var jwtHandler = new JwtSecurityTokenHandler();
+        var jar = jwtHandler.WriteToken(jwt);
+
+        var parameters = new Dictionary<string, string>
+        {
+            { "client_id", clientId },
+            { "client_secret", clientSecret },
+            { "request", jar }
+        };
+
+        if (extraForm != null)
+        {
+            foreach (var (key, value) in extraForm)
             {
                 parameters[key] = value;
             }

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Authorize/PushedAuthorizationTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Authorize/PushedAuthorizationTests.cs
@@ -4,7 +4,6 @@
 
 using System.Net;
 using System.Security.Claims;
-using System.Security.Cryptography;
 using System.Text.Json;
 using Duende.IdentityModel;
 using Duende.IdentityServer;

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Authorize/PushedAuthorizationTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Authorize/PushedAuthorizationTests.cs
@@ -8,6 +8,7 @@ using System.Security.Cryptography;
 using System.Text.Json;
 using Duende.IdentityModel;
 using Duende.IdentityServer;
+using Duende.IdentityServer.Configuration;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Test;
 using IntegrationTests.Common;
@@ -274,7 +275,7 @@ public class PushedAuthorizationTests
     [Theory]
     [InlineData("response_type", "id_token")]
     [InlineData("redirect_uri", "https://client1/callback")]
-    [InlineData("scope","openid profile")]
+    [InlineData("scope", "openid profile")]
     public async Task pushed_authorization_with_authorization_request_parameters_duplicated_in_form_and_request_object_fails(string name, string value)
     {
         var (parJson, statusCode) = await _mockPipeline.PushAuthorizationRequestUsingJarAsync(
@@ -328,9 +329,7 @@ public class PushedAuthorizationTests
 
     private void ConfigureClientKeys()
     {
-        using var rsa = RSA.Create(2048);
-        var rsaParameters = rsa.ExportParameters(true);
-        var rsaKey = new RsaSecurityKey(rsaParameters);
+        var rsaKey = CryptoHelper.CreateRsaSecurityKey();
         _privateKey = JsonWebKeyConverter.ConvertFromRSASecurityKey(rsaKey);
 
         _publicKey = new JsonWebKey

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Authorize/PushedAuthorizationTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Authorize/PushedAuthorizationTests.cs
@@ -4,10 +4,16 @@
 
 using System.Net;
 using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text.Json;
 using Duende.IdentityModel;
+using Duende.IdentityServer;
 using Duende.IdentityServer.Models;
 using Duende.IdentityServer.Test;
 using IntegrationTests.Common;
+using Microsoft.IdentityModel.Tokens;
+using JsonWebKey = Duende.IdentityServer.Models.JsonWebKey;
+using WilsonJsonWebKey = Microsoft.IdentityModel.Tokens.JsonWebKey;
 
 namespace IntegrationTests.Endpoints.Authorize;
 
@@ -15,9 +21,14 @@ public class PushedAuthorizationTests
 {
     private readonly IdentityServerPipeline _mockPipeline = new();
     private Client _client;
+    private Client _client2;
+
+    private WilsonJsonWebKey _privateKey;
+    private JsonWebKey _publicKey;
 
     public PushedAuthorizationTests()
     {
+        ConfigureClientKeys();
         ConfigureClients();
         ConfigureUsers();
         ConfigureScopesAndResources();
@@ -46,6 +57,37 @@ public class PushedAuthorizationTests
         // Authorize using pushed request
         var authorizeUrl = _mockPipeline.CreateAuthorizeUrl(
             clientId: "client1",
+            requestUri: parJson.RootElement.GetProperty("request_uri").GetString());
+        var response = await _mockPipeline.BrowserClient.GetAsync(authorizeUrl);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Found);
+        response.Headers.Location!.AbsoluteUri.ShouldMatch($"{expectedCallback}.*");
+
+        var authorization = new Duende.IdentityModel.Client.AuthorizeResponse(response.Headers.Location.ToString());
+        authorization.IsError.ShouldBeFalse();
+        authorization.IdentityToken.ShouldNotBeNull();
+        authorization.State.ShouldBe(expectedState);
+    }
+
+    [Fact]
+    public async Task happy_path_using_JAR_request()
+    {
+        // Login
+        await _mockPipeline.LoginAsync("bob");
+        _mockPipeline.BrowserClient.AllowAutoRedirect = false;
+
+        // Push Authorization
+        var expectedCallback = _client2.RedirectUris.First();
+        var expectedState = "123_state";
+        var (parJson, statusCode) = await _mockPipeline.PushAuthorizationRequestUsingJarAsync(
+            redirectUri: expectedCallback,
+            state: expectedState
+        );
+        statusCode.ShouldBe(HttpStatusCode.Created);
+
+        // Authorize using pushed request
+        var authorizeUrl = _mockPipeline.CreateAuthorizeUrl(
+            clientId: "client2",
             requestUri: parJson.RootElement.GetProperty("request_uri").GetString());
         var response = await _mockPipeline.BrowserClient.GetAsync(authorizeUrl);
 
@@ -229,6 +271,23 @@ public class PushedAuthorizationTests
         authorizeCallbackResponse.Headers.Location!.ToString().ShouldStartWith(expectedCallback);
     }
 
+    [Theory]
+    [InlineData("response_type", "id_token")]
+    [InlineData("redirect_uri", "https://client1/callback")]
+    [InlineData("scope","openid profile")]
+    public async Task pushed_authorization_with_authorization_request_parameters_duplicated_in_form_and_request_object_fails(string name, string value)
+    {
+        var (parJson, statusCode) = await _mockPipeline.PushAuthorizationRequestUsingJarAsync(
+            extraForm: new Dictionary<string, string>
+            {
+                { name, value }
+            });
+        statusCode.ShouldBe(HttpStatusCode.BadRequest);
+        parJson.ShouldNotBeNull();
+        parJson.RootElement.GetProperty("error").GetString()
+            .ShouldBe(OidcConstants.AuthorizeErrors.InvalidRequest);
+    }
+
     private void ConfigureScopesAndResources()
     {
         _mockPipeline.IdentityScopes.AddRange(new IdentityResource[] {
@@ -267,6 +326,26 @@ public class PushedAuthorizationTests
                     }
     });
 
+    private void ConfigureClientKeys()
+    {
+        using var rsa = RSA.Create(2048);
+        var rsaParameters = rsa.ExportParameters(true);
+        var rsaKey = new RsaSecurityKey(rsaParameters);
+        _privateKey = JsonWebKeyConverter.ConvertFromRSASecurityKey(rsaKey);
+
+        _publicKey = new JsonWebKey
+        {
+            kty = "RSA",
+            use = "sig",
+            kid = rsaKey.KeyId,
+            e = _privateKey.E,
+            n = _privateKey.N,
+            alg = _privateKey.Alg
+        };
+
+        _mockPipeline.ClientKeys.Add("client2", _privateKey);
+    }
+
     private void ConfigureClients() => _mockPipeline.Clients.AddRange(new Client[]
         {
             _client = new Client
@@ -281,6 +360,23 @@ public class PushedAuthorizationTests
                 RequirePkce = false,
                 AllowedScopes = new List<string> { "openid", "profile" },
                 RedirectUris = new List<string> { "https://client1/callback" },
+            },
+            _client2 = new Client
+            {
+                ClientId = "client2",
+                ClientSecrets = new []
+                {
+                    new Secret("secret".Sha256()),
+                    new Secret(JsonSerializer.Serialize(_publicKey))
+                    {
+                        Type = IdentityServerConstants.SecretTypes.JsonWebKey
+                    }
+                },
+                AllowedGrantTypes = GrantTypes.Implicit,
+                RequireConsent = false,
+                RequirePkce = false,
+                AllowedScopes = new List<string> { "openid", "profile" },
+                RedirectUris = new List<string> { "https://client2/callback" },
             },
         });
 }


### PR DESCRIPTION
**What issue does this PR address?**

When posting a PAR containing the "request" request parameter, then none of the typical authorization request parameters can be present in the posted form body. The only parameters allowed in this scenario are the ones needed for client authentication and the request parameter itself.

This PR fixes [the issue](https://github.com/orgs/DuendeSoftware/discussions/235) described in our community discussions.

**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)