### PR TITLE
Set synchronization delay to 0

### DIFF
--- a/identity-server/hosts/AspNetIdentity/IdentityServerExtensions.cs
+++ b/identity-server/hosts/AspNetIdentity/IdentityServerExtensions.cs
@@ -10,7 +10,16 @@ internal static class IdentityServerExtensions
 {
     internal static WebApplicationBuilder ConfigureIdentityServer(this WebApplicationBuilder builder)
     {
-        builder.Services.AddIdentityServer()
+        builder.Services.AddIdentityServer(opt =>
+            {
+                // In load-balanced environments, synchronization delay is important.
+                // In development, we're never load balanced and can skip it to start up faster.
+                if (builder.Environment.IsDevelopment())
+                {
+                    opt.KeyManagement.InitializationSynchronizationDelay = TimeSpan.Zero;
+                }
+            }
+        )
             .AddInMemoryIdentityResources(TestResources.IdentityResources)
             .AddInMemoryApiResources(TestResources.ApiResources)
             .AddInMemoryApiScopes(TestResources.ApiScopes)

--- a/identity-server/hosts/EntityFramework-dotnet9/IdentityServerExtensions.cs
+++ b/identity-server/hosts/EntityFramework-dotnet9/IdentityServerExtensions.cs
@@ -48,6 +48,13 @@ internal static class IdentityServerExtensions
                 UseX509Certificate = true
             });
 
+            // In load-balanced environments, synchronization delay is important.
+            // In development, we're never load balanced and can skip it to start up faster.
+            if (builder.Environment.IsDevelopment())
+            {
+                options.KeyManagement.InitializationSynchronizationDelay = TimeSpan.Zero;
+            }
+
             options.MutualTls.Enabled = true;
 
             options.Diagnostics.ChunkSize = 1024 * 1000 - 32; // 1 MB minus some formatting space;

--- a/identity-server/hosts/EntityFramework/IdentityServerExtensions.cs
+++ b/identity-server/hosts/EntityFramework/IdentityServerExtensions.cs
@@ -48,6 +48,13 @@ internal static class IdentityServerExtensions
                 UseX509Certificate = true
             });
 
+            // In load-balanced environments, synchronization delay is important.
+            // In development, we're never load balanced and can skip it to start up faster.
+            if (builder.Environment.IsDevelopment())
+            {
+                options.KeyManagement.InitializationSynchronizationDelay = TimeSpan.Zero;
+            }
+
             options.MutualTls.Enabled = true;
 
             options.Diagnostics.ChunkSize = 1024 * 1000 - 32; // 1 MB minus some formatting space;

--- a/identity-server/hosts/main/IdentityServerExtensions.cs
+++ b/identity-server/hosts/main/IdentityServerExtensions.cs
@@ -39,6 +39,13 @@ internal static class IdentityServerExtensions
                     UseX509Certificate = true
                 });
 
+                // In load-balanced environments, synchronization delay is important.
+                // In development, we're never load balanced and can skip it to start up faster.
+                if (builder.Environment.IsDevelopment())
+                {
+                    options.KeyManagement.InitializationSynchronizationDelay = TimeSpan.Zero;
+                }
+
                 options.MutualTls.Enabled = true;
 
                 options.Diagnostics.ChunkSize = 1024 * 1000 - 32; // 1 MB minus some formatting space;


### PR DESCRIPTION
In all hosts, set the InitializationSynchronizationDelay to 0. This
makes it faster for the hosts to reach a healthy state, and is safe to
do as they are never run in a load balanced environment.
