### PR TITLE
allow support for management basepath with templates

### DIFF
--- a/bff/src/Bff/BffEndpointRouteBuilderExtensions.cs
+++ b/bff/src/Bff/BffEndpointRouteBuilderExtensions.cs
@@ -74,8 +74,10 @@ public static class BffEndpointRouteBuilderExtensions
         PathString route,
         string name)
     {
-        if (endpoints.DataSources.Any(x =>
-                x.Endpoints.OfType<RouteEndpoint>().Any(x => x.RoutePattern.RawText == route.ToString())))
+        // check if there is a route endpoint that matches the provided pathstring
+        if (endpoints.DataSources
+            .Any(ds => ds.Endpoints.OfType<RouteEndpoint>()
+               .Any(endpoint => endpoint.RoutePattern.RawText == route.Value)))
         {
             var logger = endpoints.ServiceProvider.GetRequiredService<ILogger<BffBuilder>>();
             logger.AlreadyMappedManagementEndpoint(LogLevel.Warning, name);

--- a/bff/test/Bff.Tests/Endpoints/WireupTests.cs
+++ b/bff/test/Bff.Tests/Endpoints/WireupTests.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using System.Net;
+using Duende.Bff.Tests.TestInfra;
+using Xunit.Abstractions;
+
+namespace Duende.Bff.Tests.Endpoints;
+
+public class WireupTests(ITestOutputHelper output) : BffTestBase(output)
+{
+    [Fact]
+    public async Task Without_auto_wireup_management_endpoints_are_not_mapped()
+    {
+        Bff.OnConfigureBffOptions += options =>
+        {
+            options.AutomaticallyRegisterBffMiddleware = false;
+        };
+        await InitializeAsync();
+
+        await Bff.BrowserClient.Login(expectedStatusCode: HttpStatusCode.NotFound);
+    }
+    [Fact]
+    public async Task Can_call_map_management_endpoints_with_automapping_when_management_path_has_template()
+    {
+        AddOrUpdateFrontend(Some.BffFrontend());
+        Bff.OnConfigureBffOptions += options =>
+        {
+            // We've had customers who wanted to use a route parameter in the management base path
+            //https://github.com/orgs/DuendeSoftware/discussions/301
+            // Turns out there was a bug in the code that prevented this from working - fixed now.
+            options.AutomaticallyRegisterBffMiddleware = true;
+            options.ManagementBasePath = "/{value}/bff";
+        };
+
+        Bff.OnConfigureApp += app =>
+        {
+            app.MapBffManagementEndpoints();
+        };
+
+        await InitializeAsync();
+
+        await Bff.BrowserClient.Login(basePath: "/some_value");
+    }
+
+    [Fact]
+    public async Task Can_call_map_management_endpoints_with_automapping()
+    {
+        AddOrUpdateFrontend(Some.BffFrontend());
+        Bff.OnConfigureBffOptions += options =>
+        {
+            options.AutomaticallyRegisterBffMiddleware = true;
+            options.ManagementBasePath = "/some_base/bff";
+        };
+
+        Bff.OnConfigureApp += app =>
+        {
+            app.MapBffManagementEndpoints();
+        };
+
+        await InitializeAsync();
+
+        await Bff.BrowserClient.Login(basePath: "/some_base");
+    }
+}

--- a/bff/test/Bff.Tests/Endpoints/WireupTests.cs
+++ b/bff/test/Bff.Tests/Endpoints/WireupTests.cs
@@ -26,8 +26,7 @@ public class WireupTests(ITestOutputHelper output) : BffTestBase(output)
         AddOrUpdateFrontend(Some.BffFrontend());
         Bff.OnConfigureBffOptions += options =>
         {
-            // We've had customers who wanted to use a route parameter in the management base path
-            //https://github.com/orgs/DuendeSoftware/discussions/301
+            // https://github.com/orgs/DuendeSoftware/discussions/301
             // Turns out there was a bug in the code that prevented this from working - fixed now.
             options.AutomaticallyRegisterBffMiddleware = true;
             options.ManagementBasePath = "/{value}/bff";

--- a/bff/test/Bff.Tests/TestInfra/BffTestHost.cs
+++ b/bff/test/Bff.Tests/TestInfra/BffTestHost.cs
@@ -17,6 +17,7 @@ public class BffTestHost(TestHostContext context, IdentityServerTestHost identit
     public readonly string DefaultRootResponse = "Default response from root";
     private BffHttpClient _browserClient = null!;
     public BffOptions BffOptions => Resolve<IOptions<BffOptions>>().Value;
+    public Action<BffOptions> OnConfigureBffOptions = _ => { };
 
     public string? LicenseKey = null;
 
@@ -47,6 +48,7 @@ public class BffTestHost(TestHostContext context, IdentityServerTestHost identit
                 }
 
                 options.LicenseKey = LicenseKey;
+                OnConfigureBffOptions(options);
             });
 
             OnConfigureBff(builder);


### PR DESCRIPTION
**What issue does this PR address?**

Fixes a bug that required you to disable the automatic mapping of endpoints if you use a template in the ManagementBasePath. 

Fixes the issue reported here:
https://github.com/orgs/DuendeSoftware/discussions/301
fixes:https://github.com/DuendeSoftware/issues/issues/531

Automatic mapping of mangement endpoints is checking if the management endpoints are already registered. If so, this should have been a no-op. However, if you use templates (IE /{someid}/bff as the bff base path, then this check failed. This was caused because a RoutePrefix.ToString() returns an url encoded version. The RoutePrefix.Value doesn't. 


**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
