### PR TITLE
moved partition key building out of session store

### DIFF
--- a/bff/migrations/Directory.Build.props
+++ b/bff/migrations/Directory.Build.props
@@ -3,6 +3,25 @@
   <PropertyGroup>
     <RootNamespace>$(AssemblyName)</RootNamespace>
     <AssemblyName>Duende.$(MSBuildProjectName)</AssemblyName>
+
+    <!-- This line is needed because:
+    
+    Aspire needs a single target framework 
+      (until this is resolved: https://github.com/dotnet/aspire/issues/2962)
+    
+    When you add <TargetFramework>net9.0</TargetFramework> then aspire thinks there are more than
+    one framework. But this causes a problem for the Directory.Packages.props file.
+
+    In the Directory.Packages.props where we check for $(TargetFramework) == 'net9.0',
+    which is ONLY set if you use <TargetFramework>net9.0</TargetFramework> in the csproj file, not
+    if you set <TargetFramework>. 
+
+    Now normally it's not recommended to set both, however, since this is only for samples, AND
+    we do need this check, we're setting it here as well. 
+
+      -->    
+    <TargetFramework>net8.0</TargetFramework>
+
   </PropertyGroup>
   <Import Project="../../samples.props" />
 </Project>

--- a/bff/src/Bff.Blazor/BffBuilderExtensions.cs
+++ b/bff/src/Bff.Blazor/BffBuilderExtensions.cs
@@ -16,6 +16,7 @@ public static class
     {
         ArgumentNullException.ThrowIfNull(builder);
 
+        // Todo: EV: make sure server side sessions is added, as it doesn't work otherwise. 
         builder.Services
             .AddOpenIdConnectAccessTokenManagement()
             .AddBlazorServerAccessTokenManagement<ServerSideTokenStore>()

--- a/bff/src/Bff.Blazor/BffServerAuthenticationStateProvider.cs
+++ b/bff/src/Bff.Blazor/BffServerAuthenticationStateProvider.cs
@@ -33,6 +33,7 @@ internal sealed class BffServerAuthenticationStateProvider : RevalidatingServerA
     private readonly IUserSessionStore _sessionStore;
     private readonly PersistentComponentState _state;
     private readonly NavigationManager _navigation;
+    private readonly BuildUserSessionPartitionKey _userSessionPartitionBuilder;
     private readonly BffOptions _bffOptions;
     private readonly ILogger<BffServerAuthenticationStateProvider> _logger;
 
@@ -46,6 +47,7 @@ internal sealed class BffServerAuthenticationStateProvider : RevalidatingServerA
         IUserSessionStore sessionStore,
         PersistentComponentState persistentComponentState,
         NavigationManager navigation,
+        BuildUserSessionPartitionKey userSessionPartitionBuilder,
         IOptions<BffBlazorServerOptions> blazorOptions,
         IOptions<BffOptions> bffOptions,
         ILoggerFactory loggerFactory)
@@ -54,6 +56,7 @@ internal sealed class BffServerAuthenticationStateProvider : RevalidatingServerA
         _sessionStore = sessionStore;
         _state = persistentComponentState;
         _navigation = navigation;
+        _userSessionPartitionBuilder = userSessionPartitionBuilder;
         _bffOptions = bffOptions.Value;
         _logger = loggerFactory.CreateLogger<BffServerAuthenticationStateProvider>();
 
@@ -140,6 +143,7 @@ internal sealed class BffServerAuthenticationStateProvider : RevalidatingServerA
 
         var sessions = await _sessionStore.GetUserSessionsAsync(new UserSessionsFilter
         {
+            PartitionKey = _userSessionPartitionBuilder(),
             SessionId = sid,
             SubjectId = sub
         },

--- a/bff/src/Bff.Blazor/ServerSideTokenStore.cs
+++ b/bff/src/Bff.Blazor/ServerSideTokenStore.cs
@@ -61,12 +61,13 @@ internal class ServerSideTokenStore(
 
         logger.RetrievingSession(LogLevel.Debug, sid, sub);
 
-        var sessions = await sessionStore.GetUserSessionsAsync(new UserSessionsFilter
+        var userSessionsFilter = new UserSessionsFilter
         {
-            PartitionKey = userSessionPartitionKeyBuilder(),
             SubjectId = sub,
             SessionId = sid
-        });
+        };
+        var partitionKey = userSessionPartitionKeyBuilder();
+        var sessions = await sessionStore.GetUserSessionsAsync(partitionKey, userSessionsFilter);
 
         if (sessions.Count == 0)
         {

--- a/bff/src/Bff.Blazor/ServerSideTokenStore.cs
+++ b/bff/src/Bff.Blazor/ServerSideTokenStore.cs
@@ -21,6 +21,7 @@ internal class ServerSideTokenStore(
     IStoreTokensInAuthenticationProperties tokensInAuthProperties,
     IUserSessionStore sessionStore,
     IDataProtectionProvider dataProtectionProvider,
+    BuildUserSessionPartitionKey userSessionPartitionKeyBuilder,
     ILogger<ServerSideTokenStore> logger,
     AuthenticationStateProvider authenticationStateProvider) : IUserTokenStore
 {
@@ -62,6 +63,7 @@ internal class ServerSideTokenStore(
 
         var sessions = await sessionStore.GetUserSessionsAsync(new UserSessionsFilter
         {
+            PartitionKey = userSessionPartitionKeyBuilder(),
             SubjectId = sub,
             SessionId = sid
         });
@@ -114,6 +116,6 @@ internal class ServerSideTokenStore(
 
         session.Ticket = ticket.Serialize(_protector);
 
-        await sessionStore.UpdateUserSessionAsync(session.Key, session);
+        await sessionStore.UpdateUserSessionAsync(session.GetUserSessionKey(), session);
     }
 }

--- a/bff/src/Bff.EntityFramework/Internal/UserSessionStore.cs
+++ b/bff/src/Bff.EntityFramework/Internal/UserSessionStore.cs
@@ -105,9 +105,8 @@ internal sealed class UserSessionStore(
     }
 
     /// <inheritdoc/>
-    public async Task DeleteUserSessionsAsync(UserSessionsFilter filter, CT ct)
+    public async Task DeleteUserSessionsAsync(PartitionKey partitionKey, UserSessionsFilter filter, CT ct)
     {
-        var partitionKey = filter.PartitionKey;
         filter.Validate();
         var query = sessionDbContext.UserSessions.Where(x => x.PartitionKey == partitionKey).AsQueryable();
         if (!string.IsNullOrWhiteSpace(filter.SubjectId))
@@ -177,10 +176,9 @@ internal sealed class UserSessionStore(
     }
 
     /// <inheritdoc/>
-    public async Task<IReadOnlyCollection<UserSession>> GetUserSessionsAsync(UserSessionsFilter filter, CT ct)
+    public async Task<IReadOnlyCollection<UserSession>> GetUserSessionsAsync(PartitionKey partitionKey, UserSessionsFilter filter, CT ct)
     {
         filter.Validate();
-        var partitionKey = filter.PartitionKey;
         var query = sessionDbContext.UserSessions.Where(x => x.PartitionKey == partitionKey).AsQueryable();
         if (!string.IsNullOrWhiteSpace(filter.SubjectId))
         {

--- a/bff/src/Bff.EntityFramework/ModelBuilderExtensions.cs
+++ b/bff/src/Bff.EntityFramework/ModelBuilderExtensions.cs
@@ -1,8 +1,10 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
+using Duende.Bff.SessionManagement.SessionStore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Duende.Bff.EntityFramework;
 
@@ -37,8 +39,8 @@ public static class ModelBuilderExtensions
 
             entity.HasKey(x => x.Id);
 
-            entity.Property(x => x.PartitionKey).HasMaxLength(200);
-            entity.Property(x => x.Key).IsRequired().HasMaxLength(200);
+            entity.Property(x => x.PartitionKey).HasConversion<PartitionKeyConverter>().HasMaxLength(200);
+            entity.Property(x => x.Key).HasConversion<UserKeyConverter>().IsRequired().HasMaxLength(200);
             entity.Property(x => x.SubjectId).IsRequired().HasMaxLength(200);
             entity.Property(x => x.Ticket).IsRequired();
 
@@ -48,4 +50,12 @@ public static class ModelBuilderExtensions
             entity.HasIndex(x => x.Expires);
         });
     }
+
+    public class UserKeyConverter() : ValueConverter<UserKey, string>(
+        key => key.ToString(),
+        value => UserKey.Parse(value));
+
+    public class PartitionKeyConverter() : ValueConverter<PartitionKey, string>(
+        key => key.ToString(),
+        value => PartitionKey.Parse(value));
 }

--- a/bff/src/Bff.EntityFramework/UserSessionEntity.cs
+++ b/bff/src/Bff.EntityFramework/UserSessionEntity.cs
@@ -14,9 +14,4 @@ public class UserSessionEntity : UserSession
     /// Id for record in database
     /// </summary>
     public long Id { get; set; }
-
-    /// <summary>
-    /// Discriminator to allow multiple applications / frontends to share the user session table.
-    /// </summary>
-    public string? PartitionKey { get; set; }
 }

--- a/bff/src/Bff/AuthenticationTicketExtensions.cs
+++ b/bff/src/Bff/AuthenticationTicketExtensions.cs
@@ -105,7 +105,7 @@ public static class AuthenticationTicketExtensions
             {
                 logger.AuthenticationTicketEnvelopeVersionInvalid(
                     LogLevel.Debug,
-                    session.Key);
+                    session.GetUserSessionKey());
                 return null;
             }
 
@@ -116,14 +116,14 @@ public static class AuthenticationTicketExtensions
             }
             catch (CryptographicException ex)
             {
-                logger.AuthenticationTicketPayloadInvalid(ex, LogLevel.Warning, session.Key);
+                logger.AuthenticationTicketPayloadInvalid(ex, LogLevel.Warning, session.GetUserSessionKey());
                 return null;
             }
 
             var ticket = JsonSerializer.Deserialize<AuthenticationTicketLite>(payload, JsonOptions);
             if (ticket == null)
             {
-                logger.AuthenticationTicketPayloadInvalid(ex: null, LogLevel.Warning, session.Key);
+                logger.AuthenticationTicketPayloadInvalid(ex: null, LogLevel.Warning, session.GetUserSessionKey());
                 return null;
             }
 
@@ -145,7 +145,7 @@ public static class AuthenticationTicketExtensions
         catch (JsonException ex)
         {
             // failed deserialize
-            logger.AuthenticationTicketFailedToDeserialize(ex, LogLevel.Warning, session.Key);
+            logger.AuthenticationTicketFailedToDeserialize(ex, LogLevel.Warning, session.GetUserSessionKey());
         }
 
         return null;

