### PR TITLE
Revert "Support client_secret_jwt client auth"

### DIFF
--- a/identity-server/clients/src/ConsolePrivateKeyJwtClient/Program.cs
+++ b/identity-server/clients/src/ConsolePrivateKeyJwtClient/Program.cs
@@ -57,40 +57,27 @@ var ecKey =
         }
         """;
 
-var hmacKey =
-    """
-        {
-            "kty":"oct",
-            "kid":"10909c7f-d6e0-49eb-9af9-fb06076df8e1",
-            "k":"JXhpjmgEVdhO0OzwyUQ2hCFuuSU9mABtclOcqT1kqaQ",
-            "alg":"HS256"
-        }
-    """;
-
 // X.509 cert
 var certificate = X509CertificateLoader.LoadPkcs12FromFile(path: "client.p12", password: "changeit");
 var x509Credential = new X509SigningCredentials(certificate);
 
 var response = await RequestTokenAsync(x509Credential);
 response.Show();
+
 await CallServiceAsync(response.AccessToken);
 
 // RSA JsonWebkey
 var jwk = new JsonWebKey(rsaKey);
 response = await RequestTokenAsync(new SigningCredentials(jwk, "RS256"));
 response.Show();
-await CallServiceAsync(response.AccessToken);
 
-// HMAC JsonWebKey
-jwk = new JsonWebKey(hmacKey);
-response = await RequestTokenAsync(new SigningCredentials(jwk, "HS256"));
-response.Show();
 await CallServiceAsync(response.AccessToken);
 
 // EC JsonWebKey
 jwk = new JsonWebKey(ecKey);
 response = await RequestTokenAsync(new SigningCredentials(jwk, "ES256"));
 response.Show();
+
 await CallServiceAsync(response.AccessToken);
 
 // Graceful shutdown

--- a/identity-server/hosts/Shared/Configuration/ClientsConsole.cs
+++ b/identity-server/hosts/Shared/Configuration/ClientsConsole.cs
@@ -120,9 +120,9 @@ public static class ClientsConsole
                         Value =
                             """
                             {
-                                "kty":"RSA",
                                 "e":"AQAB",
                                 "kid":"ZzAjSnraU3bkWGnnAqLapYGpTyNfLbjbzgAPbbW2GEA",
+                                "kty":"RSA",
                                 "n":"wWwQFtSzeRjjerpEM5Rmqz_DsNaZ9S1Bw6UbZkDLowuuTCjBWUax0vBMMxdy6XjEEK4Oq9lKMvx9JzjmeJf1knoqSNrox3Ka0rnxXpNAz6sATvme8p9mTXyp0cX4lF4U2J54xa2_S9NF5QWvpXvBeC4GAJx7QaSw4zrUkrc6XyaAiFnLhQEwKJCwUw4NOqIuYvYp_IXhw-5Ti_icDlZS-282PcccnBeOcX7vc21pozibIdmZJKqXNsL1Ibx5Nkx1F1jLnekJAmdaACDjYRLL_6n3W4wUp19UvzB1lGtXcJKLLkqB6YDiZNu16OSiSprfmrRXvYmvD8m6Fnl5aetgKw"
                             }
                             """
@@ -141,19 +141,6 @@ public static class ClientsConsole
                                 "kid":"1"
                             }
                             """
-                    },
-                    new Secret
-                    {
-                        Type = IdentityServerConstants.SecretTypes.JsonWebKey,
-                        Value =
-                        """
-                        {
-                            "kty":"oct",
-                            "kid":"10909c7f-d6e0-49eb-9af9-fb06076df8e1",
-                            "k":"JXhpjmgEVdhO0OzwyUQ2hCFuuSU9mABtclOcqT1kqaQ",
-                            "alg":"HS256"
-                        }
-                        """
                     }
                 },
                 AllowedGrantTypes = GrantTypes.ClientCredentials,

