### PR TITLE
Reorganize client creation in template

### DIFF
--- a/identity-server/templates/src/IdentityServer/Pages/Account/Login/Index.cshtml
+++ b/identity-server/templates/src/IdentityServer/Pages/Account/Login/Index.cshtml
@@ -55,7 +55,7 @@
                                 Tip: for testing, use either <code>bob</code>/<code>bob</code>, <code>alice</code>/<code>alice</code> or <code>admin</code>/<code>admin</code>
                             </small>
 
-                            <button class="btn btn-primary" name="Input.Button" value="login">Login</button>
+                            <button class="btn btn-brand" name="Input.Button" value="login">Login</button>
                             <button class="btn btn-secondary" name="Input.Button" value="cancel">Cancel</button>
                         </form>
 
@@ -80,7 +80,7 @@
                             @foreach (var provider in Model.View.VisibleExternalProviders)
                             {
                                 <li class="list-inline-item">
-                                    <a class="btn btn-primary"
+                                    <a class="btn btn-brand"
                                        asp-page="/ExternalLogin/Challenge"
                                        asp-route-scheme="@provider.AuthenticationScheme"
                                        asp-route-returnUrl="@Model.Input.ReturnUrl">

--- a/identity-server/templates/src/IdentityServer/Pages/Account/Logout/Index.cshtml
+++ b/identity-server/templates/src/IdentityServer/Pages/Account/Logout/Index.cshtml
@@ -23,7 +23,7 @@
                 <input type="hidden" name="logoutId" value="@Model.LogoutId" />
 
                 <div class="d-grid">
-                    <button class="btn btn-primary">Yes, log me out...</button>
+                    <button class="btn btn-brand">Yes, log me out...</button>
                 </div>
 
                 <div class="text-center mt-3">

--- a/identity-server/templates/src/IdentityServer/Pages/Admin/ApiScopes/ApiScopeRepository.cs
+++ b/identity-server/templates/src/IdentityServer/Pages/Admin/ApiScopes/ApiScopeRepository.cs
@@ -95,6 +95,11 @@ public class ApiScopeRepository(ConfigurationDbContext context)
     public async Task CreateAsync(ApiScopeModel model)
     {
         ArgumentNullException.ThrowIfNull(model);
+        var exists = await _context.ApiScopes.AnyAsync(x => x.Name == model.Name);
+        if (exists)
+        {
+            throw new ValidationException($"An API Scope with the name '{model.Name}' already exists.");
+        }
         var scope = new Duende.IdentityServer.Models.ApiScope()
         {
             Name = model.Name,

--- a/identity-server/templates/src/IdentityServer/Pages/Admin/ApiScopes/Edit.cshtml
+++ b/identity-server/templates/src/IdentityServer/Pages/Admin/ApiScopes/Edit.cshtml
@@ -53,7 +53,7 @@
             Go Back
         </a>
 
-        <button class="btn btn-sm btn-success"
+        <button class="btn btn-sm btn-brand"
                 type="submit"
                 name="Button"
                 value="save">

--- a/identity-server/templates/src/IdentityServer/Pages/Admin/ApiScopes/New.cshtml
+++ b/identity-server/templates/src/IdentityServer/Pages/Admin/ApiScopes/New.cshtml
@@ -40,7 +40,7 @@
             Go Back
         </a>
 
-        <button class="btn btn-sm btn-success"
+        <button class="btn btn-sm btn-brand"
                 type="submit"
                 name="Button"
                 value="save">

--- a/identity-server/templates/src/IdentityServer/Pages/Admin/ApiScopes/New.cshtml.cs
+++ b/identity-server/templates/src/IdentityServer/Pages/Admin/ApiScopes/New.cshtml.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -19,8 +20,15 @@ public class NewModel(ApiScopeRepository repository) : PageModel
     {
         if (ModelState.IsValid)
         {
-            await repository.CreateAsync(InputModel);
-            return RedirectToPage("/Admin/ApiScopes/Edit", new { id = InputModel.Name });
+            try
+            {
+                await repository.CreateAsync(InputModel);
+                return RedirectToPage("/Admin/ApiScopes/Edit", new { id = InputModel.Name });
+            }
+            catch (ValidationException ex)
+            {
+                ModelState.AddModelError(string.Empty, ex.Message);
+            }
         }
 
         return Page();

--- a/identity-server/templates/src/IdentityServer/Pages/Admin/Clients/ClientRepository.cs
+++ b/identity-server/templates/src/IdentityServer/Pages/Admin/Clients/ClientRepository.cs
@@ -192,6 +192,13 @@ public class ClientRepository(ConfigurationDbContext context)
         var defaultMachineToMachineScopes = Array.Empty<string>();
 
         ArgumentNullException.ThrowIfNull(model);
+
+        var exists = await context.Clients.AnyAsync(x => x.ClientId == model.Name);
+        if (exists)
+        {
+            throw new ValidationException($"A Client with the id '{model.ClientId}' already exists.");
+        }
+
         var client = new Duende.IdentityServer.Models.Client
         {
             ClientId = model.ClientId.Trim(),

--- a/identity-server/templates/src/IdentityServer/Pages/Admin/Clients/ClientRepository.cs
+++ b/identity-server/templates/src/IdentityServer/Pages/Admin/Clients/ClientRepository.cs
@@ -15,7 +15,7 @@ public class ClientSummaryModel
     [DisplayName("Client Id")]
     public string ClientId { get; set; } = default!;
 
-    [DisplayName("Client Name")]
+    [DisplayName("Display Name")]
     public string? Name { get; set; }
 
     [Required]

--- a/identity-server/templates/src/IdentityServer/Pages/Admin/Clients/Edit.cshtml
+++ b/identity-server/templates/src/IdentityServer/Pages/Admin/Clients/Edit.cshtml
@@ -99,8 +99,7 @@
                         <div class="form-group mb-3">
                             <label asp-for="InputModel.Name" class="form-label"></label>
                             <input class="form-control form-control-sm"
-                                   asp-for="InputModel.Name"
-                                   autofocus />
+                                   asp-for="InputModel.Name" />
                         </div>
 
                         <div class="form-group mb-3">
@@ -118,16 +117,6 @@
                                        asp-for="InputModel.RedirectUri" />
                             </div>
                             <div class="form-group mb-3">
-                                <label asp-for="InputModel.InitiateLoginUri" class="form-label"></label>
-                                <input class="form-control form-control-sm"
-                                       asp-for="InputModel.InitiateLoginUri" />
-                            </div>
-                            <div class="form-group mb-3">
-                                <label asp-for="InputModel.LogoUri" class="form-label"></label>
-                                <input class="form-control form-control-sm"
-                                       asp-for="InputModel.LogoUri" />
-                            </div>
-                            <div class="form-group mb-3">
                                 <label asp-for="InputModel.PostLogoutRedirectUri" class="form-label"></label>
                                 <input class="form-control form-control-sm"
                                        asp-for="InputModel.PostLogoutRedirectUri" />
@@ -138,9 +127,19 @@
                                        asp-for="InputModel.FrontChannelLogoutUri" />
                             </div>
                             <div class="form-group mb-3">
-                                <label asp-for="InputModel.BackChannelLogoutUri" class="form-label"></label>
-                                <input class="form-control form-control-sm"
-                                       asp-for="InputModel.BackChannelLogoutUri" />
+                              <label asp-for="InputModel.BackChannelLogoutUri" class="form-label"></label>
+                              <input class="form-control form-control-sm"
+                                     asp-for="InputModel.BackChannelLogoutUri" />
+                            </div>
+                            <div class="form-group mb-3">
+                              <label asp-for="InputModel.InitiateLoginUri" class="form-label"></label>
+                              <input class="form-control form-control-sm"
+                                     asp-for="InputModel.InitiateLoginUri" />
+                            </div>
+                            <div class="form-group mb-3">
+                              <label asp-for="InputModel.LogoUri" class="form-label"></label>
+                              <input class="form-control form-control-sm"
+                                     asp-for="InputModel.LogoUri" />
                             </div>
                         }
 

--- a/identity-server/templates/src/IdentityServer/Pages/Admin/Clients/Edit.cshtml
+++ b/identity-server/templates/src/IdentityServer/Pages/Admin/Clients/Edit.cshtml
@@ -39,7 +39,7 @@
                 Go Back
             </a>
 
-            <button class="btn btn-sm btn-success"
+            <button class="btn btn-sm btn-brand"
                     type="submit"
                     name="Button"
                     value="save">

--- a/identity-server/templates/src/IdentityServer/Pages/Admin/Clients/EditSecret.cshtml
+++ b/identity-server/templates/src/IdentityServer/Pages/Admin/Clients/EditSecret.cshtml
@@ -41,7 +41,7 @@
                 Go Back
             </a>
 
-            <button class="btn btn-sm btn-success"
+            <button class="btn btn-sm btn-brand"
                     type="submit"
                     name="Button"
                     value="save">

--- a/identity-server/templates/src/IdentityServer/Pages/Admin/Clients/New.cshtml
+++ b/identity-server/templates/src/IdentityServer/Pages/Admin/Clients/New.cshtml
@@ -38,7 +38,7 @@
                     Go Back
                 </a>
 
-                <button class="btn btn-sm btn-success" type="submit">
+                <button class="btn btn-sm btn-brand" type="submit">
                     <i class="bi bi-floppy"></i>
                     Create Client
                 </button>

--- a/identity-server/templates/src/IdentityServer/Pages/Admin/Clients/New.cshtml
+++ b/identity-server/templates/src/IdentityServer/Pages/Admin/Clients/New.cshtml
@@ -54,14 +54,24 @@
                         </h5>
                         <div class="card-body pt-2">
 
-                            <small class="mb-2 text-body-secondary d-block fst-italic">
-                                Defines the core parameters that identify your application to the identity provider—such as its name, client ID, secret and the allowed redirect/callback URLs for authentication flows.
-                            </small>
-                            <div class="form-group mb-3">
+                          <small class="mb-2 text-body-secondary d-block fst-italic">
+                            Defines the core parameters that identify your application to the identity provider—such as its name, client ID, secret and the allowed redirect/callback URLs for authentication flows.
+                          </small>
+
+                          <div class="form-group mb-3">
+                            <label asp-for="@Model.InputModel.ClientId" class="form-label"></label>
+                            <input class="form-control form-control-sm" asp-for="@Model.InputModel.ClientId" autofocus />
+                          </div>
+
+                          <div class="form-group mb-3">
+                            <label asp-for="@Model.InputModel.Secret" class="form-label"></label>
+                            <input class="form-control form-control-sm" asp-for="@Model.InputModel.Secret" />
+                          </div>
+
+                          <div class="form-group mb-3">
                                 <label asp-for="InputModel.Name" class="form-label"></label>
                                 <input class="form-control form-control-sm"
-                                       asp-for="InputModel.Name"
-                                       autofocus />
+                                       asp-for="InputModel.Name" />
                             </div>
 
                             <div class="form-group mb-3">
@@ -72,21 +82,11 @@
                                 </select>
                             </div>
 
-                            <div class="form-group mb-3">
-                                <label asp-for="@Model.InputModel.ClientId" class="form-label"></label>
-                                <input class="form-control form-control-sm" asp-for="@Model.InputModel.ClientId" autofocus />
-                            </div>
-
-                            <div class="form-group mb-3">
-                                <label asp-for="@Model.InputModel.Secret" class="form-label"></label>
-                                <input class="form-control form-control-sm" asp-for="@Model.InputModel.Secret" autofocus />
-                            </div>
-
                             @if (Model.InputModel.Flow == IdentityServerTemplate.Pages.Admin.Clients.Flow.CodeFlowWithPkce)
                             {
                                 <div class="form-group mb-3">
                                     <label asp-for="@Model.InputModel.BaseUrl" class="form-label"></label>
-                                    <input class="form-control form-control-sm" asp-for="@Model.InputModel.BaseUrl" autofocus />
+                                    <input class="form-control form-control-sm" asp-for="@Model.InputModel.BaseUrl" />
                                 </div>
 
                                 <small class="d-block bg-white rounded border p-1 px-2">

--- a/identity-server/templates/src/IdentityServer/Pages/Admin/Clients/New.cshtml.cs
+++ b/identity-server/templates/src/IdentityServer/Pages/Admin/Clients/New.cshtml.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -53,8 +54,15 @@ public class NewModel(ClientRepository repository) : PageModel
             }
         }
 
-        await repository.CreateAsync(InputModel);
-        Created = true;
+        try
+        {
+            await repository.CreateAsync(InputModel);
+            Created = true;
+        }
+        catch (ValidationException ex)
+        {
+            ModelState.AddModelError(string.Empty, ex.Message);
+        }
 
         return Page();
     }

--- a/identity-server/templates/src/IdentityServer/Pages/Admin/Clients/New.cshtml.cs
+++ b/identity-server/templates/src/IdentityServer/Pages/Admin/Clients/New.cshtml.cs
@@ -16,8 +16,7 @@ public class NewModel(ClientRepository repository) : PageModel
 
     public void OnGet(string type) => InputModel = new CreateClientModel
     {
-        Flow = type == "m2m" ? Flow.ClientCredentials : Flow.CodeFlowWithPkce,
-        ClientId = Guid.NewGuid().ToString()
+        Flow = type == "m2m" ? Flow.ClientCredentials : Flow.CodeFlowWithPkce
     };
 
     public async Task<IActionResult> OnPostAsync()

--- a/identity-server/templates/src/IdentityServer/Pages/Admin/IdentityScopes/Edit.cshtml
+++ b/identity-server/templates/src/IdentityServer/Pages/Admin/IdentityScopes/Edit.cshtml
@@ -53,7 +53,7 @@
             Go Back
         </a>
 
-        <button class="btn btn-sm btn-success"
+        <button class="btn btn-sm btn-brand"
                 type="submit"
                 name="Button"
                 value="save">

--- a/identity-server/templates/src/IdentityServer/Pages/Admin/IdentityScopes/IdentityScopeRepository.cs
+++ b/identity-server/templates/src/IdentityServer/Pages/Admin/IdentityScopes/IdentityScopeRepository.cs
@@ -95,6 +95,11 @@ public class IdentityScopeRepository(ConfigurationDbContext context)
     public async Task CreateAsync(IdentityScopeModel model)
     {
         ArgumentNullException.ThrowIfNull(model);
+        var exists = await _context.IdentityResources.AnyAsync(x => x.Name == model.Name);
+        if (exists)
+        {
+            throw new ValidationException($"An Identity Resource with the name '{model.Name}' already exists.");
+        }
         var scope = new Duende.IdentityServer.Models.IdentityResource()
         {
             Name = model.Name,

--- a/identity-server/templates/src/IdentityServer/Pages/Admin/IdentityScopes/New.cshtml
+++ b/identity-server/templates/src/IdentityServer/Pages/Admin/IdentityScopes/New.cshtml
@@ -40,7 +40,7 @@
             Go Back
         </a>
 
-        <button class="btn btn-sm btn-success"
+        <button class="btn btn-sm btn-brand"
                 type="submit"
                 name="Button"
                 value="save">

--- a/identity-server/templates/src/IdentityServer/Pages/Admin/IdentityScopes/New.cshtml.cs
+++ b/identity-server/templates/src/IdentityServer/Pages/Admin/IdentityScopes/New.cshtml.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -19,8 +20,15 @@ public class NewModel(IdentityScopeRepository repository) : PageModel
     {
         if (ModelState.IsValid)
         {
-            await repository.CreateAsync(InputModel);
-            return RedirectToPage("/Admin/IdentityScopes/Edit", new { id = InputModel.Name });
+            try
+            {
+                await repository.CreateAsync(InputModel);
+                return RedirectToPage("/Admin/IdentityScopes/Edit", new { id = InputModel.Name });
+            }
+            catch (ValidationException ex)
+            {
+                ModelState.AddModelError(string.Empty, ex.Message);
+            }
         }
 
         return Page();


### PR DESCRIPTION
Stacks on #2162 to improve the organization of the client creation form.

- Don't generate client_id
- Move client_id and secret to be top of form
- Change label of name from client name to display name
- Move uncommonly used uris lower in the form