--- a/bff/src/Bff/BffBuilder.cs
+++ b/bff/src/Bff/BffBuilder.cs
@@ -124,6 +124,7 @@ public sealed class BffBuilder(IServiceCollection services)
     /// <returns></returns>
     public BffBuilder AddServerSideSessions()
     {
+        Services.AddSingleton<BuildUserSessionPartitionKey>(sp => sp.GetRequiredService<UserSessionPartitionKeyBuilder>().BuildPartitionKey);
         Services.AddSingleton<UserSessionPartitionKeyBuilder>();
         Services.AddSingleton<IPostConfigureOptions<CookieAuthenticationOptions>, PostConfigureApplicationCookieTicketStore>();
         Services.AddTransient<IServerTicketStore, ServerSideTicketStore>();

--- a/bff/src/Bff/Endpoints/Internal/DefaultBackchannelLogoutEndpoint.cs
+++ b/bff/src/Bff/Endpoints/Internal/DefaultBackchannelLogoutEndpoint.cs
@@ -23,7 +23,6 @@ namespace Duende.Bff.Endpoints.Internal;
 internal class DefaultBackchannelLogoutEndpoint(
     IAuthenticationSchemeProvider authenticationSchemeProvider,
     IOptionsMonitor<OpenIdConnectOptions> optionsMonitor,
-    BuildUserSessionPartitionKey partitionKeyBuilder,
     ISessionRevocationService userSession,
     ILogger<DefaultBackchannelLogoutEndpoint> logger) : IBackchannelLogoutEndpoint
 {
@@ -52,7 +51,6 @@ internal class DefaultBackchannelLogoutEndpoint(
 
                     await userSession.RevokeSessionsAsync(new UserSessionsFilter
                     {
-                        PartitionKey = partitionKeyBuilder(),
                         SubjectId = sub,
                         SessionId = sid
                     }, ct);

--- a/bff/src/Bff/Endpoints/Internal/DefaultBackchannelLogoutEndpoint.cs
+++ b/bff/src/Bff/Endpoints/Internal/DefaultBackchannelLogoutEndpoint.cs
@@ -23,6 +23,7 @@ namespace Duende.Bff.Endpoints.Internal;
 internal class DefaultBackchannelLogoutEndpoint(
     IAuthenticationSchemeProvider authenticationSchemeProvider,
     IOptionsMonitor<OpenIdConnectOptions> optionsMonitor,
+    BuildUserSessionPartitionKey partitionKeyBuilder,
     ISessionRevocationService userSession,
     ILogger<DefaultBackchannelLogoutEndpoint> logger) : IBackchannelLogoutEndpoint
 {
@@ -51,6 +52,7 @@ internal class DefaultBackchannelLogoutEndpoint(
 
                     await userSession.RevokeSessionsAsync(new UserSessionsFilter
                     {
+                        PartitionKey = partitionKeyBuilder(),
                         SubjectId = sub,
                         SessionId = sid
                     }, ct);

--- a/bff/src/Bff/Otel/LogMessages.cs
+++ b/bff/src/Bff/Otel/LogMessages.cs
@@ -3,6 +3,7 @@
 
 using Duende.Bff.AccessTokenManagement;
 using Duende.Bff.DynamicFrontends;
+using Duende.Bff.SessionManagement.SessionStore;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 
@@ -18,20 +19,20 @@ internal static partial class LogMessages
         message:
         $"Deserializing AuthenticationTicket envelope failed or found incorrect version for key {{{OTelParameters.Key}}}")]
     public static partial void AuthenticationTicketEnvelopeVersionInvalid(this ILogger logger, LogLevel logLevel,
-        string key);
+        UserSessionKey key);
 
     [LoggerMessage(
         message:
         $"Failed to unprotect AuthenticationTicket payload for key {{{OTelParameters.Key}}}")]
     public static partial void AuthenticationTicketPayloadInvalid(this ILogger logger, Exception? ex, LogLevel logLevel,
-        string key);
+        UserSessionKey key);
 
     [LoggerMessage(
         message:
         $"Failed to deserialize AuthenticationTicket payload for key {{{OTelParameters.Key}}}")]
     public static partial void AuthenticationTicketFailedToDeserialize(this ILogger logger, Exception? ex,
         LogLevel logLevel,
-        string key);
+        UserSessionKey key);
 
     [LoggerMessage(
         Message = "FrontendSelection: No frontends registered in the store.")]
@@ -130,7 +131,7 @@ internal static partial class LogMessages
     [LoggerMessage(
         message:
         $"No record found in user session store when trying to delete user session for key {{{OTelParameters.Key}}}")]
-    public static partial void NoRecordFoundForKey(this ILogger logger, LogLevel logLevel, string key);
+    public static partial void NoRecordFoundForKey(this ILogger logger, LogLevel logLevel, UserSessionKey key);
 
     [LoggerMessage(
         message:

--- a/bff/src/Bff/SessionManagement/Revocation/SessionRevocationService.cs
+++ b/bff/src/Bff/SessionManagement/Revocation/SessionRevocationService.cs
@@ -20,6 +20,7 @@ internal class SessionRevocationService(
     IOptions<BffOptions> options,
     IServerTicketStore ticketStore,
     IUserSessionStore sessionStore,
+    BuildUserSessionPartitionKey buildUserPartitionKey,
     IOpenIdConnectUserTokenEndpoint tokenEndpoint,
     ILogger<SessionRevocationService> logger) : ISessionRevocationService
 {
@@ -52,6 +53,6 @@ internal class SessionRevocationService(
             }
         }
 
-        await sessionStore.DeleteUserSessionsAsync(filter, ct);
+        await sessionStore.DeleteUserSessionsAsync(buildUserPartitionKey(), filter, ct);
     }
 }

--- a/bff/src/Bff/SessionManagement/SessionStore/IUserSessionStore.cs
+++ b/bff/src/Bff/SessionManagement/SessionStore/IUserSessionStore.cs
@@ -45,16 +45,18 @@ public interface IUserSessionStore
     /// <summary>
     /// Queries user sessions based on the filter.
     /// </summary>
+    /// <param name="partitionKey">The partition key to use</param>
     /// <param name="filter"></param>
     /// <param name="ct">A token that can be used to request cancellation of the asynchronous operation.</param>
     /// <returns></returns>
-    Task<IReadOnlyCollection<UserSession>> GetUserSessionsAsync(UserSessionsFilter filter, CT ct = default);
+    Task<IReadOnlyCollection<UserSession>> GetUserSessionsAsync(PartitionKey partitionKey, UserSessionsFilter filter, CT ct = default);
 
     /// <summary>
     /// Deletes user sessions based on the filter.
     /// </summary>
+    /// <param name="partitionKey">The partition key</param>
     /// <param name="filter"></param>
     /// <param name="ct">A token that can be used to request cancellation of the asynchronous operation.</param>
     /// <returns></returns>
-    Task DeleteUserSessionsAsync(UserSessionsFilter filter, CT ct = default);
+    Task DeleteUserSessionsAsync(PartitionKey partitionKey, UserSessionsFilter filter, CT ct = default);
 }

--- a/bff/src/Bff/SessionManagement/SessionStore/IUserSessionStore.cs
+++ b/bff/src/Bff/SessionManagement/SessionStore/IUserSessionStore.cs
@@ -15,7 +15,7 @@ public interface IUserSessionStore
     /// <param name="key"></param>
     /// <param name="ct">A token that can be used to request cancellation of the asynchronous operation.</param>
     /// <returns></returns>
-    Task<UserSession?> GetUserSessionAsync(string key, CT ct = default);
+    Task<UserSession?> GetUserSessionAsync(UserSessionKey key, CT ct = default);
 
     /// <summary>
     /// Creates a user session
@@ -32,7 +32,7 @@ public interface IUserSessionStore
     /// <param name="session"></param>
     /// <param name="ct">A token that can be used to request cancellation of the asynchronous operation.</param>
     /// <returns></returns>
-    Task UpdateUserSessionAsync(string key, UserSessionUpdate session, CT ct = default);
+    Task UpdateUserSessionAsync(UserSessionKey key, UserSessionUpdate session, CT ct = default);
 
     /// <summary>
     /// Deletes a user session
@@ -40,7 +40,7 @@ public interface IUserSessionStore
     /// <param name="key"></param>
     /// <param name="ct">A token that can be used to request cancellation of the asynchronous operation.</param>
     /// <returns></returns>
-    Task DeleteUserSessionAsync(string key, CT ct = default);
+    Task DeleteUserSessionAsync(UserSessionKey key, CT ct = default);
 
     /// <summary>
     /// Queries user sessions based on the filter.

--- a/bff/src/Bff/SessionManagement/SessionStore/InMemoryUserSessionStore.cs
+++ b/bff/src/Bff/SessionManagement/SessionStore/InMemoryUserSessionStore.cs
@@ -77,10 +77,10 @@ internal class InMemoryUserSessionStore(
         return Task.CompletedTask;
     }
 
