### PR TITLE
Address CA1034 Violations

### DIFF
--- a/identity-server/src/Directory.Build.props
+++ b/identity-server/src/Directory.Build.props
@@ -14,6 +14,8 @@
 
   <PropertyGroup>
     <!--
+    CA1034: Nested Types are OK
+
     Currently all existing warnings are suppressed. We will remove them as we address them. But this configuration
     allows us to prevent new warnings from being introduced while we work on the existing ones.
     -->


### PR DESCRIPTION
**What issue does this PR address?**
Stacks on #2114 to document that we will keep [CA1034](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1034) on the NoWarn list.


**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
