### PR TITLE
Address CA2263 Violations

### DIFF
--- a/identity-server/src/Configuration/Licensing/LicenseValidator.cs
+++ b/identity-server/src/Configuration/Licensing/LicenseValidator.cs
@@ -79,7 +79,9 @@ internal class LicenseValidator<T>
                           "Please start a conversation with us: https://duendesoftware.com/contact";
 
             // we're not using our _warningLog because we always want this emitted regardless of the context
+#pragma warning disable CA2254 // Structured logging is not needed for this message
             Logger.LogWarning(message);
+#pragma warning restore CA2254
             WarnForProductFeaturesWhenMissingLicense();
             return;
         }
@@ -186,7 +188,9 @@ internal class LicenseValidator<T>
     {
         if (Logger.IsEnabled(LogLevel.Trace))
         {
+#pragma warning disable CA2254 // Both the message template and any properties for the template are parameters here
             LoggerExtensions.LogTrace(Logger, message, args);
+#pragma warning restore CA2254
         }
     }
 
@@ -194,7 +198,9 @@ internal class LicenseValidator<T>
     {
         if (Logger.IsEnabled(LogLevel.Debug))
         {
+#pragma warning disable CA2254 // Both the message template and any properties for the template are parameters here
             LoggerExtensions.LogDebug(Logger, message, args);
+#pragma warning restore CA2254
         }
     }
 
@@ -202,7 +208,9 @@ internal class LicenseValidator<T>
     {
         if (Logger.IsEnabled(LogLevel.Information))
         {
+#pragma warning disable CA2254 // Both the message template and any properties for the template are parameters here
             LoggerExtensions.LogInformation(Logger, message, args);
+#pragma warning restore CA2254
         }
     }
 
@@ -210,7 +218,9 @@ internal class LicenseValidator<T>
     {
         if (Logger.IsEnabled(LogLevel.Warning))
         {
+#pragma warning disable CA2254 // Both the message template and any properties for the template are parameters here
             LoggerExtensions.LogWarning(Logger, message, args);
+#pragma warning restore CA2254
         }
     }
 
@@ -218,7 +228,9 @@ internal class LicenseValidator<T>
     {
         if (Logger.IsEnabled(LogLevel.Error))
         {
+#pragma warning disable CA2254 // Both the message template and any properties for the template are parameters here
             LoggerExtensions.LogError(Logger, message, args);
+#pragma warning restore CA2254
         }
     }
 }

--- a/identity-server/src/Directory.Build.props
+++ b/identity-server/src/Directory.Build.props
@@ -21,6 +21,6 @@
     Currently all existing warnings are suppressed. We will remove them as we address them. But this configuration
     allows us to prevent new warnings from being introduced while we work on the existing ones.
     -->
-    <NoWarn>$(NoWarn);CA1002;CA1008;CA1031;CA1034;CA1040;CA1051;CA1054;CA1055;CA1056;CA1062;CA1716;CA1724;CA1725;CA1727;CA1819;CA1848;CA1851;CA2201;CA2007;CA2208;CA2227;CA2234;CA2263;CA5404;CA5394;</NoWarn>
+    <NoWarn>$(NoWarn);CA1002;CA1008;CA1031;CA1034;CA1040;CA1051;CA1054;CA1055;CA1056;CA1062;CA1716;CA1724;CA1725;CA1727;CA1819;CA1848;CA1851;CA2201;CA2007;CA2208;CA2227;CA2234;CA5404;CA5394;</NoWarn>
   </PropertyGroup>
 </Project>

--- a/identity-server/src/Directory.Build.props
+++ b/identity-server/src/Directory.Build.props
@@ -21,6 +21,6 @@
     Currently all existing warnings are suppressed. We will remove them as we address them. But this configuration
     allows us to prevent new warnings from being introduced while we work on the existing ones.
     -->
-    <NoWarn>$(NoWarn);CA1002;CA1008;CA1031;CA1034;CA1040;CA1051;CA1054;CA1055;CA1056;CA1062;CA1716;CA1724;CA1725;CA1727;CA1819;CA1848;CA1851;CA2201;CA2007;CA2208;CA2227;CA2234;CA2254;CA2263;CA5404;CA5394;</NoWarn>
+    <NoWarn>$(NoWarn);CA1002;CA1008;CA1031;CA1034;CA1040;CA1051;CA1054;CA1055;CA1056;CA1062;CA1716;CA1724;CA1725;CA1727;CA1819;CA1848;CA1851;CA2201;CA2007;CA2208;CA2227;CA2234;CA2263;CA5404;CA5394;</NoWarn>
   </PropertyGroup>
 </Project>