-    public Task<IReadOnlyCollection<UserSession>> GetUserSessionsAsync(UserSessionsFilter filter, CT ct = default)
+    public Task<IReadOnlyCollection<UserSession>> GetUserSessionsAsync(PartitionKey partitionKey, UserSessionsFilter filter, CT ct = default)
     {
         filter.Validate();
-        var partition = GetPartition(filter.PartitionKey);
+        var partition = GetPartition(partitionKey);
 
         var query = partition.Values.AsQueryable();
         if (!string.IsNullOrWhiteSpace(filter.SubjectId))
@@ -97,10 +97,10 @@ internal class InMemoryUserSessionStore(
         return Task.FromResult((IReadOnlyCollection<UserSession>)results);
     }
 
-    public Task DeleteUserSessionsAsync(UserSessionsFilter filter, CT ct = default)
+    public Task DeleteUserSessionsAsync(PartitionKey partitionKey, UserSessionsFilter filter, CT ct = default)
     {
         filter.Validate();
-        var partition = GetPartition(filter.PartitionKey);
+        var partition = GetPartition(partitionKey);
 
         var query = partition.Values.AsQueryable();
         if (!string.IsNullOrWhiteSpace(filter.SubjectId))

--- a/bff/src/Bff/SessionManagement/SessionStore/InMemoryUserSessionStore.cs
+++ b/bff/src/Bff/SessionManagement/SessionStore/InMemoryUserSessionStore.cs
@@ -11,23 +11,28 @@ namespace Duende.Bff.SessionManagement.SessionStore;
 /// In-memory user session store partitioned by partition key
 /// </summary>
 internal class InMemoryUserSessionStore(
-    UserSessionPartitionKeyBuilder partitionKeyBuilder,
     ILogger<InMemoryUserSessionStore> logger) : IUserSessionStore
 {
     // A shorthand for the concurrent dictionary of user sessions, keyed by session key.
-    private class UserSessionDictionary : ConcurrentDictionary<string, UserSession>;
+    private class UserSessionDictionary : ConcurrentDictionary<UserKey, UserSession>;
 
     // A dictionary of dictionaries, where the outer dictionary is keyed by partition key
-    private readonly ConcurrentDictionary<string, UserSessionDictionary> _store = new();
-
-    // the in-memory implementation requires a partition key to avoid issues with null values in
-    // the concurrent dictionary. 
-    private string PartitionKey => partitionKeyBuilder.BuildPartitionKey() ?? "[null]";
+    private readonly ConcurrentDictionary<PartitionKey, UserSessionDictionary> _store = new();
 
     public Task CreateUserSessionAsync(UserSession session, CT ct = default)
     {
-        var partition = GetPartition();
-        if (!partition.TryAdd(session.Key, session.Clone()))
+        if (!session.PartitionKey.HasValue)
+        {
+            throw new InvalidOperationException(nameof(session.PartitionKey) + " cannot be null");
+        }
+
+        if (!session.Key.HasValue)
+        {
+            throw new InvalidOperationException(nameof(session.Key));
+        }
+
+        var partition = GetPartition(session.PartitionKey.Value);
+        if (!partition.TryAdd(session.Key.Value, session.Clone()))
         {
             // There is a known race condition when two requests are trying to create a session at the same time.
             logger.DuplicateSessionInsertDetected(LogLevel.Information);
@@ -36,47 +41,46 @@ internal class InMemoryUserSessionStore(
         return Task.CompletedTask;
     }
 
-    private UserSessionDictionary GetPartition()
+    private UserSessionDictionary GetPartition(PartitionKey key)
     {
-        var partitionKey = PartitionKey;
-        var partition = _store.GetOrAdd(partitionKey, _ => new UserSessionDictionary());
+        var partition = _store.GetOrAdd(key, _ => new UserSessionDictionary());
         return partition;
     }
 
-    public Task<UserSession?> GetUserSessionAsync(string key, CT ct = default)
+    public Task<UserSession?> GetUserSessionAsync(UserSessionKey key, CT ct = default)
     {
-        var partition = GetPartition();
-        partition.TryGetValue(key, out var item);
+        var partition = GetPartition(key.PartitionKey);
+        partition.TryGetValue(key.UserKey, out var item);
 
         return Task.FromResult(item?.Clone());
     }
 
-    public Task UpdateUserSessionAsync(string key, UserSessionUpdate session, CT ct = default)
+    public Task UpdateUserSessionAsync(UserSessionKey key, UserSessionUpdate session, CT ct = default)
     {
-        var partition = GetPartition();
-        if (!partition.TryGetValue(key, out var existing))
+        var partition = GetPartition(key.PartitionKey);
+        if (!partition.TryGetValue(key.UserKey, out var existing))
         {
             return Task.CompletedTask;
         }
 
         var item = existing.Clone();
         session.CopyTo(item);
-        partition[key] = item;
+        partition[key.UserKey] = item;
 
         return Task.CompletedTask;
     }
 
-    public Task DeleteUserSessionAsync(string key, CT ct = default)
+    public Task DeleteUserSessionAsync(UserSessionKey key, CT ct = default)
     {
-        var partition = GetPartition();
-        partition.TryRemove(key, out _);
+        var partition = GetPartition(key.PartitionKey);
+        partition.TryRemove(key.UserKey, out _);
         return Task.CompletedTask;
     }
 
     public Task<IReadOnlyCollection<UserSession>> GetUserSessionsAsync(UserSessionsFilter filter, CT ct = default)
     {
         filter.Validate();
-        var partition = GetPartition();
+        var partition = GetPartition(filter.PartitionKey);
 
         var query = partition.Values.AsQueryable();
         if (!string.IsNullOrWhiteSpace(filter.SubjectId))
@@ -96,7 +100,7 @@ internal class InMemoryUserSessionStore(
     public Task DeleteUserSessionsAsync(UserSessionsFilter filter, CT ct = default)
     {
         filter.Validate();
-        var partition = GetPartition();
+        var partition = GetPartition(filter.PartitionKey);
 
         var query = partition.Values.AsQueryable();
         if (!string.IsNullOrWhiteSpace(filter.SubjectId))
@@ -109,7 +113,8 @@ internal class InMemoryUserSessionStore(
             query = query.Where(x => x.SessionId == filter.SessionId);
         }
 
-        var keys = query.Select(x => x.Key).ToArray();
+        var keys = query.Select(x => x.Key!.Value)
+            .ToArray();
         foreach (var key in keys)
         {
             partition.TryRemove(key, out _);

--- a/bff/src/Bff/SessionManagement/SessionStore/PartitionKey.cs
+++ b/bff/src/Bff/SessionManagement/SessionStore/PartitionKey.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using System.Diagnostics.CodeAnalysis;
+using Duende.Bff.Internal;
+
+namespace Duende.Bff.SessionManagement.SessionStore;
+
+public readonly record struct PartitionKey : IStronglyTypedValue<PartitionKey>
+{
+    public override string ToString() => Value;
+
+    // This is the default length in the db
+    public const int MaxLength = 200;
+
+    private static readonly ValidationRule<string>[] Validators =
+    [
+        ValidationRules.MaxLength(MaxLength)
+    ];
+
+    /// <summary>
+    /// You can't directly create this type. 
+    /// </summary>
+    /// <exception cref="InvalidOperationException"></exception>
+    public PartitionKey() => throw new InvalidOperationException("Can't create null value");
+
+    private PartitionKey(string value) => Value = value;
+
+    private string Value { get; }
+
+    /// <summary>
+    /// Parses a value to a <see cref="PartitionKey"/>. This method will return false if the value is invalid
+    /// and also includes a list of errors. This is useful for validating user input or other scenarios where you want to provide feedback
+    /// </summary>
+    public static bool TryParse(string value, [NotNullWhen(true)] out PartitionKey? parsed, out string[] errors) =>
+        IStronglyTypedValue<PartitionKey>.TryBuildValidatedObject(value, Validators, out parsed, out errors);
+
+    static PartitionKey IStronglyTypedValue<PartitionKey>.Create(string result) => new(result);
+
+    /// <summary>
+    /// Parses a value to a <see cref="PartitionKey"/>. This will throw an exception if the string is not valid.
+    /// </summary>
+    public static PartitionKey Parse(string value) => StringParsers<PartitionKey>.Parse(value);
+}

--- a/bff/src/Bff/SessionManagement/SessionStore/UserKey.cs
+++ b/bff/src/Bff/SessionManagement/SessionStore/UserKey.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using System.Diagnostics.CodeAnalysis;
+using Duende.Bff.Internal;
+
+namespace Duende.Bff.SessionManagement.SessionStore;
+
+public readonly record struct UserKey : IStronglyTypedValue<UserKey>
+{
+    public override string ToString() => Value;
+
+    // This is the default length in the db
+    public const int MaxLength = 200;
+
+    private static readonly ValidationRule<string>[] Validators =
+    [
+        ValidationRules.MaxLength(MaxLength)
+    ];
+
+    /// <summary>
+    /// You can't directly create this type. 
+    /// </summary>
+    /// <exception cref="InvalidOperationException"></exception>
+    public UserKey() => throw new InvalidOperationException("Can't create null value");
+
+    private UserKey(string value) => Value = value;
+
+    private string Value { get; }
+
+    /// <summary>
+    /// Parses a value to a <see cref="UserKey"/>. This method will return false if the value is invalid
+    /// and also includes a list of errors. This is useful for validating user input or other scenarios where you want to provide feedback
+    /// </summary>
+    public static bool TryParse(string value, [NotNullWhen(true)] out UserKey? parsed, out string[] errors) =>
+        IStronglyTypedValue<UserKey>.TryBuildValidatedObject(value, Validators, out parsed, out errors);
+
+    static UserKey IStronglyTypedValue<UserKey>.Create(string result) => new(result);
+
+    /// <summary>
+    /// Parses a value to a <see cref="UserKey"/>. This will throw an exception if the string is not valid.
+    /// </summary>
+    public static UserKey Parse(string value) => StringParsers<UserKey>.Parse(value);
+}

--- a/bff/src/Bff/SessionManagement/SessionStore/UserSession.cs
+++ b/bff/src/Bff/SessionManagement/SessionStore/UserSession.cs
@@ -12,7 +12,24 @@ public class UserSession : UserSessionUpdate
     /// <summary>
     /// The key
     /// </summary>
-    public string Key { get; set; } = null!;
+    public UserKey? Key { get; set; }
+
+    public PartitionKey? PartitionKey { get; set; }
+
+    internal UserSessionKey GetUserSessionKey()
+    {
+        if (!PartitionKey.HasValue)
+        {
+            throw new ArgumentNullException(nameof(PartitionKey));
+        }
+
+        if (!Key.HasValue)
+        {
+            throw new ArgumentNullException(nameof(Key));
+        }
+
+        return new UserSessionKey(PartitionKey.Value, Key.Value);
+    }
 
     /// <summary>
     /// Clones the instance
@@ -34,6 +51,7 @@ public class UserSession : UserSessionUpdate
     {
         ArgumentNullException.ThrowIfNull(other);
         other.Key = Key;
+        other.PartitionKey = PartitionKey;
         base.CopyTo(other);
     }
 }

--- a/bff/src/Bff/SessionManagement/SessionStore/UserSessionKey.cs
+++ b/bff/src/Bff/SessionManagement/SessionStore/UserSessionKey.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+namespace Duende.Bff.SessionManagement.SessionStore;
+
+public readonly record struct UserSessionKey(PartitionKey PartitionKey, UserKey UserKey)
+{
+    public override string ToString() => $"{PartitionKey}|{UserKey}";
+}

--- a/bff/src/Bff/SessionManagement/SessionStore/UserSessionsFilter.cs
+++ b/bff/src/Bff/SessionManagement/SessionStore/UserSessionsFilter.cs
@@ -8,6 +8,8 @@ namespace Duende.Bff.SessionManagement.SessionStore;
 /// </summary>
 public sealed class UserSessionsFilter
 {
+    public required PartitionKey PartitionKey { get; init; }
+
     /// <summary>
     /// The subject ID
     /// </summary>

--- a/bff/src/Bff/SessionManagement/SessionStore/UserSessionsFilter.cs
+++ b/bff/src/Bff/SessionManagement/SessionStore/UserSessionsFilter.cs
@@ -8,8 +8,6 @@ namespace Duende.Bff.SessionManagement.SessionStore;
 /// </summary>
 public sealed class UserSessionsFilter
 {
-    public required PartitionKey PartitionKey { get; init; }
-
     /// <summary>
     /// The subject ID
     /// </summary>

--- a/bff/src/Bff/SessionManagement/TicketStore/ServerSideTicketStore.cs
+++ b/bff/src/Bff/SessionManagement/TicketStore/ServerSideTicketStore.cs
@@ -38,9 +38,8 @@ internal class ServerSideTicketStore(
         // it's possible that the user re-triggered OIDC (somehow) prior to
         // the session DB records being cleaned up, so we should preemptively remove
         // conflicting session records for this sub/sid combination
-        await store.DeleteUserSessionsAsync(new UserSessionsFilter
+        await store.DeleteUserSessionsAsync(partitionKeyBuilder(), new UserSessionsFilter
         {
-            PartitionKey = partitionKeyBuilder(),
             SubjectId = ticket.GetSubjectId(),
             SessionId = ticket.GetSessionId()
         }, ct);
@@ -160,7 +159,7 @@ internal class ServerSideTicketStore(
 
         var list = new List<AuthenticationTicket>();
 
-        var sessions = await store.GetUserSessionsAsync(filter, ct);
+        var sessions = await store.GetUserSessionsAsync(partitionKeyBuilder(), filter, ct);
         foreach (var session in sessions)
         {
 

--- a/bff/test/Bff.Tests/Endpoints/Management/BackchannelLogoutEndpointTests.cs
+++ b/bff/test/Bff.Tests/Endpoints/Management/BackchannelLogoutEndpointTests.cs
@@ -124,6 +124,7 @@ public class BackchannelLogoutEndpointTests : BffTestBase
         }
     }
 
+
     /// <summary>
     /// Get the user sessions for the provided frontend. If not provided, then the current frontend (if any) is used.
     /// </summary>
@@ -134,11 +135,12 @@ public class BackchannelLogoutEndpointTests : BffTestBase
         using (var scope = Bff.ResolveForFrontend(forFrontend ?? CurrentFrontend))
         {
             var sessionStore = scope.Resolve<IUserSessionStore>();
-            return await sessionStore.GetUserSessionsAsync(new UserSessionsFilter
+            var partitionKey = scope.Resolve<BuildUserSessionPartitionKey>()();
+            var userSessionsFilter = new UserSessionsFilter
             {
-                PartitionKey = scope.Resolve<BuildUserSessionPartitionKey>()(),
                 SubjectId = The.Sub
-            });
+            };
+            return await sessionStore.GetUserSessionsAsync(partitionKey, userSessionsFilter);
         }
     }
 

--- a/bff/test/Bff.Tests/Endpoints/Management/BackchannelLogoutEndpointTests.cs
+++ b/bff/test/Bff.Tests/Endpoints/Management/BackchannelLogoutEndpointTests.cs
@@ -134,7 +134,11 @@ public class BackchannelLogoutEndpointTests : BffTestBase
         using (var scope = Bff.ResolveForFrontend(forFrontend ?? CurrentFrontend))
         {
             var sessionStore = scope.Resolve<IUserSessionStore>();
-            return await sessionStore.GetUserSessionsAsync(new UserSessionsFilter { SubjectId = The.Sub });
+            return await sessionStore.GetUserSessionsAsync(new UserSessionsFilter
+            {
+                PartitionKey = scope.Resolve<BuildUserSessionPartitionKey>()(),
+                SubjectId = The.Sub
+            });
         }
     }
 

--- a/bff/test/Bff.Tests/EntityFramework/UserSessionStoreTests.cs
+++ b/bff/test/Bff.Tests/EntityFramework/UserSessionStoreTests.cs
@@ -23,6 +23,8 @@ public class UserSessionStoreTests : IAsyncLifetime
     public TestDataBuilder Some => new TestDataBuilder(The);
     private readonly string _dbFilePath;
 
+    private UserSessionKey invalidUserSessionKey => new UserSessionKey(The.PartitionKey, UserKey.Parse("wrong"));
+
     public UserSessionStoreTests(ITestOutputHelper output)
     {
         var services = new ServiceCollection();
@@ -70,7 +72,7 @@ public class UserSessionStoreTests : IAsyncLifetime
     {
         await _subject.CreateUserSessionAsync(Some.UserSession());
 
-        using var session = UseFrontend(Some.BffFrontend());
+        using (UseFrontend(Some.BffFrontend()))
         {
             await _subject.CreateUserSessionAsync(Some.UserSession());
         }
@@ -87,7 +89,7 @@ public class UserSessionStoreTests : IAsyncLifetime
         var item = await _subject.GetUserSessionAsync(The.UserSessionKey);
 
         // Now create a session (same sid, different ticket) in a different frontend
-        using var session = UseFrontend(Some.BffFrontend());
+        using (UseFrontend(Some.BffFrontend()))
         {
             await _subject.CreateUserSessionAsync(Some.UserSession().With(x => x.Ticket = "different"));
             var item2 = await _subject.GetUserSessionAsync(The.UserSessionKey);
@@ -115,7 +117,7 @@ public class UserSessionStoreTests : IAsyncLifetime
     [Fact]
     public async Task GetUserSessionAsync_for_invalid_key_should_return_null()
     {
-        var item = await _subject.GetUserSessionAsync("invalid");
+        var item = await _subject.GetUserSessionAsync(new UserSessionKey(The.PartitionKey, UserKey.Parse("wrong")));
         item.ShouldBeNull();
     }
 
@@ -138,7 +140,7 @@ public class UserSessionStoreTests : IAsyncLifetime
 
             var item = await _subject.GetUserSessionAsync(The.UserSessionKey);
             item.ShouldNotBeNull();
-            item.Key.ShouldBe(The.UserSessionKey);
+            item.Key.ShouldBe(The.UserKey);
             item.SubjectId.ShouldBe("sub");
             item.SessionId.ShouldBe("sid");
             item.Ticket.ShouldBe("ticket2");
@@ -159,7 +161,7 @@ public class UserSessionStoreTests : IAsyncLifetime
 
             var item = await _subject.GetUserSessionAsync(The.UserSessionKey);
             item.ShouldNotBeNull();
-            item.Key.ShouldBe(The.UserSessionKey);
+            item.Key.ShouldBe(The.UserKey);
             item.SubjectId.ShouldBe("sub2");
             item.SessionId.ShouldBe("sid2");
             item.Ticket.ShouldBe("ticket3");
@@ -172,14 +174,14 @@ public class UserSessionStoreTests : IAsyncLifetime
     [Fact]
     public async Task UpdateUserSessionAsync_for_invalid_key_should_succeed()
     {
-        await _subject.UpdateUserSessionAsync("key123", new UserSessionUpdate
+        await _subject.UpdateUserSessionAsync(The.UserSessionKey, new UserSessionUpdate
         {
             Ticket = "ticket2",
             Renewed = new DateTime(2024, 1, 3, 5, 7, 9, DateTimeKind.Utc),
             Expires = new DateTime(2025, 2, 4, 6, 8, 10, DateTimeKind.Utc)
         });
 
-        var item = await _subject.GetUserSessionAsync("key123");
+        var item = await _subject.GetUserSessionAsync(The.UserSessionKey);
         item.ShouldBeNull();
     }
 
@@ -219,157 +221,135 @@ public class UserSessionStoreTests : IAsyncLifetime
 
     [Fact]
     public async Task DeleteUserSessionAsync_for_invalid_key_should_succeed() =>
-        await _subject.DeleteUserSessionAsync("invalid");
+        await _subject.DeleteUserSessionAsync(invalidUserSessionKey);
 
     [Fact]
     public async Task GetUserSessionsAsync_for_valid_sub_should_succeed()
     {
-        await _subject.CreateUserSessionAsync(new UserSession
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub1",
-            SessionId = "sid1_1",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub1";
+            x.SessionId = "sid1_1";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub1",
-            SessionId = "sid1_2",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub1";
+            x.SessionId = "sid1_2";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub2",
-            SessionId = "sid2_1",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub2";
+            x.SessionId = "sid2_1";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub2",
-            SessionId = "sid2_2",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub2";
+            x.SessionId = "sid2_2";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub2",
-            SessionId = "sid2_3",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub2";
+            x.SessionId = "sid2_3";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub3",
-            SessionId = "sid3_1",
-        });
+            x.SubjectId = "sub3";
+            x.SessionId = "sid3_1";
+        }));
 
-        var items = await _subject.GetUserSessionsAsync(new UserSessionsFilter { SubjectId = "sub2" });
+        var items = await _subject.GetUserSessionsAsync(new UserSessionsFilter
+        {
+            PartitionKey = The.PartitionKey,
+            SubjectId = "sub2"
+        });
         items.Count().ShouldBe(3);
         items.Select(x => x.SubjectId).Distinct().ToArray().ShouldBeEquivalentTo(new[] { "sub2" });
         items.Select(x => x.SessionId).ToArray().ShouldBeEquivalentTo(new[] { "sid2_1", "sid2_2", "sid2_3", });
     }
 
+    private UserSession BuildUserSessionWithRandomId() => new UserSession()
+    {
+        Key = UserKey.Parse(Guid.NewGuid().ToString()),
+        PartitionKey = The.PartitionKey,
+        Ticket = "ticket"
+    };
+
     [Fact]
     public async Task GetUserSessionsAsync_for_invalid_sub_should_return_empty()
     {
-        await _subject.CreateUserSessionAsync(new UserSession
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub1",
-            SessionId = "sid1_1",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub1";
+            x.SessionId = "sid1_1";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub1",
-            SessionId = "sid1_2",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub1";
+            x.SessionId = "sid1_2";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub2",
-            SessionId = "sid2_1",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub2";
+            x.SessionId = "sid2_1";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub2",
-            SessionId = "sid2_2",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub2";
+            x.SessionId = "sid2_2";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub2",
-            SessionId = "sid2_3",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub2";
+            x.SessionId = "sid2_3";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub3",
-            SessionId = "sid3_1",
-        });
+            x.SubjectId = "sub3";
+            x.SessionId = "sid3_1";
+        }));
 
-        var items = await _subject.GetUserSessionsAsync(new UserSessionsFilter { SubjectId = "invalid" });
+        var items = await _subject.GetUserSessionsAsync(new UserSessionsFilter
+        {
+            PartitionKey = The.PartitionKey,
+            SubjectId = "invalid"
+        });
         items.Count().ShouldBe(0);
     }
 
     [Fact]
     public async Task GetUserSessionsAsync_for_valid_sid_should_succeed()
     {
-        await _subject.CreateUserSessionAsync(new UserSession
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub1",
-            SessionId = "sid1_1",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub1";
+            x.SessionId = "sid1_2";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub1",
-            SessionId = "sid1_2",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub2";
+            x.SessionId = "sid2_1";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub2",
-            SessionId = "sid2_1",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub2";
+            x.SessionId = "sid2_2";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub2",
-            SessionId = "sid2_2",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub2";
+            x.SessionId = "sid2_3";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub2",
-            SessionId = "sid2_3",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
-        {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub3",
-            SessionId = "sid3_1",
-        });
+            x.SubjectId = "sub3";
+            x.SessionId = "sid3_1";
+        }));
 
-        var items = await _subject.GetUserSessionsAsync(new UserSessionsFilter { SessionId = "sid2_2" });
+        var items = await _subject.GetUserSessionsAsync(new UserSessionsFilter
+        {
+            PartitionKey = The.PartitionKey,
+            SessionId = "sid2_2"
+        });
         items.Count().ShouldBe(1);
         items.Select(x => x.SubjectId).ToArray().ShouldBeEquivalentTo(new[] { "sub2" });
         items.Select(x => x.SessionId).ToArray().ShouldBeEquivalentTo(new[] { "sid2_2" });
@@ -378,101 +358,85 @@ public class UserSessionStoreTests : IAsyncLifetime
     [Fact]
     public async Task GetUserSessionsAsync_for_invalid_sid_should_return_empty()
     {
-        await _subject.CreateUserSessionAsync(new UserSession
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub1",
-            SessionId = "sid1_1",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub1";
+            x.SessionId = "sid1_1";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub1",
-            SessionId = "sid1_2",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub1";
+            x.SessionId = "sid1_2";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub2",
-            SessionId = "sid2_1",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub2";
+            x.SessionId = "sid2_1";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub2",
-            SessionId = "sid2_2",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub2";
+            x.SessionId = "sid2_2";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub2",
-            SessionId = "sid2_3",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub2";
+            x.SessionId = "sid2_3";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub3",
-            SessionId = "sid3_1",
-        });
+            x.SubjectId = "sub3";
+            x.SessionId = "sid3_1";
+        }));
 