--- a/identity-server/src/Configuration/Validation/DynamicClientRegistration/DynamicClientRegistrationValidator.cs
+++ b/identity-server/src/Configuration/Validation/DynamicClientRegistration/DynamicClientRegistrationValidator.cs
@@ -153,7 +153,7 @@ public class DynamicClientRegistrationValidator : IDynamicClientRegistrationVali
 
         if (context.Request.GrantTypes.Contains(OidcConstants.GrantTypes.RefreshToken))
         {
-            // Note that if we ever support additional grant types that allow refresh tokens, this
+            // Note that if we ever support additional grant types that allow refresh tokens, this 
             // could be refactored.
             if (!context.Client.AllowedGrantTypes.Contains(GrantType.AuthorizationCode))
             {
@@ -302,7 +302,7 @@ public class DynamicClientRegistrationValidator : IDynamicClientRegistrationVali
     }
 
     /// <summary>
-    /// Validates the requested jwks to set the secrets of the client.
+    /// Validates the requested jwks to set the secrets of the client.  
     /// </summary>
     /// <param name="context">The dynamic client registration context, which
     /// includes the client model that will have its secrets set, the DCR
@@ -317,11 +317,9 @@ public class DynamicClientRegistrationValidator : IDynamicClientRegistrationVali
             return StepResult.Failure("The jwks_uri and jwks parameters must not be used together");
         }
 
-        if (context.Request.Jwks is null &&
-            context.Request.TokenEndpointAuthenticationMethod is
-                OidcConstants.EndpointAuthenticationMethods.PrivateKeyJwt or "client_secret_jwt")
+        if (context.Request.Jwks is null && context.Request.TokenEndpointAuthenticationMethod == OidcConstants.EndpointAuthenticationMethods.PrivateKeyJwt)
         {
-            return StepResult.Failure($"Missing jwks parameter - the {context.Request.TokenEndpointAuthenticationMethod} token_endpoint_auth_method requires the jwks parameter");
+            return StepResult.Failure("Missing jwks parameter - the private_key_jwt token_endpoint_auth_method requires the jwks parameter");
 
         }
         if (context.Request.Jwks is not null)
@@ -573,7 +571,7 @@ public class DynamicClientRegistrationValidator : IDynamicClientRegistrationVali
     /// Validates details of the request that control the user interface,
     /// including the logo uri, client uri, initiate login uri, enable local
     /// login flag, and identity provider restrictions, and uses them to set the
-    /// corresponding client properties.
+    /// corresponding client properties. 
     /// </summary>
     /// <param name="context">The dynamic client registration context, which
     /// includes the client model that will have miscellaneous properties set,

--- a/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
+++ b/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
@@ -226,8 +226,8 @@ public class IdentityServerOptions
     /// request_object_signing_alg_values_supported discovery property is populated with these values.
     /// </para>
     /// <para>
-    /// Defaults to [RS256, RS384, RS512, PS256, PS384, PS512, ES256, ES384, ES512, HS256, HS384, HS512], which allows
-    /// the RSA, Probabilistic RSA, ECDSA, or HMAC signing algorithms with 256, 384, or 512-bit SHA hashing.
+    /// Defaults to [RS256, RS384, RS512, PS256, PS384, PS512, ES256, ES384, ES512], which allows
+    /// the RSA, Probabilistic RSA, or ECDSA signing algorithms with 256, 384, or 512-bit SHA hashing.
     /// </para>
     /// <para>
     /// If set to an empty collection, all algorithms are allowed, but the request_object_signing_alg_values_supported
@@ -247,10 +247,6 @@ public class IdentityServerOptions
         SecurityAlgorithms.EcdsaSha256,
         SecurityAlgorithms.EcdsaSha384,
         SecurityAlgorithms.EcdsaSha512,
-
-        SecurityAlgorithms.HmacSha256,
-        SecurityAlgorithms.HmacSha384,
-        SecurityAlgorithms.HmacSha512
     ];
 
     /// <summary>
@@ -260,8 +256,8 @@ public class IdentityServerOptions
     /// token_endpoint_auth_signing_alg_values_supported discovery property is populated with these values.
     /// </para>
     /// <para>
-    /// Defaults to [RS256, RS384, RS512, PS256, PS384, PS512, ES256, ES384, ES512, HS256, HS384, HS512], which allows
-    /// the RSA, Probabilistic RSA, ECDSA, or HMAC signing algorithms with 256, 384, or 512-bit SHA hashing.
+    /// Defaults to [RS256, RS384, RS512, PS256, PS384, PS512, ES256, ES384, ES512], which allows
+    /// the RSA, Probabilistic RSA, or ECDSA signing algorithms with 256, 384, or 512-bit SHA hashing.
     /// </para>
     /// <para>
     /// If set to an empty collection, all algorithms are allowed, but the