--- a/identity-server/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Additional.cs
+++ b/identity-server/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Additional.cs
@@ -17,7 +17,7 @@ using Microsoft.Extensions.Logging;
 namespace Microsoft.Extensions.DependencyInjection;
 
 /// <summary>
-/// Builder extension methods for registering additional services 
+/// Builder extension methods for registering additional services
 /// </summary>
 public static class IdentityServerBuilderExtensionsAdditional
 {
@@ -121,7 +121,7 @@ public static class IdentityServerBuilderExtensionsAdditional
     public static IIdentityServerBuilder AddClientStore<T>(this IIdentityServerBuilder builder)
         where T : class, IClientStore
     {
-        builder.Services.TryAddTransient(typeof(T));
+        builder.Services.TryAddTransient<T>();
         builder.Services.AddTransient<IClientStore, ValidatingClientStore<T>>();
 
         return builder;
@@ -218,7 +218,7 @@ public static class IdentityServerBuilderExtensionsAdditional
     public static IIdentityServerBuilder AddCorsPolicyCache<T>(this IIdentityServerBuilder builder)
         where T : class, ICorsPolicyService
     {
-        builder.Services.TryAddTransient(typeof(T));
+        builder.Services.TryAddTransient<T>();
         builder.Services.AddTransient<ICorsPolicyService, CachingCorsPolicyService<T>>();
         return builder;
     }
@@ -538,8 +538,8 @@ public static class IdentityServerBuilderExtensionsAdditional
     public static IIdentityServerBuilder AddIdentityProviderStore<T>(this IIdentityServerBuilder builder)
         where T : class, IIdentityProviderStore
     {
-        builder.Services.TryAddTransient(typeof(T));
-        builder.Services.TryAddTransient(typeof(ValidatingIdentityProviderStore<T>));
+        builder.Services.TryAddTransient<T>();
+        builder.Services.TryAddTransient<ValidatingIdentityProviderStore<T>>();
         builder.Services.AddTransient<IIdentityProviderStore, NonCachingIdentityProviderStore<ValidatingIdentityProviderStore<T>>>();
 
         return builder;

--- a/identity-server/src/IdentityServer/Configuration/IdentityServerApplicationBuilderExtensions.cs
+++ b/identity-server/src/IdentityServer/Configuration/IdentityServerApplicationBuilderExtensions.cs
@@ -43,7 +43,7 @@ public static class IdentityServerApplicationBuilderExtensions
         app.UseMiddleware<DynamicSchemeAuthenticationMiddleware>();
 
         // it seems ok if we have UseAuthentication more than once in the pipeline --
-        // this will just re-run the various callback handlers and the default authN 
+        // this will just re-run the various callback handlers and the default authN
         // handler, which just re-assigns the user on the context. claims transformation
         // will run twice, since that's not cached (whereas the authN handler result is)
         // related: https://github.com/aspnet/Security/issues/1399
@@ -225,7 +225,9 @@ public static class IdentityServerApplicationBuilderExtensions
         {
             var error = message ?? $"Required service {service.FullName} is not registered in the DI container. Aborting startup";
 
+#pragma warning disable CA2254 // This message may not be structured, and the value is also used below making conditionals awkward
             logger.LogCritical(error);
+#pragma warning restore CA2254
 
             if (doThrow)
             {

--- a/identity-server/src/IdentityServer/Endpoints/AuthorizeEndpointBase.cs
+++ b/identity-server/src/IdentityServer/Endpoints/AuthorizeEndpointBase.cs
@@ -169,7 +169,9 @@ internal abstract class AuthorizeEndpointBase : IEndpointHandler
     {
         if (logError)
         {
+#pragma warning disable CA2254 // Structured logging is not needed for this message
             Logger.LogError(logMessage);
+#pragma warning restore CA2254
         }
 
         if (request != null)

--- a/identity-server/src/IdentityServer/Endpoints/PushedAuthorizationEndpoint.cs
+++ b/identity-server/src/IdentityServer/Endpoints/PushedAuthorizationEndpoint.cs
@@ -135,7 +135,9 @@ internal class PushedAuthorizationEndpoint : IEndpointHandler
     {
         if (logError)
         {
+#pragma warning disable CA2254 // Structured logging is not needed for this message
             _logger.LogError(logMessage);
+#pragma warning restore CA2254
         }
 
         if (request != null)

--- a/identity-server/src/IdentityServer/Endpoints/UserInfoEndpoint.cs
+++ b/identity-server/src/IdentityServer/Endpoints/UserInfoEndpoint.cs
@@ -71,7 +71,9 @@ internal class UserInfoEndpoint : IEndpointHandler
         {
             var error = "No access token found.";
 
+#pragma warning disable CA2254 // Structured logging is not needed for this message
             _logger.LogError(error);
+#pragma warning restore CA2254
             return Error(OidcConstants.ProtectedResourceErrors.InvalidToken);
         }
 

--- a/identity-server/src/IdentityServer/Licensing/LicenseValidator.cs
+++ b/identity-server/src/IdentityServer/Licensing/LicenseValidator.cs
@@ -81,7 +81,9 @@ internal class LicenseValidator<T>
                           "Please start a conversation with us: https://duendesoftware.com/contact";
 
             // we're not using our _warningLog because we always want this emitted regardless of the context
+#pragma warning disable CA2254 // Structured logging is not needed for this message
             Logger.LogWarning(message);
+#pragma warning restore CA2254
             WarnForProductFeaturesWhenMissingLicense();
             return;
         }
@@ -188,7 +190,9 @@ internal class LicenseValidator<T>
     {
         if (Logger.IsEnabled(LogLevel.Trace))
         {
+#pragma warning disable CA2254 // Both the message template and any properties for the template are parameters here
             LoggerExtensions.LogTrace(Logger, message, args);
+#pragma warning restore CA2254
         }
     }
 
@@ -196,7 +200,9 @@ internal class LicenseValidator<T>
     {
         if (Logger.IsEnabled(LogLevel.Debug))
         {
+#pragma warning disable CA2254 // Both the message template and any properties for the template are parameters here
             LoggerExtensions.LogDebug(Logger, message, args);
+#pragma warning restore CA2254
         }
     }
 
@@ -204,7 +210,9 @@ internal class LicenseValidator<T>
     {
         if (Logger.IsEnabled(LogLevel.Information))
         {
+#pragma warning disable CA2254 // Both the message template and any properties for the template are parameters here
             LoggerExtensions.LogInformation(Logger, message, args);
+#pragma warning restore CA2254
         }
     }
 
@@ -212,7 +220,9 @@ internal class LicenseValidator<T>
     {
         if (Logger.IsEnabled(LogLevel.Warning))
         {
+#pragma warning disable CA2254 // Both the message template and any properties for the template are parameters here
             LoggerExtensions.LogWarning(Logger, message, args);
+#pragma warning restore CA2254
         }
     }
 
@@ -220,7 +230,9 @@ internal class LicenseValidator<T>
     {
         if (Logger.IsEnabled(LogLevel.Error))
         {
+#pragma warning disable CA2254 // Both the message template and any properties for the template are parameters here
             LoggerExtensions.LogError(Logger, message, args);
+#pragma warning restore CA2254
         }
     }
 }

--- a/identity-server/src/IdentityServer/Logging/ILoggerExtensions.cs
+++ b/identity-server/src/IdentityServer/Logging/ILoggerExtensions.cs
@@ -12,7 +12,9 @@ internal static class ILoggerDevExtensions
     {
         if (logger.IsEnabled(LogLevel.Trace))
         {
+#pragma warning disable CA2254 // Both the message template and any properties for the template are parameters here
             LoggerExtensions.LogTrace(logger, message);
+#pragma warning restore CA2254
         }
     }
 
@@ -20,7 +22,9 @@ internal static class ILoggerDevExtensions
     {
         if (logger.IsEnabled(LogLevel.Trace))
         {
+#pragma warning disable CA2254 // Both the message template and any properties for the template are parameters here
             LoggerExtensions.LogTrace(logger, message, arg0);
+#pragma warning restore CA2254
         }
     }
 
@@ -28,7 +32,9 @@ internal static class ILoggerDevExtensions
     {
         if (logger.IsEnabled(LogLevel.Trace))
         {
+#pragma warning disable CA2254 // Both the message template and any properties for the template are parameters here
             LoggerExtensions.LogTrace(logger, message, arg0, arg1);
+#pragma warning restore CA2254
         }
     }
 
@@ -36,7 +42,9 @@ internal static class ILoggerDevExtensions
     {
         if (logger.IsEnabled(LogLevel.Trace))
         {
+#pragma warning disable CA2254 // Both the message template and any properties for the template are parameters here
             LoggerExtensions.LogTrace(logger, message, arg0, arg1, arg2);
+#pragma warning restore CA2254
         }
     }
 
@@ -44,7 +52,9 @@ internal static class ILoggerDevExtensions
     {
         if (logger.IsEnabled(LogLevel.Trace))
         {
+#pragma warning disable CA2254 // Both the message template and any properties for the template are parameters here
             LoggerExtensions.LogTrace(logger, message, arg0, arg1, arg2, arg3);
+#pragma warning restore CA2254
         }
     }
 
@@ -52,7 +62,9 @@ internal static class ILoggerDevExtensions
     {
         if (logger.IsEnabled(LogLevel.Debug))
         {
+#pragma warning disable CA2254 // Both the message template and any properties for the template are parameters here
             LoggerExtensions.LogDebug(logger, message);
+#pragma warning restore CA2254
         }
     }
 
@@ -60,7 +72,9 @@ internal static class ILoggerDevExtensions
     {
         if (logger.IsEnabled(LogLevel.Debug))
         {
+#pragma warning disable CA2254 // Both the message template and any properties for the template are parameters here
             LoggerExtensions.LogDebug(logger, message, arg0);
+#pragma warning restore CA2254
         }
     }
 
@@ -68,7 +82,9 @@ internal static class ILoggerDevExtensions
     {
         if (logger.IsEnabled(LogLevel.Debug))
         {
+#pragma warning disable CA2254 // Both the message template and any properties for the template are parameters here
             LoggerExtensions.LogDebug(logger, message, arg0, arg1);
+#pragma warning restore CA2254
         }
     }
 
@@ -76,7 +92,9 @@ internal static class ILoggerDevExtensions
     {
         if (logger.IsEnabled(LogLevel.Debug))
         {
+#pragma warning disable CA2254 // Both the message template and any properties for the template are parameters here
             LoggerExtensions.LogDebug(logger, message, arg0, arg1, arg2);
+#pragma warning restore CA2254
         }
     }
 
@@ -84,7 +102,9 @@ internal static class ILoggerDevExtensions
     {
         if (logger.IsEnabled(LogLevel.Debug))
         {
+#pragma warning disable CA2254 // Both the message template and any properties for the template are parameters here
             LoggerExtensions.LogDebug(logger, message, arg0, arg1, arg2, arg3);
+#pragma warning restore CA2254
         }
     }
 

--- a/identity-server/src/IdentityServer/Logging/SanitizedLogger.cs
+++ b/identity-server/src/IdentityServer/Logging/SanitizedLogger.cs
@@ -26,7 +26,9 @@ internal class SanitizedLogger<T>
     {
         if (_logger.IsEnabled(LogLevel.Debug))
         {
+#pragma warning disable CA2254 // Both the message template and any properties for the template are parameters here
             LoggerExtensions.LogDebug(_logger, message, args.Select(ILoggerDevExtensions.SanitizeLogParameter).ToArray());
+#pragma warning restore CA2254
         }
     }
 
@@ -34,7 +36,9 @@ internal class SanitizedLogger<T>
     {
         if (_logger.IsEnabled(LogLevel.Information))
         {
+#pragma warning disable CA2254 // Both the message template and any properties for the template are parameters here
             _logger.LogInformation(message, args.Select(ILoggerDevExtensions.SanitizeLogParameter).ToArray());
+#pragma warning restore CA2254
         }
     }
 
@@ -42,7 +46,9 @@ internal class SanitizedLogger<T>
     {
         if (_logger.IsEnabled(LogLevel.Warning))
         {
+#pragma warning disable CA2254 // Both the message template and any properties for the template are parameters here
             _logger.LogWarning(message, args.Select(ILoggerDevExtensions.SanitizeLogParameter).ToArray());
+#pragma warning restore CA2254
         }
     }
 
@@ -50,7 +56,9 @@ internal class SanitizedLogger<T>
     {
         if (_logger.IsEnabled(LogLevel.Error))
         {
+#pragma warning disable CA2254 // Both the message template and any properties for the template are parameters here
             _logger.LogError(message, args.Select(ILoggerDevExtensions.SanitizeLogParameter).ToArray());
+#pragma warning restore CA2254
         }
     }
 
@@ -58,7 +66,9 @@ internal class SanitizedLogger<T>
     {
         if (_logger.IsEnabled(LogLevel.Critical))
         {
+#pragma warning disable CA2254 // Both the message template and any properties for the template are parameters here
             _logger.LogCritical(exception, message, args.Select(ILoggerDevExtensions.SanitizeLogParameter).ToArray());
+#pragma warning restore CA2254
         }
     }
 

--- a/identity-server/src/IdentityServer/ResponseHandling/Default/AuthorizeResponseGenerator.cs
+++ b/identity-server/src/IdentityServer/ResponseHandling/Default/AuthorizeResponseGenerator.cs
@@ -105,7 +105,7 @@ public class AuthorizeResponseGenerator : IAuthorizeResponseGenerator
             return await CreateHybridFlowResponseAsync(request);
         }
 
-        Logger.LogError("Unsupported grant type: " + request.GrantType);
+        Logger.LogError("Unsupported grant type: {GrantType}", request.GrantType);
         throw new InvalidOperationException("invalid grant type: " + request.GrantType);
     }
 

--- a/identity-server/src/IdentityServer/Services/Default/DefaultDeviceFlowInteractionService.cs
+++ b/identity-server/src/IdentityServer/Services/Default/DefaultDeviceFlowInteractionService.cs
@@ -103,7 +103,9 @@ internal class DefaultDeviceFlowInteractionService : IDeviceFlowInteractionServi
 
     private DeviceFlowInteractionResult LogAndReturnError(string error, string errorDescription = null)
     {
+#pragma warning disable CA2254 // Structured logging is not needed for this message
         _logger.LogError(errorDescription);
+#pragma warning restore CA2254
         return DeviceFlowInteractionResult.Failure(error);
     }
 }

--- a/identity-server/src/IdentityServer/Services/Default/KeyManagement/FileSystemKeyStore.cs
+++ b/identity-server/src/IdentityServer/Services/Default/KeyManagement/FileSystemKeyStore.cs
@@ -69,7 +69,7 @@ public class FileSystemKeyStore : ISigningKeyStore
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error reading file: " + file.Name);
+                _logger.LogError(ex, "Error reading file: {FileName}", file.Name);
             }
         }
 