-        var items = await _subject.GetUserSessionsAsync(new UserSessionsFilter { SessionId = "invalid" });
+        var items = await _subject.GetUserSessionsAsync(new UserSessionsFilter
+        {
+            PartitionKey = The.PartitionKey,
+            SessionId = "invalid"
+        });
         items.Count().ShouldBe(0);
     }
 
     [Fact]
     public async Task GetUserSessionsAsync_for_valid_sub_and_sid_should_succeed()
     {
-        await _subject.CreateUserSessionAsync(new UserSession
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub1",
-            SessionId = "sid1_1",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub1";
+            x.SessionId = "sid1_1";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub1",
-            SessionId = "sid1_2",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub1";
+            x.SessionId = "sid1_2";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub2",
-            SessionId = "sid2_1",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub2";
+            x.SessionId = "sid2_1";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub2",
-            SessionId = "sid2_2",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub2";
+            x.SessionId = "sid2_2";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub2",
-            SessionId = "sid2_3",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub2";
+            x.SessionId = "sid2_3";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub3",
-            SessionId = "sid3_1",
-        });
+            x.SubjectId = "sub3";
+            x.SessionId = "sid3_1";
+        }));
 
         var items = await _subject.GetUserSessionsAsync(new UserSessionsFilter
-        { SubjectId = "sub2", SessionId = "sid2_2" });
+        {
+            PartitionKey = The.PartitionKey,
+            SubjectId = "sub2",
+            SessionId = "sid2_2"
+        });
         items.Count().ShouldBe(1);
         items.Select(x => x.SubjectId).ToArray().ShouldBeEquivalentTo(new[] { "sub2" });
         items.Select(x => x.SessionId).ToArray().ShouldBeEquivalentTo(new[] { "sid2_2" });
