### PR TITLE
Token Diagnostic Entry Updates

### DIFF
--- a/identity-server/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/identity-server/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -228,7 +228,11 @@ public static class IdentityServerBuilderExtensionsCore
         builder.Services.AddSingleton<IDiagnosticEntry, ClientInfoDiagnosticEntry>();
         builder.Services.AddSingleton<ResourceLoadedTracker>();
         builder.Services.AddSingleton<IDiagnosticEntry, ResourceInfoDiagnosticEntry>();
-        builder.Services.AddSingleton<DiagnosticSummary>();
+        builder.Services.AddSingleton(serviceProvider => new DiagnosticSummary(
+            DateTime.UtcNow,
+            serviceProvider.GetServices<IDiagnosticEntry>(),
+            serviceProvider.GetRequiredService<IdentityServerOptions>(),
+            serviceProvider.GetRequiredService<ILoggerFactory>()));
         builder.Services.AddHostedService<DiagnosticHostedService>();
 
         return builder;

--- a/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticContext.cs
+++ b/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticContext.cs
@@ -1,11 +1,6 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
-using System.Text.Json;
-
 namespace Duende.IdentityServer.Licensing.V2.Diagnostics;
 
-internal interface IDiagnosticEntry
-{
-    public Task WriteAsync(DiagnosticContext context, Utf8JsonWriter writer);
-}
+public record DiagnosticContext(DateTime ServerStartTime, DateTime CurrentSeverTime);

--- a/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/AssemblyInfoDiagnosticEntry.cs
+++ b/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/AssemblyInfoDiagnosticEntry.cs
@@ -39,7 +39,7 @@ internal class AssemblyInfoDiagnosticEntry : IDiagnosticEntry
         _startsWithMatches = startsWithMatches ?? _defaultStartsWithMatches;
     }
 