@@ -108,7 +108,7 @@ public class FileSystemKeyStore : ISigningKeyStore
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error deleting file: " + path);
+            _logger.LogError(ex, "Error deleting file: {FilePath}", path);
         }
 
         return Task.CompletedTask;

--- a/identity-server/src/IdentityServer/Validation/Default/BackchannelAuthenticationRequestValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/Default/BackchannelAuthenticationRequestValidator.cs
@@ -528,11 +528,13 @@ internal class BackchannelAuthenticationRequestValidator : IBackchannelAuthentic
             {
                 if (values == null)
                 {
-                    _logger.Log(logLevel, message + ", {@details}", details);
+                    _logger.Log(logLevel, "{Message}: {@details}", message, details);
                 }
                 else
                 {
+#pragma warning disable CA2254 // This cannot be static because the message parameter is a template to be used with values
                     _logger.Log(logLevel, message + ", details: {@details}", values, details);
+#pragma warning restore CA2254
                 }
 
             }

--- a/identity-server/src/IdentityServer/Validation/Default/DeviceAuthorizationRequestValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/Default/DeviceAuthorizationRequestValidator.cs
@@ -63,13 +63,13 @@ internal class DeviceAuthorizationRequestValidator : IDeviceAuthorizationRequest
     private void LogError(string message, ValidatedDeviceAuthorizationRequest request)
     {
         var requestDetails = new DeviceAuthorizationRequestValidationLog(request);
-        _logger.LogError(message + "\n{requestDetails}", requestDetails);
+        _logger.LogError("{Message}:{RequestDetails}", message, requestDetails);
     }
 
     private void LogError(string message, string detail, ValidatedDeviceAuthorizationRequest request)
     {
         var requestDetails = new DeviceAuthorizationRequestValidationLog(request);
-        _logger.LogError(message + ": {detail}\n{requestDetails}", detail, requestDetails);
+        _logger.LogError("{Message}: {Detail}:{RequestDetails}", message, detail, requestDetails);
     }
 
     private DeviceAuthorizationRequestValidationResult ValidateClient(ValidatedDeviceAuthorizationRequest request, ClientSecretValidationResult clientValidationResult)

