### PR TITLE
Support RespectNullableAnnotationsDefault 

### DIFF
--- a/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/ClientLoadedTracker.cs
+++ b/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/ClientLoadedTracker.cs
@@ -26,7 +26,7 @@ internal class ClientLoadedTracker : IDisposable
         WriteIndented = false
     };
 
-    public ClientLoadedTracker() => _defaultClient = JsonSerializer.SerializeToDocument(new Client(), _serializerOptions);
+    public ClientLoadedTracker() => _defaultClient = JsonSerializer.SerializeToDocument(new Client { ClientId = "" }, _serializerOptions);
 
     public void TrackClientLoaded(Client client)
     {

--- a/identity-server/test/IdentityServer.UnitTests/IdentityServer.UnitTests.csproj
+++ b/identity-server/test/IdentityServer.UnitTests/IdentityServer.UnitTests.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
-
+    <PackageReference Include="System.Text.Json" VersionOverride="9.0.8" />
   </ItemGroup>
 
   <ItemGroup>
@@ -32,5 +32,8 @@
     <Folder Include="Licensing\v2\licenses\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <RuntimeHostConfigurationOption Include="System.Text.Json.Serialization.RespectNullableAnnotationsDefault" Value="true" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This sets a non-null value into a default client that is serialized, allowing RespectNullableAnnotationsDefault to be enabled.