@@ -281,10 +277,6 @@ public class IdentityServerOptions
         SecurityAlgorithms.EcdsaSha256,
         SecurityAlgorithms.EcdsaSha384,
         SecurityAlgorithms.EcdsaSha512,
-
-        SecurityAlgorithms.HmacSha256,
-        SecurityAlgorithms.HmacSha384,
-        SecurityAlgorithms.HmacSha512
     ];
 
     /// <summary>

--- a/identity-server/src/IdentityServer/ResponseHandling/Default/DiscoveryResponseGenerator.cs
+++ b/identity-server/src/IdentityServer/ResponseHandling/Default/DiscoveryResponseGenerator.cs
@@ -326,22 +326,14 @@ public class DiscoveryResponseGenerator : IDiscoveryResponseGenerator
                 types.Add(OidcConstants.EndpointAuthenticationMethods.TlsClientAuth);
                 types.Add(OidcConstants.EndpointAuthenticationMethods.SelfSignedTlsClientAuth);
             }
+            entries.Add(OidcConstants.Discovery.TokenEndpointAuthenticationMethodsSupported, types);
+
             if (types.Contains(OidcConstants.EndpointAuthenticationMethods.PrivateKeyJwt) &&
                 !IEnumerableExtensions.IsNullOrEmpty(Options.SupportedClientAssertionSigningAlgorithms))
             {
                 entries.Add(OidcConstants.Discovery.TokenEndpointAuthSigningAlgorithmsSupported,
                     Options.SupportedClientAssertionSigningAlgorithms);
-                if (Options.SupportedClientAssertionSigningAlgorithms.Any(alg => alg.StartsWith("HS")))
-                {
-                    types.Add("client_secret_jwt");
-                }
-
-                if (Options.SupportedClientAssertionSigningAlgorithms.All(alg => alg.StartsWith("HS")))
-                {
-                    types.Remove("private_key_jwt");
-                }
             }
-            entries.Add(OidcConstants.Discovery.TokenEndpointAuthenticationMethodsSupported, types);
         }
 
         var signingCredentials = await Keys.GetAllSigningCredentialsAsync();

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Authorize/JwtRequestAuthorizeTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Authorize/JwtRequestAuthorizeTests.cs
@@ -31,11 +31,11 @@ public class JwtRequestAuthorizeTests
 
     private readonly string _symmetricJwk =
         """
-        { 
-            "kid": "1", 
+        {
+            "kid": "1",
             "alg": "HS256",
-            "kty": "oct", 
-            "use": "sig", 
+            "kty": "oct",
+            "use": "sig",
             "k": "nYA-IFt8xTsdBHe9hunvizcp3Dt7f6qGqudq18kZHNtvqEGjJ9Ud-9x3kbQ-LYfLHS3xM2MpFQFg1JzT_0U_F8DI40oby4TvBDGszP664UgA8_5GjB7Flnrlsap1NlitvNpgQX3lpyTvC2zVuQ-UVsXbBDAaSBUSlnw7SE4LM8Ye2WYZrdCCXL8yAX9vIR7vf77yvNTEcBCI6y4JlvZaqMB4YKVSfygs8XqGGCHjLpE5bvI-A4ESbAUX26cVFvCeDg9pR6HK7BmwPMlO96krgtKZcXEJtUELYPys6-rbwAIdmxJxKxpgRpt0FRv_9fm6YPwG7QivYBX-vRwaodL1TA"
         }
         """;