-    public Task WriteAsync(Utf8JsonWriter writer)
+    public Task WriteAsync(DiagnosticContext context, Utf8JsonWriter writer)
     {
         var assemblies = GetAssemblyInfo();
         writer.WriteStartObject("AssemblyInfo");

--- a/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/AuthSchemeInfoDiagnosticEntry.cs
+++ b/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/AuthSchemeInfoDiagnosticEntry.cs
@@ -8,7 +8,7 @@ namespace Duende.IdentityServer.Licensing.V2.Diagnostics.DiagnosticEntries;
 
 internal class AuthSchemeInfoDiagnosticEntry(IAuthenticationSchemeProvider authenticationSchemeProvider) : IDiagnosticEntry
 {
-    public async Task WriteAsync(Utf8JsonWriter writer)
+    public async Task WriteAsync(DiagnosticContext context, Utf8JsonWriter writer)
     {
         var schemes = await authenticationSchemeProvider.GetAllSchemesAsync();
 

--- a/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/BasicServerInfoDiagnosticEntry.cs
+++ b/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/BasicServerInfoDiagnosticEntry.cs
@@ -7,11 +7,13 @@ namespace Duende.IdentityServer.Licensing.V2.Diagnostics.DiagnosticEntries;
 
 internal class BasicServerInfoDiagnosticEntry(Func<string> hostNameResolver) : IDiagnosticEntry
 {
-    public Task WriteAsync(Utf8JsonWriter writer)
+    public Task WriteAsync(DiagnosticContext context, Utf8JsonWriter writer)
     {
         writer.WriteStartObject("BasicServerInfo");
 
         writer.WriteString("HostName", hostNameResolver());
+        writer.WriteString("ServerStartTime", context.ServerStartTime.ToString("o"));
+        writer.WriteString("CurrentServerTime", context.CurrentSeverTime.ToString("o"));
 
         writer.WriteEndObject();
 

--- a/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/ClientInfoDiagnosticEntry.cs
+++ b/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/ClientInfoDiagnosticEntry.cs
@@ -13,7 +13,7 @@ internal class ClientInfoDiagnosticEntry(ClientLoadedTracker clientLoadedTracker
         WriteIndented = false
     };
 
-    public Task WriteAsync(Utf8JsonWriter writer)
+    public Task WriteAsync(DiagnosticContext context, Utf8JsonWriter writer)
     {
         writer.WriteStartArray("Clients");
 

--- a/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/DataProtectionDiagnosticEntry.cs
+++ b/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/DataProtectionDiagnosticEntry.cs
@@ -10,7 +10,7 @@ namespace Duende.IdentityServer.Licensing.V2.Diagnostics.DiagnosticEntries;
 
 internal class DataProtectionDiagnosticEntry(IOptions<DataProtectionOptions> dataProtectionOptions, IOptions<KeyManagementOptions> keyManagementOptions) : IDiagnosticEntry
 {
-    public Task WriteAsync(Utf8JsonWriter writer)
+    public Task WriteAsync(DiagnosticContext context, Utf8JsonWriter writer)
     {
         writer.WriteStartObject("DataProtectionConfiguration");
         writer.WriteString("ApplicationDiscriminator", dataProtectionOptions?.Value?.ApplicationDiscriminator ?? "Not Configured");

--- a/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/EndpointUsageDiagnosticEntry.cs
+++ b/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/EndpointUsageDiagnosticEntry.cs
@@ -45,7 +45,7 @@ internal class EndpointUsageDiagnosticEntry : IDiagnosticEntry
         _meterListener.Start();
     }
 
-    public Task WriteAsync(Utf8JsonWriter writer)
+    public Task WriteAsync(DiagnosticContext context, Utf8JsonWriter writer)
     {
         writer.WriteStartObject("EndpointUsage");
 

--- a/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/IdentityServerOptionsDiagnosticEntry.cs
+++ b/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/IdentityServerOptionsDiagnosticEntry.cs
@@ -23,7 +23,7 @@ internal class IdentityServerOptionsDiagnosticEntry(IOptions<IdentityServerOptio
         WriteIndented = false
     };
 
-    public Task WriteAsync(Utf8JsonWriter writer)
+    public Task WriteAsync(DiagnosticContext context, Utf8JsonWriter writer)
     {
         writer.WritePropertyName("IdentityServerOptions");
 

--- a/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/LicenseUsageDiagnosticEntry.cs
+++ b/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/LicenseUsageDiagnosticEntry.cs
@@ -7,7 +7,7 @@ namespace Duende.IdentityServer.Licensing.V2.Diagnostics.DiagnosticEntries;
 
 internal class LicenseUsageDiagnosticEntry(LicenseUsageTracker licenseUsageTracker) : IDiagnosticEntry
 {
-    public Task WriteAsync(Utf8JsonWriter writer)
+    public Task WriteAsync(DiagnosticContext context, Utf8JsonWriter writer)
     {
         writer.WriteStartObject("LicenseUsageSummary");
 

--- a/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/RegisteredImplementationsDiagnosticEntry.cs
+++ b/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/RegisteredImplementationsDiagnosticEntry.cs
@@ -160,7 +160,7 @@ internal class RegisteredImplementationsDiagnosticEntry(ServiceCollectionAccesso
         }
     };
 
-    public Task WriteAsync(Utf8JsonWriter writer)
+    public Task WriteAsync(DiagnosticContext context, Utf8JsonWriter writer)
     {
         writer.WriteStartObject("RegisteredImplementations");
 

--- a/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/ResourceInfoDiagnosticEntry.cs
+++ b/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/ResourceInfoDiagnosticEntry.cs
@@ -7,7 +7,7 @@ namespace Duende.IdentityServer.Licensing.V2.Diagnostics.DiagnosticEntries;
 
 internal class ResourceInfoDiagnosticEntry(ResourceLoadedTracker resourceLoadedTracker) : IDiagnosticEntry
 {
-    public Task WriteAsync(Utf8JsonWriter writer)
+    public Task WriteAsync(DiagnosticContext context, Utf8JsonWriter writer)
     {
         writer.WriteStartObject("Resources");
 

--- a/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/TokenIssueCountDiagnosticEntry.cs
+++ b/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/TokenIssueCountDiagnosticEntry.cs
@@ -25,6 +25,7 @@ internal class TokenIssueCountDiagnosticEntry : IDiagnosticEntry
     private long _clientCredentialsGrantTypeFlows;
     private long _resourceOwnerPasswordGrantTypeFlows;
     private long _deviceFlowGrantTypeFlows;
+    private long _refreshTokenGrantTypeFlows;
     private long _otherGrantTypeFlows;
 
     private readonly MeterListener _meterListener;
@@ -177,6 +178,9 @@ internal class TokenIssueCountDiagnosticEntry : IDiagnosticEntry
                 break;
             case GrantType.DeviceFlow:
                 Interlocked.Increment(ref _deviceFlowGrantTypeFlows);
+                break;
+            case GrantType.RefreshToken:
+                Interlocked.Increment(ref _refreshTokenGrantTypeFlows);
                 break;
             default:
                 Interlocked.Increment(ref _otherGrantTypeFlows);

--- a/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/TokenIssueCountDiagnosticEntry.cs
+++ b/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/TokenIssueCountDiagnosticEntry.cs
@@ -46,7 +46,7 @@ internal class TokenIssueCountDiagnosticEntry : IDiagnosticEntry
         _meterListener.Start();
     }
 
-    public Task WriteAsync(Utf8JsonWriter writer)
+    public Task WriteAsync(DiagnosticContext context, Utf8JsonWriter writer)
     {
         writer.WritePropertyName("TokenIssueCounts");
         writer.WriteStartObject();

--- a/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticSummary.cs
+++ b/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticSummary.cs
@@ -9,9 +9,10 @@ using Microsoft.Extensions.Logging;
 
 namespace Duende.IdentityServer.Licensing.V2.Diagnostics;
 
-internal class DiagnosticSummary(IEnumerable<IDiagnosticEntry> entries, IdentityServerOptions options, ILoggerFactory loggerFactory)
+internal class DiagnosticSummary(DateTime serverStartTime, IEnumerable<IDiagnosticEntry> entries, IdentityServerOptions options, ILoggerFactory loggerFactory)
 {
     private readonly ILogger _logger = loggerFactory.CreateLogger("Duende.IdentityServer.Diagnostics.Summary");
+
     public async Task PrintSummary()
     {
         var bufferWriter = new ArrayBufferWriter<byte>();
@@ -19,9 +20,10 @@ internal class DiagnosticSummary(IEnumerable<IDiagnosticEntry> entries, Identity
 
         writer.WriteStartObject();
 
+        var diagnosticContext = new DiagnosticContext(serverStartTime, DateTime.UtcNow);
         foreach (var diagnosticEntry in entries)
         {
-            await diagnosticEntry.WriteAsync(writer);
+            await diagnosticEntry.WriteAsync(diagnosticContext, writer);
         }
 
         writer.WriteEndObject();

--- a/identity-server/src/Storage/Models/GrantType.cs
+++ b/identity-server/src/Storage/Models/GrantType.cs
@@ -14,4 +14,5 @@ public static class GrantType
     public const string ClientCredentials = "client_credentials";
     public const string ResourceOwnerPassword = "password";
     public const string DeviceFlow = "urn:ietf:params:oauth:grant-type:device_code";
+    public const string RefreshToken = "refresh_token";
 }

--- a/identity-server/test/IdentityServer.UnitTests/Licensing/v2/DiagnosticEntries/BasicServerInfoDiagnosticEntryTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Licensing/v2/DiagnosticEntries/BasicServerInfoDiagnosticEntryTests.cs
@@ -12,11 +12,15 @@ public class BasicServerInfoDiagnosticEntryTests
     public async Task WriteAsync_ShouldWriteBasicServerInfo()
     {
         const string expectedHostName = "testing.local";
+        var expectedServerStartTime = DateTime.UtcNow.AddMinutes(-5);
+        var expectedCurrentServerTime = DateTime.UtcNow;
         var subject = new BasicServerInfoDiagnosticEntry(() => expectedHostName);
 
-        var result = await DiagnosticEntryTestHelper.WriteEntryToJson(subject);
+        var result = await DiagnosticEntryTestHelper.WriteEntryToJson(subject, expectedServerStartTime, expectedCurrentServerTime);
 
         var basicServerInfo = result.RootElement.GetProperty("BasicServerInfo");
         basicServerInfo.GetProperty("HostName").GetString().ShouldBe(expectedHostName);
+        basicServerInfo.GetProperty("ServerStartTime").GetString().ShouldBe(expectedServerStartTime.ToString("o"));
+        basicServerInfo.GetProperty("CurrentServerTime").GetString().ShouldBe(expectedCurrentServerTime.ToString("o"));
     }
 }

--- a/identity-server/test/IdentityServer.UnitTests/Licensing/v2/DiagnosticEntries/DiagnosticEntryTestHelper.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Licensing/v2/DiagnosticEntries/DiagnosticEntryTestHelper.cs
@@ -10,14 +10,14 @@ namespace IdentityServer.UnitTests.Licensing.V2.DiagnosticEntries;
 
 internal static class DiagnosticEntryTestHelper
 {
-    public static async Task<JsonDocument> WriteEntryToJson(IDiagnosticEntry subject)
+    public static async Task<JsonDocument> WriteEntryToJson(IDiagnosticEntry subject, DateTime? serverStartTime = null, DateTime? currentServerTime = null)
     {
         var bufferWriter = new ArrayBufferWriter<byte>();
 
         await using var writer = new Utf8JsonWriter(bufferWriter, new JsonWriterOptions { Indented = false });
         writer.WriteStartObject();
 
-        await subject.WriteAsync(writer);
+        await subject.WriteAsync(new DiagnosticContext(serverStartTime ?? DateTime.UtcNow.AddMinutes(-5), currentServerTime ?? DateTime.UtcNow), writer);
 
         writer.WriteEndObject();
         await writer.FlushAsync();

--- a/identity-server/test/IdentityServer.UnitTests/Licensing/v2/DiagnosticEntries/TokenIssueCountDiagnosticEntryTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Licensing/v2/DiagnosticEntries/TokenIssueCountDiagnosticEntryTests.cs
@@ -18,7 +18,7 @@ public class TokenIssueCountDiagnosticEntryTests
 
         var result = await DiagnosticEntryTestHelper.WriteEntryToJson(_subject);
 
-        result.RootElement.GetProperty("TokenIssueCounts").GetProperty("Jwt").GetInt64().ShouldBe(1);
+        result.RootElement.GetProperty("TokenIssueCounts").GetProperty("AccessTokensByType").GetProperty("Jwt").GetInt64().ShouldBe(1);
     }
 
     [Fact]
@@ -28,67 +28,67 @@ public class TokenIssueCountDiagnosticEntryTests
 
         var result = await DiagnosticEntryTestHelper.WriteEntryToJson(_subject);
 
-        result.RootElement.GetProperty("TokenIssueCounts").GetProperty("Reference").GetInt64().ShouldBe(1);
+        result.RootElement.GetProperty("TokenIssueCounts").GetProperty("AccessTokensByType").GetProperty("Reference").GetInt64().ShouldBe(1);
     }
 
     [Fact]
-    public async Task Should_Count_JwtDPoPToken()
+    public async Task Should_Count_DPoP_Constraint_For_DPoP_Constrained_JWT()
     {
         IssueToken(GrantType.AuthorizationCode, true, AccessTokenType.Jwt, false, ProofType.DPoP, false);
 
         var result = await DiagnosticEntryTestHelper.WriteEntryToJson(_subject);
 
-        result.RootElement.GetProperty("TokenIssueCounts").GetProperty("JwtDPoP").GetInt64().ShouldBe(1);
+        result.RootElement.GetProperty("TokenIssueCounts").GetProperty("AccessTokensBySenderConstraint").GetProperty("DPoP").GetInt64().ShouldBe(1);
     }
 
     [Fact]
-    public async Task Should_Count_ReferenceDPoPToken()
+    public async Task Should_Count_DPoP_Constraint_For_DPoP_Constrained_Reference_Token()
     {
         IssueToken(GrantType.AuthorizationCode, true, AccessTokenType.Reference, false, ProofType.DPoP, false);
 
         var result = await DiagnosticEntryTestHelper.WriteEntryToJson(_subject);
 
-        result.RootElement.GetProperty("TokenIssueCounts").GetProperty("ReferenceDPoP").GetInt64().ShouldBe(1);
+        result.RootElement.GetProperty("TokenIssueCounts").GetProperty("AccessTokensBySenderConstraint").GetProperty("DPoP").GetInt64().ShouldBe(1);
     }
 
     [Fact]
-    public async Task Should_Count_JwtMTlsToken()
+    public async Task Should_Count_mTLS_Constraint_For_mTLS_Constrained_JWT()
     {
         IssueToken(GrantType.AuthorizationCode, true, AccessTokenType.Jwt, false, ProofType.ClientCertificate, false);
 
         var result = await DiagnosticEntryTestHelper.WriteEntryToJson(_subject);
 
-        result.RootElement.GetProperty("TokenIssueCounts").GetProperty("JwtMTLS").GetInt64().ShouldBe(1);
+        result.RootElement.GetProperty("TokenIssueCounts").GetProperty("AccessTokensBySenderConstraint").GetProperty("mTLS").GetInt64().ShouldBe(1);
     }
 
     [Fact]
-    public async Task Should_Count_ReferenceMTlsToken()
+    public async Task Should_Count_mTLS_Constraint_For_mTLS_Constrained_Reference_Token()
     {
         IssueToken(GrantType.AuthorizationCode, true, AccessTokenType.Reference, false, ProofType.ClientCertificate, false);
 
         var result = await DiagnosticEntryTestHelper.WriteEntryToJson(_subject);
 
-        result.RootElement.GetProperty("TokenIssueCounts").GetProperty("ReferenceMTLS").GetInt64().ShouldBe(1);
+        result.RootElement.GetProperty("TokenIssueCounts").GetProperty("AccessTokensBySenderConstraint").GetProperty("mTLS").GetInt64().ShouldBe(1);
     }
 
     [Fact]
-    public async Task Should_Count_RefreshToken()
+    public async Task Should_Count_Refresh_Token()
     {
         IssueToken("refresh_token", false, AccessTokenType.Jwt, true, ProofType.None, false);
 
         var result = await DiagnosticEntryTestHelper.WriteEntryToJson(_subject);
 
-        result.RootElement.GetProperty("TokenIssueCounts").GetProperty("Refresh").GetInt64().ShouldBe(1);
+        result.RootElement.GetProperty("TokenIssueCounts").GetProperty("TokensByType").GetProperty("Refresh").GetInt64().ShouldBe(1);
     }
 
     [Fact]
-    public async Task Should_Count_IdToken()
+    public async Task Should_Count_Id_Token()
     {
         IssueToken(GrantType.AuthorizationCode, false, AccessTokenType.Jwt, false, ProofType.None, true);
 
         var result = await DiagnosticEntryTestHelper.WriteEntryToJson(_subject);
 
-        result.RootElement.GetProperty("TokenIssueCounts").GetProperty("Id").GetInt64().ShouldBe(1);
+        result.RootElement.GetProperty("TokenIssueCounts").GetProperty("TokensByType").GetProperty("Id").GetInt64().ShouldBe(1);
     }
 
     [Fact]
@@ -100,9 +100,11 @@ public class TokenIssueCountDiagnosticEntryTests
         var result = await DiagnosticEntryTestHelper.WriteEntryToJson(_subject);
 
         var tokenIssueCounts = result.RootElement.GetProperty("TokenIssueCounts");
-        tokenIssueCounts.GetProperty("Jwt").GetInt64().ShouldBe(1);
-        tokenIssueCounts.GetProperty("JwtDPoP").GetInt64().ShouldBe(1);
-        tokenIssueCounts.GetProperty("Refresh").GetInt64().ShouldBe(1);
+        tokenIssueCounts.GetProperty("AccessTokensByType").GetProperty("Jwt").GetInt64().ShouldBe(2);
+        var senderConstraint = tokenIssueCounts.GetProperty("AccessTokensBySenderConstraint");
+        senderConstraint.GetProperty("None").GetInt64().ShouldBe(1);
+        senderConstraint.GetProperty("DPoP").GetInt64().ShouldBe(1);
+        tokenIssueCounts.GetProperty("TokensByType").GetProperty("Refresh").GetInt64().ShouldBe(1);
     }
 
     [Fact]
@@ -113,14 +115,17 @@ public class TokenIssueCountDiagnosticEntryTests
         var result = await DiagnosticEntryTestHelper.WriteEntryToJson(_subject);
 
         var tokenIssueCounts = result.RootElement.GetProperty("TokenIssueCounts");
-        tokenIssueCounts.GetProperty("Jwt").GetInt64().ShouldBe(0);
-        tokenIssueCounts.GetProperty("Reference").GetInt64().ShouldBe(0);
-        tokenIssueCounts.GetProperty("JwtDPoP").GetInt64().ShouldBe(0);
-        tokenIssueCounts.GetProperty("JwtMTLS").GetInt64().ShouldBe(0);
-        tokenIssueCounts.GetProperty("ReferenceDPoP").GetInt64().ShouldBe(0);
-        tokenIssueCounts.GetProperty("ReferenceMTLS").GetInt64().ShouldBe(0);
-        tokenIssueCounts.GetProperty("Refresh").GetInt64().ShouldBe(0);
-        tokenIssueCounts.GetProperty("Id").GetInt64().ShouldBe(0);
+        var accessTokensByType = tokenIssueCounts.GetProperty("AccessTokensByType");
+        accessTokensByType.GetProperty("Jwt").GetInt64().ShouldBe(0);
+        accessTokensByType.GetProperty("Reference").GetInt64().ShouldBe(0);
+        var senderConstraint = tokenIssueCounts.GetProperty("AccessTokensBySenderConstraint");
+        senderConstraint.GetProperty("None").GetInt64().ShouldBe(0);
+        senderConstraint.GetProperty("DPoP").GetInt64().ShouldBe(0);
+        senderConstraint.GetProperty("mTLS").GetInt64().ShouldBe(0);
+        var tokensByType = tokenIssueCounts.GetProperty("TokensByType");
+        tokensByType.GetProperty("Access").GetInt64().ShouldBe(0);
+        tokensByType.GetProperty("Refresh").GetInt64().ShouldBe(0);
+        tokensByType.GetProperty("Id").GetInt64().ShouldBe(0);
     }
 
     [Fact]
@@ -131,7 +136,7 @@ public class TokenIssueCountDiagnosticEntryTests
         var result = await DiagnosticEntryTestHelper.WriteEntryToJson(_subject);
 
         var tokenIssueCounts = result.RootElement.GetProperty("TokenIssueCounts");
-        tokenIssueCounts.GetProperty(GrantType.AuthorizationCode).GetInt64().ShouldBe(1);
+        tokenIssueCounts.GetProperty("RequestsByGrantType").GetProperty(GrantType.AuthorizationCode).GetInt64().ShouldBe(1);
     }
 
     [Fact]
@@ -143,8 +148,9 @@ public class TokenIssueCountDiagnosticEntryTests
         var result = await DiagnosticEntryTestHelper.WriteEntryToJson(_subject);
 
         var tokenIssueCounts = result.RootElement.GetProperty("TokenIssueCounts");
-        tokenIssueCounts.GetProperty(GrantType.AuthorizationCode).GetInt64().ShouldBe(1);
-        tokenIssueCounts.GetProperty(GrantType.ClientCredentials).GetInt64().ShouldBe(1);
+        var grantTypeCounts = tokenIssueCounts.GetProperty("RequestsByGrantType");
+        grantTypeCounts.GetProperty(GrantType.AuthorizationCode).GetInt64().ShouldBe(1);
+        grantTypeCounts.GetProperty(GrantType.ClientCredentials).GetInt64().ShouldBe(1);
     }
 
     [Fact]
@@ -156,7 +162,7 @@ public class TokenIssueCountDiagnosticEntryTests
         var result = await DiagnosticEntryTestHelper.WriteEntryToJson(_subject);
 
         var tokenIssueCounts = result.RootElement.GetProperty("TokenIssueCounts");
-        tokenIssueCounts.GetProperty(GrantType.AuthorizationCode).GetInt64().ShouldBe(2);
+        tokenIssueCounts.GetProperty("RequestsByGrantType").GetProperty(GrantType.AuthorizationCode).GetInt64().ShouldBe(2);
     }
 
     [Fact]
@@ -174,9 +180,10 @@ public class TokenIssueCountDiagnosticEntryTests
         var result = await DiagnosticEntryTestHelper.WriteEntryToJson(_subject);
 
         var tokenIssueCounts = result.RootElement.GetProperty("TokenIssueCounts");
+        var grantTypeCounts = tokenIssueCounts.GetProperty("RequestsByGrantType");
         foreach (var grantType in grantTypes)
         {
-            tokenIssueCounts.GetProperty(grantType).GetInt64().ShouldBe(1);
+            grantTypeCounts.GetProperty(grantType).GetInt64().ShouldBe(1);
         }
     }
 
@@ -188,13 +195,17 @@ public class TokenIssueCountDiagnosticEntryTests
         var result = await DiagnosticEntryTestHelper.WriteEntryToJson(_subject);
 
         var tokenIssueCounts = result.RootElement.GetProperty("TokenIssueCounts");
-        tokenIssueCounts.GetProperty("Jwt").GetInt64().ShouldBe(0);
-        tokenIssueCounts.GetProperty("Reference").GetInt64().ShouldBe(0);
-        tokenIssueCounts.GetProperty("JwtDPoP").GetInt64().ShouldBe(0);
-        tokenIssueCounts.GetProperty("JwtMTLS").GetInt64().ShouldBe(0);
-        tokenIssueCounts.GetProperty("ReferenceDPoP").GetInt64().ShouldBe(0);
-        tokenIssueCounts.GetProperty("ReferenceMTLS").GetInt64().ShouldBe(0);
-        tokenIssueCounts.GetProperty("Refresh").GetInt64().ShouldBe(0);
+        var accessTokensByType = tokenIssueCounts.GetProperty("AccessTokensByType");
+        accessTokensByType.GetProperty("Jwt").GetInt64().ShouldBe(0);
+        accessTokensByType.GetProperty("Reference").GetInt64().ShouldBe(0);
+        var senderConstraint = tokenIssueCounts.GetProperty("AccessTokensBySenderConstraint");
+        senderConstraint.GetProperty("None").GetInt64().ShouldBe(0);
+        senderConstraint.GetProperty("DPoP").GetInt64().ShouldBe(0);
+        senderConstraint.GetProperty("mTLS").GetInt64().ShouldBe(0);
+        var tokensByType = tokenIssueCounts.GetProperty("TokensByType");
+        tokensByType.GetProperty("Access").GetInt64().ShouldBe(0);
+        tokensByType.GetProperty("Refresh").GetInt64().ShouldBe(0);
+        tokensByType.GetProperty("Id").GetInt64().ShouldBe(0);
     }
 
     private void IssueToken(string grantType, bool accessTokenIssued, AccessTokenType? accessTokenType, bool refreshTokenIssued,

--- a/identity-server/test/IdentityServer.UnitTests/Licensing/v2/DiagnosticSummaryTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Licensing/v2/DiagnosticSummaryTests.cs
@@ -25,7 +25,7 @@ public class DiagnosticSummaryTests
             secondDiagnosticEntry,
             thirdDiagnosticEntry
         };
-        var summary = new DiagnosticSummary(entries, new IdentityServerOptions(), new StubLoggerFactory(logger));
+        var summary = new DiagnosticSummary(DateTime.UtcNow, entries, new IdentityServerOptions(), new StubLoggerFactory(logger));
 
         await summary.PrintSummary();
 
@@ -42,7 +42,7 @@ public class DiagnosticSummaryTests
 
         var logger = new FakeLogger<DiagnosticSummary>();
         var diagnosticEntry = new LongDiagnosticEntry { OutputLength = chunkSize * 2 };
-        var summary = new DiagnosticSummary([diagnosticEntry], options, new StubLoggerFactory(logger));
+        var summary = new DiagnosticSummary(DateTime.UtcNow, [diagnosticEntry], options, new StubLoggerFactory(logger));
 
         await summary.PrintSummary();
 
@@ -61,7 +61,7 @@ public class DiagnosticSummaryTests
 
         var logger = new FakeLogger<DiagnosticSummary>();
         var diagnosticEntry = new LongDiagnosticEntry { OutputLength = 2, OutputCharacter = '€' };
-        var summary = new DiagnosticSummary([diagnosticEntry], options, new StubLoggerFactory(logger));
+        var summary = new DiagnosticSummary(DateTime.UtcNow, [diagnosticEntry], options, new StubLoggerFactory(logger));
 
         await summary.PrintSummary();
 
@@ -76,7 +76,7 @@ public class DiagnosticSummaryTests
 
         var logger = new FakeLogger<DiagnosticSummary>();
         var diagnosticEntry = new LongDiagnosticEntry { OutputLength = options.Diagnostics.ChunkSize * 2 };
-        var summary = new DiagnosticSummary([diagnosticEntry], options, new StubLoggerFactory(logger));
+        var summary = new DiagnosticSummary(DateTime.UtcNow, [diagnosticEntry], options, new StubLoggerFactory(logger));
 
         await summary.PrintSummary();
         foreach (var entry in logger.Collector.GetSnapshot())
@@ -91,7 +91,7 @@ public class DiagnosticSummaryTests
         var options = new IdentityServerOptions();
         var logger = new FakeLogger<DiagnosticSummary>();
         var diagnosticEntry = new LongDiagnosticEntry { OutputLength = 100000 };
-        var summary = new DiagnosticSummary([diagnosticEntry], options, new StubLoggerFactory(logger));
+        var summary = new DiagnosticSummary(DateTime.UtcNow, [diagnosticEntry], options, new StubLoggerFactory(logger));
 
         await summary.PrintSummary();
 
@@ -103,7 +103,7 @@ public class DiagnosticSummaryTests
     private class TestDiagnosticEntry : IDiagnosticEntry
     {
         public bool WasCalled { get; private set; }
-        public Task WriteAsync(Utf8JsonWriter writer)
+        public Task WriteAsync(DiagnosticContext context, Utf8JsonWriter writer)
         {
             WasCalled = true;
             return Task.CompletedTask;
@@ -115,7 +115,7 @@ public class DiagnosticSummaryTests
         public int OutputLength { get; set; }
         public char OutputCharacter { get; set; } = 'x';
 
-        public Task WriteAsync(Utf8JsonWriter writer)
+        public Task WriteAsync(DiagnosticContext context, Utf8JsonWriter writer)
         {
             writer.WriteString("test", new string(OutputCharacter, OutputLength));
             return Task.CompletedTask;


### PR DESCRIPTION
**What issue does this PR address?**
* Adds serve startup and current time to basic server info to provide more context to the rest of the data in the diagnostic dump
* Reworks structure of the token count diagnostic entry based on feedback


**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