@@ -481,62 +445,62 @@ public class UserSessionStoreTests : IAsyncLifetime
     [Fact]
     public async Task GetUserSessionsAsync_for_invalid_sub_and_sid_should_succeed()
     {
-        await _subject.CreateUserSessionAsync(new UserSession
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub1",
-            SessionId = "sid1_1",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub1";
+            x.SessionId = "sid1_1";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub1",
-            SessionId = "sid1_2",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub1";
+            x.SessionId = "sid1_2";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub2",
-            SessionId = "sid2_1",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub2";
+            x.SessionId = "sid2_1";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub2",
-            SessionId = "sid2_2",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub2";
+            x.SessionId = "sid2_2";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub2",
-            SessionId = "sid2_3",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub2";
+            x.SessionId = "sid2_3";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub3",
-            SessionId = "sid3_1",
-        });
+            x.SubjectId = "sub3";
+            x.SessionId = "sid3_1";
+        }));
 
         {
             var items = await _subject.GetUserSessionsAsync(new UserSessionsFilter
-            { SubjectId = "invalid", SessionId = "invalid" });
+            {
+                PartitionKey = The.PartitionKey,
+                SubjectId = "invalid",
+                SessionId = "invalid"
+            });
             items.Count().ShouldBe(0);
         }
         {
             var items = await _subject.GetUserSessionsAsync(new UserSessionsFilter
-            { SubjectId = "sub1", SessionId = "invalid" });
+            {
+                PartitionKey = The.PartitionKey,
+                SubjectId = "sub1",
+                SessionId = "invalid"
+            });
             items.Count().ShouldBe(0);
         }
         {
             var items = await _subject.GetUserSessionsAsync(new UserSessionsFilter
-            { SubjectId = "invalid", SessionId = "sid1_1" });
+            {
+                PartitionKey = The.PartitionKey,
+                SubjectId = "invalid",
+                SessionId = "sid1_1"
+            });
             items.Count().ShouldBe(0);
         }
     }
@@ -544,7 +508,10 @@ public class UserSessionStoreTests : IAsyncLifetime
     [Fact]
     public async Task GetUserSessionsAsync_for_missing_sub_and_sid_should_throw()
     {
-        Func<Task> f = () => _subject.GetUserSessionsAsync(new UserSessionsFilter());
+        Func<Task> f = () => _subject.GetUserSessionsAsync(new UserSessionsFilter()
+        {
+            PartitionKey = The.PartitionKey,
+        });
         await f.ShouldThrowAsync<Exception>();
     }
 
@@ -552,50 +519,43 @@ public class UserSessionStoreTests : IAsyncLifetime
     [Fact]
     public async Task DeleteUserSessionsAsync_for_valid_sub_should_succeed()
     {
-        await _subject.CreateUserSessionAsync(new UserSession
-        {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub1",
-            SessionId = "sid1_1",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
-        {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub1",
-            SessionId = "sid1_2",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
-        {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub2",
-            SessionId = "sid2_1",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
-        {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub2",
-            SessionId = "sid2_2",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
-        {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub2",
-            SessionId = "sid2_3",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
-        {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub3",
-            SessionId = "sid3_1",
-        });
 
-        await _subject.DeleteUserSessionsAsync(new UserSessionsFilter { SubjectId = "sub2" });
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
+        {
+            x.SubjectId = "sub1";
+            x.SessionId = "sid1_1";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
+        {
+            x.SubjectId = "sub1";
+            x.SessionId = "sid1_2";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
+        {
+            x.SubjectId = "sub2";
+            x.SessionId = "sid2_1";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
+        {
+            x.SubjectId = "sub2";
+            x.SessionId = "sid2_2";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
+        {
+            x.SubjectId = "sub2";
+            x.SessionId = "sid2_3";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
+        {
+            x.SubjectId = "sub3";
+            x.SessionId = "sid3_1";
+        })); ;
+
+        await _subject.DeleteUserSessionsAsync(new UserSessionsFilter
+        {
+            PartitionKey = The.PartitionKey,
+            SubjectId = "sub2"
+        });
         _database.UserSessions.Count().ShouldBe(3);
         _database.UserSessions.Count(x => x.SubjectId == "sub2").ShouldBe(0);
     }
@@ -603,100 +563,80 @@ public class UserSessionStoreTests : IAsyncLifetime
     [Fact]
     public async Task DeleteUserSessionsAsync_for_invalid_sub_should_do_nothing()
     {
-        await _subject.CreateUserSessionAsync(new UserSession
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub1",
-            SessionId = "sid1_1",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub1";
+            x.SessionId = "sid1_1";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub1",
-            SessionId = "sid1_2",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub1";
+            x.SessionId = "sid1_2";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub2",
-            SessionId = "sid2_1",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub2";
+            x.SessionId = "sid2_1";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub2",
-            SessionId = "sid2_2",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub2";
+            x.SessionId = "sid2_2";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub2",
-            SessionId = "sid2_3",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub2";
+            x.SessionId = "sid2_3";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub3",
-            SessionId = "sid3_1",
-        });
+            x.SubjectId = "sub3";
+            x.SessionId = "sid3_1";
+        }));
 
-        await _subject.DeleteUserSessionsAsync(new UserSessionsFilter { SubjectId = "invalid" });
+        await _subject.DeleteUserSessionsAsync(new UserSessionsFilter
+        {
+            PartitionKey = The.PartitionKey,
+            SubjectId = "invalid"
+        });
         _database.UserSessions.Count().ShouldBe(6);
     }
 
     [Fact]
     public async Task DeleteUserSessionsAsync_for_valid_sid_should_succeed()
     {
-        await _subject.CreateUserSessionAsync(new UserSession
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub1",
-            SessionId = "sid1_1",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub1";
+            x.SessionId = "sid1_1";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub1",
-            SessionId = "sid1_2",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub1";
+            x.SessionId = "sid1_2";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub2",
-            SessionId = "sid2_1",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub2";
+            x.SessionId = "sid2_1";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub2",
-            SessionId = "sid2_2",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub2";
+            x.SessionId = "sid2_2";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub2",
-            SessionId = "sid2_3",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub2";
+            x.SessionId = "sid2_3";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub3",
-            SessionId = "sid3_1",
-        });
+            x.SubjectId = "sub3";
+            x.SessionId = "sid3_1";
+        }));
 
-        await _subject.DeleteUserSessionsAsync(new UserSessionsFilter { SessionId = "sid2_2" });
+        await _subject.DeleteUserSessionsAsync(new UserSessionsFilter { PartitionKey = The.PartitionKey, SessionId = "sid2_2" });
         _database.UserSessions.Count().ShouldBe(5);
         _database.UserSessions.Count(x => x.SessionId == "sid2_2").ShouldBe(0);
     }
@@ -704,100 +644,75 @@ public class UserSessionStoreTests : IAsyncLifetime
     [Fact]
     public async Task DeleteUserSessionsAsync_for_invalid_sid_should_do_nothing()
     {
-        await _subject.CreateUserSessionAsync(new UserSession
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub1",
-            SessionId = "sid1_1",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub1";
+            x.SessionId = "sid1_1";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub1",
-            SessionId = "sid1_2",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub1";
+            x.SessionId = "sid1_2";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub2",
-            SessionId = "sid2_1",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub2";
+            x.SessionId = "sid2_1";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub2",
-            SessionId = "sid2_2",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub2";
+            x.SessionId = "sid2_2";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub2",
-            SessionId = "sid2_3",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub2";
+            x.SessionId = "sid2_3";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub3",
-            SessionId = "sid3_1",
-        });
-
-        await _subject.DeleteUserSessionsAsync(new UserSessionsFilter { SessionId = "invalid" });
+            x.SubjectId = "sub3";
+            x.SessionId = "sid3_1";
+        }));
+        await _subject.DeleteUserSessionsAsync(new UserSessionsFilter { PartitionKey = The.PartitionKey, SessionId = "invalid" });
         _database.UserSessions.Count().ShouldBe(6);
     }
 
     [Fact]
     public async Task DeleteUserSessionsAsync_for_valid_sub_and_sid_should_succeed()
     {
-        await _subject.CreateUserSessionAsync(new UserSession
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub1",
-            SessionId = "sid1_1",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub1";
+            x.SessionId = "sid1_1";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub1",
-            SessionId = "sid1_2",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub1";
+            x.SessionId = "sid1_2";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub2",
-            SessionId = "sid2_1",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub2";
+            x.SessionId = "sid2_1";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub2",
-            SessionId = "sid2_2",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub2";
+            x.SessionId = "sid2_2";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub2",
-            SessionId = "sid2_3",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub2";
+            x.SessionId = "sid2_3";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub3",
-            SessionId = "sid3_1",
-        });
+            x.SubjectId = "sub3";
+            x.SessionId = "sid3_1";
+        }));
 
