### PR TITLE
Fixed typo in XML doc for Client.CoordinateLifetimeWithUserSession

### DIFF
--- a/identity-server/CHANGELOG.md
+++ b/identity-server/CHANGELOG.md
@@ -1,3 +1,6 @@
 # IdentityServer Changelog
 
-## 7.4.0-preview.1
+# 7.4.0-preview.1
+
+## Code Quality
+- Fixed typo in XML doc for Client.CoordinateLifetimeWithUserSession by @wcabus

--- a/identity-server/src/Storage/Models/Client.cs
+++ b/identity-server/src/Storage/Models/Client.cs
@@ -349,7 +349,7 @@ public class Client
     /// When enabled, the client's token lifetimes (e.g. refresh tokens) will be tied to the user's session lifetime.
     /// This means when the user logs out, any revokable tokens will be removed.
     /// If using server-side sessions, expired sessions will also remove any revokable tokens, and backchannel logout will be triggered.
-    /// This client's setting overrides the global CoordinateTokensWithUserSession configuration setting.
+    /// This client's setting overrides the global CoordinateClientLifetimesWithUserSession configuration setting.
     /// </summary>
     public bool? CoordinateLifetimeWithUserSession { get; set; }
 


### PR DESCRIPTION
**What issue does this PR address?**

The XML docs on the property `Client.CoordinateLifetimeWithUserSession` pointed to a global configuration setting called `CoordinateTokensWithUserSession`. That setting's name is `CoordinateClientLifetimesWithUserSession`.


**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