--- a/identity-server/src/IdentityServer/Validation/Default/EndSessionRequestValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/Default/EndSessionRequestValidator.cs
@@ -164,7 +164,7 @@ public class EndSessionRequestValidator : IEndSessionRequestValidator
             if (uilocales.Length > Options.InputLengthRestrictions.UiLocale)
             {
                 var log = new EndSessionRequestValidationLog(validatedRequest);
-                Logger.LogWarning("UI locale too long. It will be ignored." + Environment.NewLine + "{@details}", log);
+                Logger.LogWarning("UI locale too long. It will be ignored: {@details}", log);
             }
             else
             {
@@ -193,11 +193,13 @@ public class EndSessionRequestValidator : IEndSessionRequestValidator
         if (request != null)
         {
             var log = new EndSessionRequestValidationLog(request);
-            Logger.LogInformation(message + Environment.NewLine + "{@details}", log);
+            Logger.LogInformation("{Message}:{@details}", message, log);
         }
         else
         {
+#pragma warning disable CA2254 // Structured logging is not needed for this message
             Logger.LogInformation(message);
+#pragma warning restore CA2254
         }
 
         return new EndSessionValidationResult
@@ -215,7 +217,7 @@ public class EndSessionRequestValidator : IEndSessionRequestValidator
     protected virtual void LogSuccess(ValidatedEndSessionRequest request)
     {
         var log = new EndSessionRequestValidationLog(request);
-        Logger.LogInformation("End session request validation success" + Environment.NewLine + "{@details}", log);
+        Logger.LogInformation("End session request validation success:{@details}", log);
     }
 
     /// <inheritdoc />

--- a/identity-server/src/IdentityServer/Validation/Default/RequestObjectValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/Default/RequestObjectValidator.cs
@@ -342,12 +342,12 @@ internal class RequestObjectValidator : IRequestObjectValidator
     private void LogError(string message, ValidatedAuthorizeRequest request)
     {
         var requestDetails = new AuthorizeRequestValidationLog(request, _options.Logging.AuthorizeRequestSensitiveValuesFilter);
-        _logger.LogError(message + "\n{@requestDetails}", requestDetails);
+        _logger.LogError("{Message}: {@requestDetails}", message, requestDetails);
     }
 
     private void LogError(string message, string detail, ValidatedAuthorizeRequest request)
     {
         var requestDetails = new AuthorizeRequestValidationLog(request, _options.Logging.AuthorizeRequestSensitiveValuesFilter);
-        _logger.LogError(message + ": {detail}\n{@requestDetails}", detail, requestDetails);
+        _logger.LogError("{Message}: {detail}:{@requestDetails}", message, detail, requestDetails);
     }
 }