-        await _subject.DeleteUserSessionsAsync(new UserSessionsFilter { SubjectId = "sub2", SessionId = "sid2_2" });
+        await _subject.DeleteUserSessionsAsync(new UserSessionsFilter { PartitionKey = The.PartitionKey, SubjectId = "sub2", SessionId = "sid2_2" });
         _database.UserSessions.Count().ShouldBe(5);
         _database.UserSessions.Count(x => x.SubjectId == "sub2" && x.SessionId == "sid2_2").ShouldBe(0);
     }
@@ -805,62 +720,62 @@ public class UserSessionStoreTests : IAsyncLifetime
     [Fact]
     public async Task DeleteUserSessionsAsync_for_invalid_sub_and_sid_should_succeed()
     {
-        await _subject.CreateUserSessionAsync(new UserSession
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub1",
-            SessionId = "sid1_1",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub1";
+            x.SessionId = "sid1_1";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub1",
-            SessionId = "sid1_2",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub1";
+            x.SessionId = "sid1_2";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub2",
-            SessionId = "sid2_1",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub2";
+            x.SessionId = "sid2_1";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub2",
-            SessionId = "sid2_2",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub2";
+            x.SessionId = "sid2_2";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub2",
-            SessionId = "sid2_3",
-        });
-        await _subject.CreateUserSessionAsync(new UserSession
+            x.SubjectId = "sub2";
+            x.SessionId = "sid2_3";
+        }));
+        await _subject.CreateUserSessionAsync(BuildUserSessionWithRandomId().With(x =>
         {
-            Key = Guid.NewGuid().ToString(),
-            Ticket = "ticket",
-            SubjectId = "sub3",
-            SessionId = "sid3_1",
-        });
+            x.SubjectId = "sub3";
+            x.SessionId = "sid3_1";
+        }));
 
         {
             await _subject.DeleteUserSessionsAsync(new UserSessionsFilter
-            { SubjectId = "invalid", SessionId = "invalid" });
+            {
+                PartitionKey = The.PartitionKey,
+                SubjectId = "invalid",
+                SessionId = "invalid"
+            });
             _database.UserSessions.Count().ShouldBe(6);
         }
         {
             await _subject.DeleteUserSessionsAsync(new UserSessionsFilter
-            { SubjectId = "sub1", SessionId = "invalid" });
+            {
+                PartitionKey = The.PartitionKey,
+                SubjectId = "sub1",
+                SessionId = "invalid"
+            });
             _database.UserSessions.Count().ShouldBe(6);
         }
         {
             await _subject.DeleteUserSessionsAsync(new UserSessionsFilter
-            { SubjectId = "invalid", SessionId = "sid1_1" });
+            {
+                PartitionKey = The.PartitionKey,
+                SubjectId = "invalid",
+                SessionId = "sid1_1"
+            });
             _database.UserSessions.Count().ShouldBe(6);
         }
     }
@@ -868,7 +783,10 @@ public class UserSessionStoreTests : IAsyncLifetime
     [Fact]
     public async Task DeleteUserSessionsAsync_for_missing_sub_and_sid_should_throw()
     {
-        Func<Task> f = () => _subject.DeleteUserSessionsAsync(new UserSessionsFilter());
+        Func<Task> f = () => _subject.DeleteUserSessionsAsync(new UserSessionsFilter()
+        {
+            PartitionKey = The.PartitionKey,
+        });
         await f.ShouldThrowAsync<Exception>();
     }
 
@@ -883,12 +801,12 @@ public class UserSessionStoreTests : IAsyncLifetime
 
         using var scope0 = provider.CreateScope();
         var ctx0 = scope0.ServiceProvider.GetRequiredService<SessionDbContext>();
-        var key = Guid.NewGuid().ToString();
+        var key = UserKey.Parse(Guid.NewGuid().ToString());
         ctx0.UserSessions.Add(new UserSessionEntity
         {
+            PartitionKey = The.PartitionKey,
             Key = key,
             Ticket = "ticket",
-            PartitionKey = "app",
             SubjectId = "sub",
             SessionId = "sid",
         });
@@ -928,11 +846,11 @@ public class UserSessionStoreTests : IAsyncLifetime
 
     public IDisposable UseFrontend(BffFrontend frontent)
     {
-        _provider.GetRequiredService<CurrentFrontendAccessor>().Set(frontent);
-
+        var original = The.PartitionKey;
+        The.PartitionKey = PartitionKey.Parse(frontent.Name.ToString());
         return new DelegateDisposable(() =>
         {
-            _provider.GetRequiredService<CurrentFrontendAccessor>().Set(null!);
+            The.PartitionKey = original;
         });
     }
 

--- a/bff/test/Bff.Tests/EntityFramework/UserSessionStoreTests.cs
+++ b/bff/test/Bff.Tests/EntityFramework/UserSessionStoreTests.cs
@@ -257,9 +257,8 @@ public class UserSessionStoreTests : IAsyncLifetime
             x.SessionId = "sid3_1";
         }));
 
-        var items = await _subject.GetUserSessionsAsync(new UserSessionsFilter
+        var items = await _subject.GetUserSessionsAsync(The.PartitionKey, new UserSessionsFilter
         {
-            PartitionKey = The.PartitionKey,
             SubjectId = "sub2"
         });
         items.Count().ShouldBe(3);
@@ -308,9 +307,8 @@ public class UserSessionStoreTests : IAsyncLifetime
             x.SessionId = "sid3_1";
         }));
 
-        var items = await _subject.GetUserSessionsAsync(new UserSessionsFilter
+        var items = await _subject.GetUserSessionsAsync(The.PartitionKey, new UserSessionsFilter
         {
-            PartitionKey = The.PartitionKey,
             SubjectId = "invalid"
         });
         items.Count().ShouldBe(0);
@@ -345,9 +343,8 @@ public class UserSessionStoreTests : IAsyncLifetime
             x.SessionId = "sid3_1";
         }));
 
-        var items = await _subject.GetUserSessionsAsync(new UserSessionsFilter
+        var items = await _subject.GetUserSessionsAsync(The.PartitionKey, new UserSessionsFilter
         {
-            PartitionKey = The.PartitionKey,
             SessionId = "sid2_2"
         });
         items.Count().ShouldBe(1);
@@ -389,9 +386,8 @@ public class UserSessionStoreTests : IAsyncLifetime
             x.SessionId = "sid3_1";
         }));
 
-        var items = await _subject.GetUserSessionsAsync(new UserSessionsFilter
+        var items = await _subject.GetUserSessionsAsync(The.PartitionKey, new UserSessionsFilter
         {
-            PartitionKey = The.PartitionKey,
             SessionId = "invalid"
         });
         items.Count().ShouldBe(0);
@@ -431,9 +427,8 @@ public class UserSessionStoreTests : IAsyncLifetime
             x.SessionId = "sid3_1";
         }));
 
-        var items = await _subject.GetUserSessionsAsync(new UserSessionsFilter
+        var items = await _subject.GetUserSessionsAsync(The.PartitionKey, new UserSessionsFilter
         {
-            PartitionKey = The.PartitionKey,
             SubjectId = "sub2",
             SessionId = "sid2_2"
         });
@@ -477,27 +472,24 @@ public class UserSessionStoreTests : IAsyncLifetime
         }));
 
         {
-            var items = await _subject.GetUserSessionsAsync(new UserSessionsFilter
+            var items = await _subject.GetUserSessionsAsync(The.PartitionKey, new UserSessionsFilter
             {
-                PartitionKey = The.PartitionKey,
                 SubjectId = "invalid",
                 SessionId = "invalid"
             });
             items.Count().ShouldBe(0);
         }
         {
-            var items = await _subject.GetUserSessionsAsync(new UserSessionsFilter
+            var items = await _subject.GetUserSessionsAsync(The.PartitionKey, new UserSessionsFilter
             {
-                PartitionKey = The.PartitionKey,
                 SubjectId = "sub1",
                 SessionId = "invalid"
             });
             items.Count().ShouldBe(0);
         }
         {
-            var items = await _subject.GetUserSessionsAsync(new UserSessionsFilter
+            var items = await _subject.GetUserSessionsAsync(The.PartitionKey, new UserSessionsFilter
             {
-                PartitionKey = The.PartitionKey,
                 SubjectId = "invalid",
                 SessionId = "sid1_1"
             });
@@ -508,9 +500,8 @@ public class UserSessionStoreTests : IAsyncLifetime
     [Fact]
     public async Task GetUserSessionsAsync_for_missing_sub_and_sid_should_throw()
     {
-        Func<Task> f = () => _subject.GetUserSessionsAsync(new UserSessionsFilter()
+        Func<Task> f = () => _subject.GetUserSessionsAsync(The.PartitionKey, new UserSessionsFilter()
         {
-            PartitionKey = The.PartitionKey,
         });
         await f.ShouldThrowAsync<Exception>();
     }
@@ -551,9 +542,8 @@ public class UserSessionStoreTests : IAsyncLifetime
             x.SessionId = "sid3_1";
         })); ;
 
-        await _subject.DeleteUserSessionsAsync(new UserSessionsFilter
+        await _subject.DeleteUserSessionsAsync(The.PartitionKey, new UserSessionsFilter
         {
-            PartitionKey = The.PartitionKey,
             SubjectId = "sub2"
         });
         _database.UserSessions.Count().ShouldBe(3);
@@ -594,9 +584,8 @@ public class UserSessionStoreTests : IAsyncLifetime
             x.SessionId = "sid3_1";
         }));
 
-        await _subject.DeleteUserSessionsAsync(new UserSessionsFilter
+        await _subject.DeleteUserSessionsAsync(The.PartitionKey, new UserSessionsFilter
         {
-            PartitionKey = The.PartitionKey,
             SubjectId = "invalid"
         });
         _database.UserSessions.Count().ShouldBe(6);
@@ -636,7 +625,7 @@ public class UserSessionStoreTests : IAsyncLifetime
             x.SessionId = "sid3_1";
         }));
 
-        await _subject.DeleteUserSessionsAsync(new UserSessionsFilter { PartitionKey = The.PartitionKey, SessionId = "sid2_2" });
+        await _subject.DeleteUserSessionsAsync(The.PartitionKey, new UserSessionsFilter { SessionId = "sid2_2" });
         _database.UserSessions.Count().ShouldBe(5);
         _database.UserSessions.Count(x => x.SessionId == "sid2_2").ShouldBe(0);
     }
@@ -674,7 +663,7 @@ public class UserSessionStoreTests : IAsyncLifetime
             x.SubjectId = "sub3";
             x.SessionId = "sid3_1";
         }));
-        await _subject.DeleteUserSessionsAsync(new UserSessionsFilter { PartitionKey = The.PartitionKey, SessionId = "invalid" });
+        await _subject.DeleteUserSessionsAsync(The.PartitionKey, new UserSessionsFilter { SessionId = "invalid" });
         _database.UserSessions.Count().ShouldBe(6);
     }
 
@@ -712,7 +701,7 @@ public class UserSessionStoreTests : IAsyncLifetime
             x.SessionId = "sid3_1";
         }));
 