@@ -268,6 +268,7 @@ public class JwtRequestAuthorizeTests
     [Trait("Category", Category)]
     public async Task authorize_should_accept_valid_JWT_request_object_parameters_using_symmetric_jwk()
     {
+        _mockPipeline.Options.SupportedRequestObjectSigningAlgorithms.Add(SecurityAlgorithms.HmacSha256);
         var requestJwt = CreateRequestJwt(
             issuer: _client.ClientId,
             audience: IdentityServerPipeline.BaseUrl,

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Discovery/DiscoveryEndpointTests_token_endpoint_auth_signing_algs_supported.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Discovery/DiscoveryEndpointTests_token_endpoint_auth_signing_algs_supported.cs
@@ -41,7 +41,7 @@ public class DiscoveryEndpointTests_token_endpoint_auth_signing_alg_values_suppo
 
     [Fact]
     [Trait("Category", Category)]
-    public async Task token_endpoint_auth_signing_alg_values_supported_should_default_to_rs_ps_es_hmac()
+    public async Task token_endpoint_auth_signing_alg_values_supported_should_default_to_rs_ps_es()
     {
         var pipeline = new IdentityServerPipeline();
         pipeline.OnPostConfigureServices += svcs =>
@@ -55,19 +55,17 @@ public class DiscoveryEndpointTests_token_endpoint_auth_signing_alg_values_suppo
         result.IsError.ShouldBeFalse();
         var algorithmsSupported = result.TokenEndpointAuthenticationSigningAlgorithmsSupported;
 
-        algorithmsSupported.Count().ShouldBe(12);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSha256);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSha384);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSha512);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSsaPssSha384);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSsaPssSha512);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSsaPssSha256);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.EcdsaSha256);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.EcdsaSha384);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.EcdsaSha512);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.HmacSha256);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.HmacSha384);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.HmacSha512);
+        algorithmsSupported.ShouldBe([
+            SecurityAlgorithms.RsaSha256,
+            SecurityAlgorithms.RsaSha384,
+            SecurityAlgorithms.RsaSha512,
+            SecurityAlgorithms.RsaSsaPssSha384,
+            SecurityAlgorithms.RsaSsaPssSha512,
+            SecurityAlgorithms.RsaSsaPssSha256,
+            SecurityAlgorithms.EcdsaSha256,
+            SecurityAlgorithms.EcdsaSha384,
+            SecurityAlgorithms.EcdsaSha512,
+        ], ignoreOrder: true);
     }
 
     [Fact]

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Discovery/DiscoveryEndpoint_request_object_auth_signing_algs_supported.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Discovery/DiscoveryEndpoint_request_object_auth_signing_algs_supported.cs
@@ -55,7 +55,7 @@ public class DiscoveryEndpoint_request_object_auth_signing_algs_supported_Tests
 
     [Fact]
     [Trait("Category", Category)]
-    public async Task request_object_signing_alg_values_supported_should_default_to_rs_ps_es_hmac()
+    public async Task request_object_signing_alg_values_supported_should_default_to_rs_ps_es()
     {
         var pipeline = new IdentityServerPipeline();
         pipeline.Initialize();
@@ -65,19 +65,17 @@ public class DiscoveryEndpoint_request_object_auth_signing_algs_supported_Tests
                 "https://server/.well-known/openid-configuration");
         var algorithmsSupported = result.TryGetStringArray("request_object_signing_alg_values_supported");
 
-        algorithmsSupported.Count().ShouldBe(12);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSha256);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSha384);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSha512);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSsaPssSha384);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSsaPssSha512);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.RsaSsaPssSha256);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.EcdsaSha256);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.EcdsaSha384);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.EcdsaSha512);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.HmacSha256);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.HmacSha384);
-        algorithmsSupported.ShouldContain(SecurityAlgorithms.HmacSha512);
+        algorithmsSupported.ShouldBe([
+            SecurityAlgorithms.RsaSha256,
+            SecurityAlgorithms.RsaSha384,
+            SecurityAlgorithms.RsaSha512,
+            SecurityAlgorithms.RsaSsaPssSha384,
+            SecurityAlgorithms.RsaSsaPssSha512,
+            SecurityAlgorithms.RsaSsaPssSha256,
+            SecurityAlgorithms.EcdsaSha256,
+            SecurityAlgorithms.EcdsaSha384,
+            SecurityAlgorithms.EcdsaSha512,
+        ], ignoreOrder: true);
     }
 
     public static IEnumerable<object[]> NullOrEmptySupportedAlgorithms() =>


### PR DESCRIPTION
Reverts DuendeSoftware/products#2062, and sets default jwt algorithms to not include HMAC, as HMAC requires that the secret be insecurely stored in plain text. 