### PR TITLE
change host binding for bff benchmarks

### DIFF
--- a/bff/performance/Bff.Benchmarks/Hosts/Host.cs
+++ b/bff/performance/Bff.Benchmarks/Hosts/Host.cs
@@ -40,7 +40,7 @@ public abstract class Host : IAsyncDisposable
             _builder.Logging.ClearProviders();
             //_builder.Logging.AddSerilog(Internet.Log);
 
-            _builder.WebHost.UseUrls("https://127.0.0.1:0");
+            _builder.WebHost.UseUrls("https://*:0");
         }
         else
         {


### PR DESCRIPTION
**What issue does this PR address?**
Looks like host binding is a lot faster. 


**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
