### PR TITLE
make access token type case insensitive

### DIFF
--- a/bff/src/Bff/HttpContextExtensions.cs
+++ b/bff/src/Bff/HttpContextExtensions.cs
@@ -73,7 +73,10 @@ internal static class HttpContextExtensions
 
             if (userTokenResult.WasSuccessful(out var userToken, out var userTokenFailure))
             {
-                if (userToken.AccessTokenType != OidcConstants.TokenResponse.DPoPTokenType)
+                // Doing a case insensitive comparison here, because some openid connect providers return
+                // non standard casing: https://github.com/orgs/DuendeSoftware/discussions/280#discussioncomment-13862452
+                if (!string.Equals(userToken.AccessTokenType, OidcConstants.TokenResponse.DPoPTokenType,
+                        StringComparison.OrdinalIgnoreCase))
                 {
                     return new BearerTokenResult
                     {
@@ -112,7 +115,10 @@ internal static class HttpContextExtensions
         var clientTokenResult = await context.GetClientAccessTokenAsync(userAccessTokenRequestParameters, ct);
         if (clientTokenResult.WasSuccessful(out var clientToken, out var clientTokenFailure))
         {
-            if (clientToken.AccessTokenType != OidcConstants.TokenResponse.DPoPTokenType)
+            // Doing a case insensitive comparison here, because some openid connect providers return
+            // non standard casing: https://github.com/orgs/DuendeSoftware/discussions/280#discussioncomment-13862452
+            if (!string.Equals(clientToken.AccessTokenType, OidcConstants.TokenResponse.DPoPTokenType,
+                    StringComparison.OrdinalIgnoreCase))
             {
                 return new BearerTokenResult
                 {


### PR DESCRIPTION
**What issue does this PR address?**
There are openid connect providers that return non standard casings for Bearer or DPoP token names.

fixes https://github.com/DuendeSoftware/products/issues/2131

**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
