### PR TITLE
Address CA2211 Violations

### DIFF
--- a/identity-server/CHANGELOG.md
+++ b/identity-server/CHANGELOG.md
@@ -5,6 +5,8 @@
 ## Breaking Changes
 - Address CA1707 violations by @bhazen
   - This PR removed the unused Duende.IdentityServer.Models.DiscoveryDocument class which was public
+- Address CA2211 violations by @bhazen
+  - This PR marked static properties referring to counters in Telemetry.cs as readonly
 
 ## Enhancements
 - Skip front-channel logout iframe when unnecessary by @bhazen

--- a/identity-server/src/Directory.Build.props
+++ b/identity-server/src/Directory.Build.props
@@ -21,6 +21,6 @@
     Currently all existing warnings are suppressed. We will remove them as we address them. But this configuration
     allows us to prevent new warnings from being introduced while we work on the existing ones.
     -->
-    <NoWarn>$(NoWarn);CA1002;CA1008;CA1031;CA1034;CA1040;CA1051;CA1054;CA1055;CA1056;CA1062;CA1716;CA1724;CA1725;CA1727;CA1819;CA1848;CA1851;CA2201;CA2007;CA2208;CA2211;CA2227;CA2234;CA2249;CA2253;CA2254;CA2263;CA5404;CA5394;</NoWarn>
+    <NoWarn>$(NoWarn);CA1002;CA1008;CA1031;CA1034;CA1040;CA1051;CA1054;CA1055;CA1056;CA1062;CA1716;CA1724;CA1725;CA1727;CA1819;CA1848;CA1851;CA2201;CA2007;CA2208;CA2227;CA2234;CA2249;CA2253;CA2254;CA2263;CA5404;CA5394;</NoWarn>
   </PropertyGroup>
 </Project>

--- a/identity-server/src/Shared/Telemetry/Telemetry.cs
+++ b/identity-server/src/Shared/Telemetry/Telemetry.cs
@@ -164,7 +164,7 @@ public static class Telemetry
         /// <summary>
         /// Successful Api Secret validations
         /// </summary>
-        public static Counter<long> ApiSecretValidationCounter
+        public static readonly Counter<long> ApiSecretValidationCounter
             = Meter.CreateCounter<long>(Counters.ApiSecretValidation);
 
         /// <summary>
@@ -220,7 +220,7 @@ public static class Telemetry
         /// <summary>
         /// Client configuration validation
         /// </summary>
-        public static Counter<long> ClientValidationCounter =
+        public static readonly Counter<long> ClientValidationCounter =
             Meter.CreateCounter<long>(Counters.ClientConfigValidation);
 
         /// <summary>
@@ -247,7 +247,7 @@ public static class Telemetry
         /// <summary>
         /// Successful Client Secret validations
         /// </summary>
-        public static Counter<long> ClientSecretValidationCounter =
+        public static readonly Counter<long> ClientSecretValidationCounter =
             Meter.CreateCounter<long>(Counters.ClientSecretValidation);
 
         /// <summary>
@@ -302,7 +302,7 @@ public static class Telemetry
         /// <summary>
         /// Dynamic identityprovider validations
         /// </summary>
-        public static Counter<long> DynamicIdentityProviderValidationCounter
+        public static readonly Counter<long> DynamicIdentityProviderValidationCounter
             = Meter.CreateCounter<long>(Counters.DynamicIdentityProviderValidation);
 
         /// <summary>
@@ -358,7 +358,7 @@ public static class Telemetry
         /// <summary>
         /// Pushed Authorization Request Counter
         /// </summary>
-        public static Counter<long> PushedAuthorizationRequestCounter
+        public static readonly Counter<long> PushedAuthorizationRequestCounter
             = Meter.CreateCounter<long>(Counters.PushedAuthorizationRequest);
 
         /// <summary>
@@ -385,7 +385,7 @@ public static class Telemetry
         /// <summary>
         /// Resource Owner Authentication Counter
         /// </summary>
-        public static Counter<long> ResourceOwnerAuthenticationCounter
+        public static readonly Counter<long> ResourceOwnerAuthenticationCounter
             = Meter.CreateCounter<long>(Counters.ResourceOwnerAuthentication);
 
         /// <summary>


### PR DESCRIPTION
**What issue does this PR address?**
Removes [CA2211](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2211) from the NoWarn list and addresses the resulting violations. This is technically a breaking change as the affected properties are public, but I could not think of a reason anyone would need to modify our Otel counters.


**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