-        await _subject.DeleteUserSessionsAsync(new UserSessionsFilter { PartitionKey = The.PartitionKey, SubjectId = "sub2", SessionId = "sid2_2" });
+        await _subject.DeleteUserSessionsAsync(The.PartitionKey, new UserSessionsFilter { SubjectId = "sub2", SessionId = "sid2_2" });
         _database.UserSessions.Count().ShouldBe(5);
         _database.UserSessions.Count(x => x.SubjectId == "sub2" && x.SessionId == "sid2_2").ShouldBe(0);
     }
@@ -752,27 +741,24 @@ public class UserSessionStoreTests : IAsyncLifetime
         }));
 
         {
-            await _subject.DeleteUserSessionsAsync(new UserSessionsFilter
+            await _subject.DeleteUserSessionsAsync(The.PartitionKey, new UserSessionsFilter
             {
-                PartitionKey = The.PartitionKey,
                 SubjectId = "invalid",
                 SessionId = "invalid"
             });
             _database.UserSessions.Count().ShouldBe(6);
         }
         {
-            await _subject.DeleteUserSessionsAsync(new UserSessionsFilter
+            await _subject.DeleteUserSessionsAsync(The.PartitionKey, new UserSessionsFilter
             {
-                PartitionKey = The.PartitionKey,
                 SubjectId = "sub1",
                 SessionId = "invalid"
             });
             _database.UserSessions.Count().ShouldBe(6);
         }
         {
-            await _subject.DeleteUserSessionsAsync(new UserSessionsFilter
+            await _subject.DeleteUserSessionsAsync(The.PartitionKey, new UserSessionsFilter
             {
-                PartitionKey = The.PartitionKey,
                 SubjectId = "invalid",
                 SessionId = "sid1_1"
             });
@@ -783,9 +769,8 @@ public class UserSessionStoreTests : IAsyncLifetime
     [Fact]
     public async Task DeleteUserSessionsAsync_for_missing_sub_and_sid_should_throw()
     {
-        Func<Task> f = () => _subject.DeleteUserSessionsAsync(new UserSessionsFilter()
+        Func<Task> f = () => _subject.DeleteUserSessionsAsync(The.PartitionKey, new UserSessionsFilter()
         {
-            PartitionKey = The.PartitionKey,
         });
         await f.ShouldThrowAsync<Exception>();
     }

--- a/bff/test/Bff.Tests/PublicApiVerificationTests.VerifyPublicApi_Bff.verified.txt
+++ b/bff/test/Bff.Tests/PublicApiVerificationTests.VerifyPublicApi_Bff.verified.txt
@@ -464,9 +464,9 @@ namespace Duende.Bff.SessionManagement.SessionStore
     {
         System.Threading.Tasks.Task CreateUserSessionAsync(Duende.Bff.SessionManagement.SessionStore.UserSession session, System.Threading.CancellationToken ct = default);
         System.Threading.Tasks.Task DeleteUserSessionAsync(Duende.Bff.SessionManagement.SessionStore.UserSessionKey key, System.Threading.CancellationToken ct = default);
-        System.Threading.Tasks.Task DeleteUserSessionsAsync(Duende.Bff.SessionManagement.SessionStore.UserSessionsFilter filter, System.Threading.CancellationToken ct = default);
+        System.Threading.Tasks.Task DeleteUserSessionsAsync(Duende.Bff.SessionManagement.SessionStore.PartitionKey partitionKey, Duende.Bff.SessionManagement.SessionStore.UserSessionsFilter filter, System.Threading.CancellationToken ct = default);
         System.Threading.Tasks.Task<Duende.Bff.SessionManagement.SessionStore.UserSession?> GetUserSessionAsync(Duende.Bff.SessionManagement.SessionStore.UserSessionKey key, System.Threading.CancellationToken ct = default);
-        System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyCollection<Duende.Bff.SessionManagement.SessionStore.UserSession>> GetUserSessionsAsync(Duende.Bff.SessionManagement.SessionStore.UserSessionsFilter filter, System.Threading.CancellationToken ct = default);
+        System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyCollection<Duende.Bff.SessionManagement.SessionStore.UserSession>> GetUserSessionsAsync(Duende.Bff.SessionManagement.SessionStore.PartitionKey partitionKey, Duende.Bff.SessionManagement.SessionStore.UserSessionsFilter filter, System.Threading.CancellationToken ct = default);
         System.Threading.Tasks.Task UpdateUserSessionAsync(Duende.Bff.SessionManagement.SessionStore.UserSessionKey key, Duende.Bff.SessionManagement.SessionStore.UserSessionUpdate session, System.Threading.CancellationToken ct = default);
     }
     public interface IUserSessionStoreCleanup
@@ -515,16 +515,10 @@ namespace Duende.Bff.SessionManagement.SessionStore
         public string Ticket { get; set; }
         public void CopyTo(Duende.Bff.SessionManagement.SessionStore.UserSessionUpdate other) { }
     }
-    [System.Runtime.CompilerServices.RequiredMember]
     public sealed class UserSessionsFilter
     {
-        [System.Obsolete(("Constructors of types with required members are not supported in this version of " +
-            "your compiler."), true)]
-        [System.Runtime.CompilerServices.CompilerFeatureRequired("RequiredMembers")]
         public UserSessionsFilter() { }
         public string? SessionId { get; set; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public Duende.Bff.SessionManagement.SessionStore.PartitionKey PartitionKey { get; init; }
         public string? SubjectId { get; init; }
         public void Validate() { }
     }

--- a/bff/test/Bff.Tests/PublicApiVerificationTests.VerifyPublicApi_Bff.verified.txt
+++ b/bff/test/Bff.Tests/PublicApiVerificationTests.VerifyPublicApi_Bff.verified.txt
@@ -459,25 +459,50 @@ namespace Duende.Bff.SessionManagement.Revocation
 }
 namespace Duende.Bff.SessionManagement.SessionStore
 {
+    public delegate Duende.Bff.SessionManagement.SessionStore.PartitionKey BuildUserSessionPartitionKey();
     public interface IUserSessionStore
     {
         System.Threading.Tasks.Task CreateUserSessionAsync(Duende.Bff.SessionManagement.SessionStore.UserSession session, System.Threading.CancellationToken ct = default);
-        System.Threading.Tasks.Task DeleteUserSessionAsync(string key, System.Threading.CancellationToken ct = default);
+        System.Threading.Tasks.Task DeleteUserSessionAsync(Duende.Bff.SessionManagement.SessionStore.UserSessionKey key, System.Threading.CancellationToken ct = default);
         System.Threading.Tasks.Task DeleteUserSessionsAsync(Duende.Bff.SessionManagement.SessionStore.UserSessionsFilter filter, System.Threading.CancellationToken ct = default);
-        System.Threading.Tasks.Task<Duende.Bff.SessionManagement.SessionStore.UserSession?> GetUserSessionAsync(string key, System.Threading.CancellationToken ct = default);
+        System.Threading.Tasks.Task<Duende.Bff.SessionManagement.SessionStore.UserSession?> GetUserSessionAsync(Duende.Bff.SessionManagement.SessionStore.UserSessionKey key, System.Threading.CancellationToken ct = default);
         System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyCollection<Duende.Bff.SessionManagement.SessionStore.UserSession>> GetUserSessionsAsync(Duende.Bff.SessionManagement.SessionStore.UserSessionsFilter filter, System.Threading.CancellationToken ct = default);
-        System.Threading.Tasks.Task UpdateUserSessionAsync(string key, Duende.Bff.SessionManagement.SessionStore.UserSessionUpdate session, System.Threading.CancellationToken ct = default);
+        System.Threading.Tasks.Task UpdateUserSessionAsync(Duende.Bff.SessionManagement.SessionStore.UserSessionKey key, Duende.Bff.SessionManagement.SessionStore.UserSessionUpdate session, System.Threading.CancellationToken ct = default);
     }
     public interface IUserSessionStoreCleanup
     {
         System.Threading.Tasks.Task<int> DeleteExpiredSessionsAsync(System.Threading.CancellationToken ct = default);
     }
+    public readonly struct PartitionKey : System.IEquatable<Duende.Bff.SessionManagement.SessionStore.PartitionKey>
+    {
+        public const int MaxLength = 200;
+        public PartitionKey() { }
+        public override string ToString() { }
+        public static Duende.Bff.SessionManagement.SessionStore.PartitionKey Parse(string value) { }
+        public static bool TryParse(string value, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Duende.Bff.SessionManagement.SessionStore.PartitionKey? parsed, out string[] errors) { }
+    }
+    public readonly struct UserKey : System.IEquatable<Duende.Bff.SessionManagement.SessionStore.UserKey>
+    {
+        public const int MaxLength = 200;
+        public UserKey() { }
+        public override string ToString() { }
+        public static Duende.Bff.SessionManagement.SessionStore.UserKey Parse(string value) { }
+        public static bool TryParse(string value, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Duende.Bff.SessionManagement.SessionStore.UserKey? parsed, out string[] errors) { }
+    }
     public class UserSession : Duende.Bff.SessionManagement.SessionStore.UserSessionUpdate
     {
         public UserSession() { }
-        public string Key { get; set; }
+        public Duende.Bff.SessionManagement.SessionStore.UserKey? Key { get; set; }
+        public Duende.Bff.SessionManagement.SessionStore.PartitionKey? PartitionKey { get; set; }
         public Duende.Bff.SessionManagement.SessionStore.UserSession Clone() { }
         public void CopyTo(Duende.Bff.SessionManagement.SessionStore.UserSession other) { }
+    }
+    public readonly struct UserSessionKey : System.IEquatable<Duende.Bff.SessionManagement.SessionStore.UserSessionKey>
+    {
+        public UserSessionKey(Duende.Bff.SessionManagement.SessionStore.PartitionKey PartitionKey, Duende.Bff.SessionManagement.SessionStore.UserKey UserKey) { }
+        public Duende.Bff.SessionManagement.SessionStore.PartitionKey PartitionKey { get; init; }
+        public Duende.Bff.SessionManagement.SessionStore.UserKey UserKey { get; init; }
+        public override string ToString() { }
     }
     public class UserSessionUpdate
     {
@@ -490,10 +515,16 @@ namespace Duende.Bff.SessionManagement.SessionStore
         public string Ticket { get; set; }
         public void CopyTo(Duende.Bff.SessionManagement.SessionStore.UserSessionUpdate other) { }
     }
+    [System.Runtime.CompilerServices.RequiredMember]
     public sealed class UserSessionsFilter
     {
+        [System.Obsolete(("Constructors of types with required members are not supported in this version of " +
+            "your compiler."), true)]
+        [System.Runtime.CompilerServices.CompilerFeatureRequired("RequiredMembers")]
         public UserSessionsFilter() { }
         public string? SessionId { get; set; }
+        [System.Runtime.CompilerServices.RequiredMember]
+        public Duende.Bff.SessionManagement.SessionStore.PartitionKey PartitionKey { get; init; }
         public string? SubjectId { get; init; }
         public void Validate() { }
     }

--- a/bff/test/Bff.Tests/PublicApiVerificationTests.VerifyPublicApi_Bff_EntityFramework.verified.txt
+++ b/bff/test/Bff.Tests/PublicApiVerificationTests.VerifyPublicApi_Bff_EntityFramework.verified.txt
@@ -20,6 +20,14 @@ namespace Duende.Bff.EntityFramework
     public static class ModelBuilderExtensions
     {
         public static void ConfigureSessionContext(this Microsoft.EntityFrameworkCore.ModelBuilder modelBuilder, Duende.Bff.EntityFramework.SessionStoreOptions storeOptions) { }
+        public class PartitionKeyConverter : Microsoft.EntityFrameworkCore.Storage.ValueConversion.ValueConverter<Duende.Bff.SessionManagement.SessionStore.PartitionKey, string>
+        {
+            public PartitionKeyConverter() { }
+        }
+        public class UserKeyConverter : Microsoft.EntityFrameworkCore.Storage.ValueConversion.ValueConverter<Duende.Bff.SessionManagement.SessionStore.UserKey, string>
+        {
+            public UserKeyConverter() { }
+        }
     }
     public class SessionDbContext : Duende.Bff.EntityFramework.SessionDbContext<Duende.Bff.EntityFramework.SessionDbContext>
     {
@@ -51,6 +59,5 @@ namespace Duende.Bff.EntityFramework
     {
         public UserSessionEntity() { }
         public long Id { get; set; }
-        public string? PartitionKey { get; set; }
     }
 }

--- a/bff/test/Bff.Tests/SessionManagement/CookieSlidingTests.cs
+++ b/bff/test/Bff.Tests/SessionManagement/CookieSlidingTests.cs
@@ -32,13 +32,13 @@ public class CookieSlidingTests : BffTestBase
 
         var session = sessions.Single();
 
-        var firstTicket = await GetTicket(session.Key);
+        var firstTicket = await GetTicket(session.Key.ToString()!);
         firstTicket.ShouldNotBeNull();
 
         AdvanceClock(TimeSpan.FromMinutes(8));
         (await Bff.BrowserClient.GetIsUserLoggedInAsync()).ShouldBeTrue();
 
-        var secondTicket = await GetTicket(session.Key);
+        var secondTicket = await GetTicket(session.Key.ToString()!);
         secondTicket.ShouldNotBeNull();
 
         (secondTicket.Properties.IssuedUtc > firstTicket.Properties.IssuedUtc).ShouldBeTrue();
@@ -59,13 +59,13 @@ public class CookieSlidingTests : BffTestBase
 
         var session = sessions.Single();
 
-        var firstTicket = await GetTicket(session.Key);
+        var firstTicket = await GetTicket(session.Key.ToString()!);
         firstTicket.ShouldNotBeNull();
 
         AdvanceClock(TimeSpan.FromMinutes(8));
         (await Bff.BrowserClient.GetIsUserLoggedInAsync("slide=false")).ShouldBeTrue();
 
-        var secondTicket = await GetTicket(session.Key);
+        var secondTicket = await GetTicket(session.Key.ToString()!);
         secondTicket.ShouldNotBeNull();
 
         (secondTicket.Properties.IssuedUtc == firstTicket.Properties.IssuedUtc).ShouldBeTrue();
@@ -99,14 +99,14 @@ public class CookieSlidingTests : BffTestBase
 
         var session = sessions.Single();
 
-        var firstTicket = await GetTicket(session.Key);
+        var firstTicket = await GetTicket(session.Key.ToString()!);
         firstTicket.ShouldNotBeNull();
 
         shouldRenew = true;
         AdvanceClock(TimeSpan.FromSeconds(1));
         (await Bff.BrowserClient.GetIsUserLoggedInAsync()).ShouldBeTrue();
 
-        var secondTicket = await GetTicket(session.Key);
+        var secondTicket = await GetTicket(session.Key.ToString()!);
         secondTicket.ShouldNotBeNull();
 
         (secondTicket.Properties.IssuedUtc > firstTicket.Properties.IssuedUtc).ShouldBeTrue();
@@ -140,14 +140,14 @@ public class CookieSlidingTests : BffTestBase
 
         var session = sessions.Single();
 
-        var firstTicket = await GetTicket(session.Key);
+        var firstTicket = await GetTicket(session.Key.ToString()!);
         firstTicket.ShouldNotBeNull();
 
         shouldRenew = true;
         AdvanceClock(TimeSpan.FromSeconds(1));
         (await Bff.BrowserClient.GetIsUserLoggedInAsync("slide=false")).ShouldBeTrue();
 
-        var secondTicket = await GetTicket(session.Key);
+        var secondTicket = await GetTicket(session.Key.ToString()!);
         secondTicket.ShouldNotBeNull();
 
         (secondTicket.Properties.IssuedUtc == firstTicket.Properties.IssuedUtc).ShouldBeTrue();
@@ -165,7 +165,11 @@ public class CookieSlidingTests : BffTestBase
         using (var scope = Bff.ResolveForFrontend(CurrentFrontend))
         {
             var sessionStore = scope.Resolve<IUserSessionStore>();
-            return await sessionStore.GetUserSessionsAsync(new UserSessionsFilter { SubjectId = The.Sub });
+            return await sessionStore.GetUserSessionsAsync(new UserSessionsFilter
+            {
+                PartitionKey = scope.Resolve<UserSessionPartitionKeyBuilder>().BuildPartitionKey(),
+                SubjectId = The.Sub
+            });
         }
     }
     private async Task<AuthenticationTicket?> GetTicket(string key)

--- a/bff/test/Bff.Tests/SessionManagement/CookieSlidingTests.cs
+++ b/bff/test/Bff.Tests/SessionManagement/CookieSlidingTests.cs
@@ -165,11 +165,12 @@ public class CookieSlidingTests : BffTestBase
         using (var scope = Bff.ResolveForFrontend(CurrentFrontend))
         {
             var sessionStore = scope.Resolve<IUserSessionStore>();
-            return await sessionStore.GetUserSessionsAsync(new UserSessionsFilter
+            var partitionKey = scope.Resolve<BuildUserSessionPartitionKey>()();
+            var userSessionsFilter = new UserSessionsFilter
             {
-                PartitionKey = scope.Resolve<UserSessionPartitionKeyBuilder>().BuildPartitionKey(),
                 SubjectId = The.Sub
-            });
+            };
+            return await sessionStore.GetUserSessionsAsync(partitionKey, userSessionsFilter);
         }
     }
     private async Task<AuthenticationTicket?> GetTicket(string key)

--- a/bff/test/Bff.Tests/SessionManagement/ServerSideTicketStoreTests.cs
+++ b/bff/test/Bff.Tests/SessionManagement/ServerSideTicketStoreTests.cs
@@ -98,11 +98,12 @@ public class ServerSideTicketStoreTests : BffTestBase
         {
             var sessionStore = scope.Resolve<IUserSessionStore>();
 
-            return await sessionStore.GetUserSessionsAsync(new UserSessionsFilter
+            var partitionKey = scope.Resolve<BuildUserSessionPartitionKey>()();
+            var userSessionsFilter = new UserSessionsFilter
             {
-                PartitionKey = scope.Resolve<BuildUserSessionPartitionKey>()(),
                 SubjectId = The.Sub
-            });
+            };
+            return await sessionStore.GetUserSessionsAsync(partitionKey, userSessionsFilter);
         }
     }
 

