### PR TITLE
add xforwarded header support

### DIFF
--- a/bff/src/Bff/BffApplicationBuilderExtensions.cs
+++ b/bff/src/Bff/BffApplicationBuilderExtensions.cs
@@ -1,9 +1,12 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
+using Duende.Bff.Configuration;
 using Duende.Bff.DynamicFrontends.Internal;
 using Duende.Bff.Endpoints.Internal;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace Duende.Bff;
 
@@ -28,4 +31,47 @@ public static class BffApplicationBuilderExtensions
 
 
     public static IApplicationBuilder UseBffIndexPages(this IApplicationBuilder app) => app.UseMiddleware<ProxyIndexMiddleware>();
+
+    /// <summary>
+    /// If you have disabled automatic middleware registration using <see cref="BffOptions.AutomaticallyRegisterBffMiddleware"/>
+    /// Then you must call this very early in the aspnet core pipeline. It handles FrontendSelection, Path mapping and OpenID callbacks.
+    /// If you have not disabled automatic middleware registration, then this is called automatically by the BFF framework.
+    /// </summary>
+    public static IApplicationBuilder UseBffPreProcessing(this IApplicationBuilder app)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+        app.UseBffFrontendSelection();
+        app.UseBffPathMapping();
+        app.UseBffOpenIdCallbacks();
+        return app;
+    }
+
+    /// <summary>
+    /// If you have disabled automatic middleware registration using <see cref="BffOptions.AutomaticallyRegisterBffMiddleware"/>
+    /// Then you must call at the end of the aspnet core pipeline. It adds the remote api handling, management endpoints and index pages.
+    /// If you have not disabled automatic middleware registration, then this is called automatically by the BFF framework.
+    /// </summary>
+    /// <param name="app"></param>
+    /// <returns></returns>
+    public static IApplicationBuilder UseBffPostProcessing(this IApplicationBuilder app)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+
+        var bffOptions = app.ApplicationServices.GetRequiredService<IOptions<BffOptions>>()
+            .Value;
+        foreach (var loader in bffOptions.MiddlewareLoaders)
+        {
+            loader(app);
+        }
+        app.UseEndpoints(endpoints =>
+        {
+            if (!endpoints.AlreadyMappedManagementEndpoint(bffOptions.LoginPath, "Login"))
+            {
+                endpoints.MapBffManagementEndpoints();
+            }
+        });
+        app.UseBffIndexPages();
+        return app;
+
+    }
 }

--- a/bff/src/Bff/DynamicFrontends/Internal/ConfigureBffStartupFilter.cs
+++ b/bff/src/Bff/DynamicFrontends/Internal/ConfigureBffStartupFilter.cs
@@ -19,27 +19,15 @@ internal class ConfigureBffStartupFilter : IStartupFilter
 
             if (bffOptions.AutomaticallyRegisterBffMiddleware)
             {
-                app.UseBffFrontendSelection();
-                app.UseBffPathMapping();
-                app.UseBffOpenIdCallbacks();
+                app.UseForwardedHeaders();
+                app.UseBffPreProcessing();
             }
 
             next(app);
 
             if (bffOptions.AutomaticallyRegisterBffMiddleware)
             {
-                foreach (var loader in bffOptions.MiddlewareLoaders)
-                {
-                    loader(app);
-                }
-                app.UseEndpoints(endpoints =>
-                {
-                    if (!endpoints.AlreadyMappedManagementEndpoint(bffOptions.LoginPath, "Login"))
-                    {
-                        endpoints.MapBffManagementEndpoints();
-                    }
-                });
-                app.UseBffIndexPages();
+                app.UseBffPostProcessing();
 
             }
         };

--- a/bff/test/Bff.Tests/PublicApiVerificationTests.VerifyPublicApi_Bff.verified.txt
+++ b/bff/test/Bff.Tests/PublicApiVerificationTests.VerifyPublicApi_Bff.verified.txt
@@ -153,6 +153,8 @@ namespace Duende.Bff
         public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseBffIndexPages(this Microsoft.AspNetCore.Builder.IApplicationBuilder app) { }
         public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseBffOpenIdCallbacks(this Microsoft.AspNetCore.Builder.IApplicationBuilder app) { }
         public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseBffPathMapping(this Microsoft.AspNetCore.Builder.IApplicationBuilder app) { }
+        public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseBffPostProcessing(this Microsoft.AspNetCore.Builder.IApplicationBuilder app) { }
+        public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseBffPreProcessing(this Microsoft.AspNetCore.Builder.IApplicationBuilder app) { }
     }
     public static class BffBuilderExtensions
     {

--- a/bff/test/Bff.Tests/TestInfra/BffTestHost.cs
+++ b/bff/test/Bff.Tests/TestInfra/BffTestHost.cs
@@ -75,8 +75,16 @@ public class BffTestHost(TestHostContext context, IdentityServerTestHost identit
     protected override void ConfigureApp(IApplicationBuilder app)
     {
         app.UseRouting();
-
+        app.Use(async (c, n) =>
+        {
+            await n();
+        });
         app.UseAuthentication();
+        app.Use(async (c, n) =>
+        {
+            await n();
+            Console.WriteLine();
+        });
         app.UseAuthorization();
 
         app.UseBff();


### PR DESCRIPTION
**What issue does this PR address?**
A user reported that, if there is a proxy BEFORE the BFF, then there is a problem with handling the xforwarded headers correctly. 
https://github.com/orgs/DuendeSoftware/discussions/281

Basically, if you automatically register the BFF middleware, then it's harder to also add the XForward header checks in the pipeline. Technically, a user could also add a startup filter to add this, but I think it's a legitimate usecase. 

With this PR, the BFF now automatically adds the XForward middleware at the beginning of the pipeline. It's still up to the user to configure it. Without any configuration, this middleware should be a noop. 

Also, I've made it easier for users with two extension methods to manually add the BFF to the aspnet pipeline, if automatic registration is disabled. 


**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