--- a/identity-server/src/IdentityServer/Validation/Default/TokenRequestValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/Default/TokenRequestValidator.cs
@@ -1256,11 +1256,11 @@ internal class TokenRequestValidator : ITokenRequestValidator
             {
                 if (values == null)
                 {
-                    _logger.Log(logLevel, message + ", {@details}", details);
+                    _logger.Log(logLevel, "{Message}: {@details}", message, details);
                 }
                 else
                 {
-                    _logger.Log(logLevel, message + " {@values}, details: {@details}", values, details);
+                    _logger.Log(logLevel, "{Message}: {@values}, details: {@details}", message, values, details);
                 }
 
             }

--- a/identity-server/src/IdentityServer/Validation/Default/TokenValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/Default/TokenValidator.cs
@@ -464,7 +464,7 @@ internal class TokenValidator : ITokenValidator
         Error = error
     };
 
-    private void LogError(string message) => _logger.LogError(message + "\n{@logMessage}", _log);
+    private void LogError(string message) => _logger.LogError("{Message}:{@logMessage}", message, _log);
 
-    private void LogSuccess() => _logger.LogDebug("Token validation success\n{@logMessage}", _log);
+    private void LogSuccess() => _logger.LogDebug("Token validation success:{@logMessage}", _log);
 }


### PR DESCRIPTION
**What issue does this PR address?**
Stacks on #2173 to remove [CA2263](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2263) from the NoWarn list and address the resulting violations.


**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