--- a/bff/test/Bff.Tests/SessionManagement/ServerSideTicketStoreTests.cs
+++ b/bff/test/Bff.Tests/SessionManagement/ServerSideTicketStoreTests.cs
@@ -97,7 +97,12 @@ public class ServerSideTicketStoreTests : BffTestBase
         using (var scope = Bff.ResolveForFrontend(forFrontend ?? CurrentFrontend))
         {
             var sessionStore = scope.Resolve<IUserSessionStore>();
-            return await sessionStore.GetUserSessionsAsync(new UserSessionsFilter { SubjectId = The.Sub });
+
+            return await sessionStore.GetUserSessionsAsync(new UserSessionsFilter
+            {
+                PartitionKey = scope.Resolve<BuildUserSessionPartitionKey>()(),
+                SubjectId = The.Sub
+            });
         }
     }
 

--- a/bff/test/Bff.Tests/TestInfra/TestData.cs
+++ b/bff/test/Bff.Tests/TestInfra/TestData.cs
@@ -6,6 +6,7 @@ using System.Security.Cryptography;
 using System.Text.Json;
 using Duende.Bff.AccessTokenManagement;
 using Duende.Bff.DynamicFrontends;
+using Duende.Bff.SessionManagement.SessionStore;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.Extensions.Time.Testing;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
@@ -47,7 +48,11 @@ public class TestData
     public FakeTimeProvider Clock = new FakeTimeProvider(DateTimeOffset.UtcNow);
 
     public DateTimeOffset CurrentTime => Clock.GetUtcNow();
-    public string UserSessionKey = PropertyName();
+
+    public PartitionKey PartitionKey = PartitionKey.Parse(PropertyName());
+
+    public UserKey UserKey = UserKey.Parse(PropertyName());
+    public UserSessionKey UserSessionKey => new UserSessionKey(PartitionKey, UserKey);
 
     public Type TokenRetrieverType = typeof(TestTokenRetriever);
 

--- a/bff/test/Bff.Tests/TestInfra/TestDataBuilder.cs
+++ b/bff/test/Bff.Tests/TestInfra/TestDataBuilder.cs
@@ -172,7 +172,11 @@ public class TestDataBuilder(TestData the)
         },
     };
 
-    public UserSessionsFilter UserSessionsFilter() => new() { SubjectId = The.Sub };
+    public UserSessionsFilter UserSessionsFilter() => new()
+    {
+        PartitionKey = The.PartitionKey,
+        SubjectId = The.Sub
+    };
 
     internal FrontendProxyConfiguration FrontendProxyConfiguration() => new()
     {
@@ -181,7 +185,8 @@ public class TestDataBuilder(TestData the)
 
     public UserSession UserSession() => new()
     {
-        Key = The.UserSessionKey,
+        PartitionKey = The.PartitionKey,
+        Key = The.UserKey,
         SessionId = "sid",
         SubjectId = "sub",
         Created = new DateTime(2020, 3, 1, 9, 12, 33, DateTimeKind.Utc),

--- a/bff/test/Bff.Tests/TestInfra/TestDataBuilder.cs
+++ b/bff/test/Bff.Tests/TestInfra/TestDataBuilder.cs
@@ -174,7 +174,6 @@ public class TestDataBuilder(TestData the)
 
     public UserSessionsFilter UserSessionsFilter() => new()
     {
-        PartitionKey = The.PartitionKey,
         SubjectId = The.Sub
     };
 


### PR DESCRIPTION
**What issue does this PR address?**

When implementing an ApplicationBuilder, I ran into the issue that the session storage should not depend on the partition key, but instead should have this injected. 

* For testing purposes, I introduced a delegate for the partition key generation. Note, this delegate is public, because people need to be able to use it, but not an extensibility point (cannot be overwritten)
* Introduced strongly typed values for PartitionKey and UserSessionkey. In the DB, this is converted back to a string. 


**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
