### PR TITLE
RFC 8414 support

### DIFF
--- a/identity-server/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/identity-server/src/IdentityServer/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -118,6 +118,7 @@ public static class IdentityServerBuilderExtensionsCore
         builder.AddEndpoint<DeviceAuthorizationEndpoint>(EndpointNames.DeviceAuthorization, ProtocolRoutePaths.DeviceAuthorization.EnsureLeadingSlash());
         builder.AddEndpoint<DiscoveryKeyEndpoint>(EndpointNames.Jwks, ProtocolRoutePaths.DiscoveryWebKeys.EnsureLeadingSlash());
         builder.AddEndpoint<DiscoveryEndpoint>(EndpointNames.Discovery, ProtocolRoutePaths.DiscoveryConfiguration.EnsureLeadingSlash());
+        builder.AddEndpoint<DiscoveryEndpoint>(EndpointNames.OAuth2AuthorizationServerMetadata, ProtocolRoutePaths.OAuth2AuthorizationServerMetadata.EnsureLeadingSlash());
         builder.AddEndpoint<EndSessionCallbackEndpoint>(EndpointNames.EndSession, ProtocolRoutePaths.EndSessionCallback.EnsureLeadingSlash());
         builder.AddEndpoint<EndSessionEndpoint>(EndpointNames.EndSession, ProtocolRoutePaths.EndSession.EnsureLeadingSlash());
         builder.AddEndpoint<IntrospectionEndpoint>(EndpointNames.Introspection, ProtocolRoutePaths.Introspection.EnsureLeadingSlash());

--- a/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/EndpointOptions.cs
+++ b/identity-server/src/IdentityServer/Configuration/DependencyInjection/Options/EndpointOptions.cs
@@ -103,4 +103,12 @@ public class EndpointsOptions
     /// <c>true</c> if the pushed authorization endpoint is enabled; otherwise, <c>false</c>.
     /// </value>
     public bool EnablePushedAuthorizationEndpoint { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the OAuth 2.0 metadata endpoint (.well-known/oauth-authorization-server) is enabled.
+    /// </summary>
+    /// <value>
+    /// <c>true</c> if the OAuth 2.0 discovery metadata is enabled; otherwise, <c>false</c>.
+    /// </value>
+    public bool EnableOAuth2MetadataEndpoint { get; set; } = true;
 }

--- a/identity-server/src/IdentityServer/Endpoints/BaseDiscoveryEndpoint.cs
+++ b/identity-server/src/IdentityServer/Endpoints/BaseDiscoveryEndpoint.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using Duende.IdentityServer.Configuration;
+using Duende.IdentityServer.Endpoints.Results;
+using Duende.IdentityServer.Hosting;
+using Duende.IdentityServer.ResponseHandling;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Duende.IdentityServer.Endpoints;
+
+internal abstract class BaseDiscoveryEndpoint(
+    IdentityServerOptions options,
+    IDiscoveryResponseGenerator responseGenerator)
+{
+    protected IdentityServerOptions Options = options;
+    protected IDiscoveryResponseGenerator ResponseGenerator = responseGenerator;
+
+    protected async Task<IEndpointResult> GetDiscoveryDocument(HttpContext context, string baseUrl, string issuerUri)
+    {
+        if (Options.Preview.EnableDiscoveryDocumentCache)
+        {
+            var distributedCache = context.RequestServices.GetRequiredService<IDistributedCache>();
+            if (distributedCache is not null)
+            {
+                return await GetCachedDiscoveryDocument(distributedCache, baseUrl, issuerUri);
+            }
+            // fall through to default implementation if there is no cache provider registered
+        }
+
+        var response = await ResponseGenerator.CreateDiscoveryDocumentAsync(baseUrl, issuerUri);
+        return new DiscoveryDocumentResult(response, Options.Discovery.ResponseCacheInterval);
+    }
+
+    private async Task<IEndpointResult> GetCachedDiscoveryDocument(IDistributedCache cache, string baseUrl,
+        string issuerUri)
+    {
+        var key = $"discoveryDocument/{baseUrl}/{issuerUri}";
+        var json = await cache.GetStringAsync(key);
+
+        if (json is not null)
+        {
+            return new DiscoveryDocumentResult(
+                json: json,
+                maxAge: Options.Discovery.ResponseCacheInterval
+            );
+        }
+
+        var entries =
+            await ResponseGenerator.CreateDiscoveryDocumentAsync(baseUrl, issuerUri);
+
+        var expirationFromNow = Options.Preview.DiscoveryDocumentCacheDuration;
+
+        var result =
+            new DiscoveryDocumentResult(
+                entries,
+                isUsingPreviewFeature: true,
+                maxAge: Options.Discovery.ResponseCacheInterval);
+
+        await cache.SetStringAsync(key, result.Json, new DistributedCacheEntryOptions
+        {
+            AbsoluteExpirationRelativeToNow = expirationFromNow,
+        });
+
+        return result;
+    }
+}

--- a/identity-server/src/IdentityServer/Endpoints/DiscoveryEndpoint.cs
+++ b/identity-server/src/IdentityServer/Endpoints/DiscoveryEndpoint.cs
@@ -9,34 +9,28 @@ using Duende.IdentityServer.Hosting;
 using Duende.IdentityServer.ResponseHandling;
 using Duende.IdentityServer.Services;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Caching.Distributed;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 
 namespace Duende.IdentityServer.Endpoints;
 
-internal class DiscoveryEndpoint : IEndpointHandler
+internal class DiscoveryEndpoint : BaseDiscoveryEndpoint, IEndpointHandler
 {
     private readonly ILogger _logger;
 
-    private readonly IdentityServerOptions _options;
     private readonly IIssuerNameService _issuerNameService;
     private readonly IServerUrls _urls;
-    private readonly IDiscoveryResponseGenerator _responseGenerator;
 
     public DiscoveryEndpoint(
         IdentityServerOptions options,
         IIssuerNameService issuerNameService,
         IDiscoveryResponseGenerator responseGenerator,
         IServerUrls urls,
-        ILogger<DiscoveryEndpoint> logger)
+        ILogger<DiscoveryEndpoint> logger) : base(options, responseGenerator)
     {
         _logger = logger;
-        _options = options;
         _issuerNameService = issuerNameService;
         _urls = urls;
-        _responseGenerator = responseGenerator;
     }
 
     public async Task<IEndpointResult> ProcessAsync(HttpContext context)
@@ -55,7 +49,7 @@ internal class DiscoveryEndpoint : IEndpointHandler
 
         _logger.LogDebug("Start discovery request");
 
-        if (!_options.Endpoints.EnableDiscoveryEndpoint)
+        if (!Options.Endpoints.EnableDiscoveryEndpoint)
         {
             _logger.LogInformation("Discovery endpoint disabled. 404.");
             return new StatusCodeResult(HttpStatusCode.NotFound);
@@ -65,52 +59,8 @@ internal class DiscoveryEndpoint : IEndpointHandler
         var issuerUri = await _issuerNameService.GetCurrentAsync();
 
         // generate response
-        _logger.LogTrace("Calling into discovery response generator: {type}", _responseGenerator.GetType().FullName);
+        _logger.LogTrace("Calling into discovery response generator: {type}", ResponseGenerator.GetType().FullName);
 
-        if (_options.Preview.EnableDiscoveryDocumentCache)
-        {
-            var distributedCache = context.RequestServices.GetRequiredService<IDistributedCache>();
-            if (distributedCache is not null)
-            {
-                return await GetCachedDiscoveryDocument(distributedCache, baseUrl, issuerUri);
-            }
-            // fall through to default implementation if there is no cache provider registered
-        }
-
-        var response = await _responseGenerator.CreateDiscoveryDocumentAsync(baseUrl, issuerUri);
-        return new DiscoveryDocumentResult(response, _options.Discovery.ResponseCacheInterval);
-    }
-
-    private async Task<IEndpointResult> GetCachedDiscoveryDocument(IDistributedCache cache, string baseUrl,
-        string issuerUri)
-    {
-        var key = $"discoveryDocument/{baseUrl}/{issuerUri}";
-        var json = await cache.GetStringAsync(key);
-
-        if (json is not null)
-        {
-            return new DiscoveryDocumentResult(
-                json: json,
-                maxAge: _options.Discovery.ResponseCacheInterval
-            );
-        }
-
-        var entries =
-            await _responseGenerator.CreateDiscoveryDocumentAsync(baseUrl, issuerUri);
-
-        var expirationFromNow = _options.Preview.DiscoveryDocumentCacheDuration;
-
-        var result =
-            new DiscoveryDocumentResult(
-                entries,
-                isUsingPreviewFeature: true,
-                maxAge: _options.Discovery.ResponseCacheInterval);
-
-        await cache.SetStringAsync(key, result.Json, new DistributedCacheEntryOptions
-        {
-            AbsoluteExpirationRelativeToNow = expirationFromNow,
-        });
-
-        return result;
+        return await GetDiscoveryDocument(context, baseUrl, issuerUri);
     }
 }

--- a/identity-server/src/IdentityServer/Endpoints/OAuthMetadataEndpoint.cs
+++ b/identity-server/src/IdentityServer/Endpoints/OAuthMetadataEndpoint.cs
@@ -67,7 +67,7 @@ internal class OAuthMetadataEndpoint(
 
         if (!issuerUri.Equals($"{context.Request.Scheme}://{context.Request.Host}{issuerSubPath}", StringComparison.Ordinal))
         {
-            logger.LogDebug("Request for OAuth discovery document contains an issuer URI does not match the request URL. Returning 404. Issuer: {issuer}, Request: {request}", issuerUri, $"{context.Request.Scheme}://{context.Request.Host}{issuerSubPath}");
+            logger.LogDebug("Request for OAuth discovery document with a request URL that does not match the issuer URI. Returning 404. Issuer: {issuer}, Request: {request}", issuerUri, $"{context.Request.Scheme}://{context.Request.Host}{issuerSubPath}");
             return new StatusCodeResult(HttpStatusCode.NotFound);
         }
 

--- a/identity-server/src/IdentityServer/Endpoints/OAuthMetadataEndpoint.cs
+++ b/identity-server/src/IdentityServer/Endpoints/OAuthMetadataEndpoint.cs
@@ -67,7 +67,7 @@ internal class OAuthMetadataEndpoint(
 
         if (!issuerUri.Equals($"{context.Request.Scheme}://{context.Request.Host}{issuerSubPath}", StringComparison.Ordinal))
         {
-            logger.LogWarning("Issuer URI does not match the request URL. Issuer: {issuer}, Request: {request}", issuerUri, $"{context.Request.Scheme}://{context.Request.Host}{issuerSubPath}");
+            logger.LogDebug("Request for OAuth discovery document contains an issuer URI does not match the request URL. Returning 404. Issuer: {issuer}, Request: {request}", issuerUri, $"{context.Request.Scheme}://{context.Request.Host}{issuerSubPath}");
             return new StatusCodeResult(HttpStatusCode.NotFound);
         }
 

--- a/identity-server/src/IdentityServer/Endpoints/OAuthMetadataEndpoint.cs
+++ b/identity-server/src/IdentityServer/Endpoints/OAuthMetadataEndpoint.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using System.Net;
+using Duende.IdentityServer.Configuration;
+using Duende.IdentityServer.Endpoints.Results;
+using Duende.IdentityServer.Hosting;
+using Duende.IdentityServer.ResponseHandling;
+using Duende.IdentityServer.Services;
+using Duende.IdentityServer.Validation;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Duende.IdentityServer.Endpoints;
+
+internal class OAuthMetadataEndpoint(
+    IdentityServerOptions options,
+    IIssuerPathValidator issuerPathValidator,
+    IServerUrls serverUrls,
+    IIssuerNameService issuerNameService,
+    IDiscoveryResponseGenerator discoveryResponseGenerator,
+    ILogger<OAuthMetadataEndpoint> logger) : BaseDiscoveryEndpoint(options, discoveryResponseGenerator), IEndpointHandler
+{
+    public async Task<IEndpointResult> ProcessAsync(HttpContext context)
+    {
+        using var activity =
+            Tracing.BasicActivitySource.StartActivity(
+                IdentityServerConstants.EndpointNames.OAuthMetadata + "Endpoint");
+
+        logger.LogTrace("Processing OAuth discovery request.");
+
+        // validate HTTP
+        if (!HttpMethods.IsGet(context.Request.Method))
+        {
+            logger.LogWarning("OAuth Discovery endpoint only supports GET requests");
+            return new StatusCodeResult(HttpStatusCode.MethodNotAllowed);
+        }
+
+        logger.LogDebug("Start OAuth discovery request");
+
+        if (!Options.Endpoints.EnableOAuth2MetadataEndpoint)
+        {
+            logger.LogInformation("OAuth Discovery endpoint disabled. 404.");
+            return new StatusCodeResult(HttpStatusCode.NotFound);
+        }
+
+        if (context.Request.PathBase.HasValue)
+        {
+            logger.LogDebug("Request for OAuth discovery document contains PathBase. Returning 404");
+            return new StatusCodeResult(HttpStatusCode.NotFound);
+        }
+
+        context.Request.Path.StartsWithSegments("/.well-known/oauth-authorization-server", StringComparison.OrdinalIgnoreCase, out var issuerSubPath);
+        if (!await issuerPathValidator.ValidateAsync(issuerSubPath))
+        {
+            logger.LogDebug("Request for OAuth discovery document contains invalid sub-path. Returning 404");
+            return new StatusCodeResult(HttpStatusCode.NotFound);
+        }
+
+        if (issuerSubPath.HasValue)
+        {
+            serverUrls.BasePath = issuerSubPath;
+        }
+
+        var issuerUri = await issuerNameService.GetCurrentAsync();
+        var baseUrl = serverUrls.BaseUrl;
+
+        if (!issuerUri.Equals($"{context.Request.Scheme}://{context.Request.Host}{issuerSubPath}", StringComparison.Ordinal))
+        {
+            logger.LogWarning("Issuer URI does not match the request URL. Issuer: {issuer}, Request: {request}",
+                issuerUri.SanitizeLogParameter(), $"{context.Request.Scheme}://{context.Request.Host}{issuerSubPath}".SanitizeLogParameter());
+            return new StatusCodeResult(HttpStatusCode.NotFound);
+        }
+
+        // generate response
+        logger.LogTrace("Calling into discovery response generator: {type}",
+            ResponseGenerator.GetType().FullName);
+
+        return await GetDiscoveryDocument(context, baseUrl, issuerUri);
+    }
+}

--- a/identity-server/src/IdentityServer/Hosting/Endpoint.cs
+++ b/identity-server/src/IdentityServer/Hosting/Endpoint.cs
@@ -7,8 +7,6 @@
 #pragma warning disable 1591
 
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Routing;
-using Microsoft.Extensions.Logging;
 
 namespace Duende.IdentityServer.Hosting;
 
@@ -18,6 +16,7 @@ public class Endpoint
     {
         Name = name;
         Path = path;
+        IsMatch = context => context.Request.Path.Equals(Path, StringComparison.OrdinalIgnoreCase);
         Handler = handlerType;
     }
 
@@ -46,19 +45,10 @@ public class Endpoint
     public Type Handler { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether this endpoint uses a route template.
-    /// This is used to determine if the endpoint needs to be parsed and matched.
+    /// Determines if the request matches this endpoint.
     /// </summary>
     /// <value>
-    /// If true, the endpoint uses a route template; otherwise, it does not.
+    /// The function that determines if the request matches this endpoint.
     /// </value>
-    public bool UsesRouteTemplate { get; set; }
-
-    /// <summary>
-    /// Function called on endpoint route matched to allow custom logic based on matched route values.
-    /// </summary>
-    /// <value>
-    /// Function called on endpoint route matched to allow custom logic based on matched route values.
-    /// </value>
-    public Func<HttpContext, RouteValueDictionary, ILogger, bool>? OnRouteMatched { get; set; }
+    public Func<HttpContext, bool> IsMatch { get; set; }
 }

--- a/identity-server/src/IdentityServer/Hosting/Endpoint.cs
+++ b/identity-server/src/IdentityServer/Hosting/Endpoint.cs
@@ -7,6 +7,8 @@
 #pragma warning disable 1591
 
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
 
 namespace Duende.IdentityServer.Hosting;
 
@@ -42,4 +44,21 @@ public class Endpoint
     /// The handler.
     /// </value>
     public Type Handler { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this endpoint uses a route template.
+    /// This is used to determine if the endpoint needs to be parsed and matched.
+    /// </summary>
+    /// <value>
+    /// If true, the endpoint uses a route template; otherwise, it does not.
+    /// </value>
+    public bool UsesRouteTemplate { get; set; }
+
+    /// <summary>
+    /// Function called on endpoint route matched to allow custom logic based on matched route values.
+    /// </summary>
+    /// <value>
+    /// Function called on endpoint route matched to allow custom logic based on matched route values.
+    /// </value>
+    public Func<HttpContext, RouteValueDictionary, ILogger, bool>? OnRouteMatched { get; set; }
 }

--- a/identity-server/src/IdentityServer/Hosting/EndpointHelpers.cs
+++ b/identity-server/src/IdentityServer/Hosting/EndpointHelpers.cs
@@ -1,36 +1,15 @@
 // Copyright (c) Duende Software. All rights reserved.
 // See LICENSE in the project root for license information.
 
-using Duende.IdentityServer.Extensions;
-using Duende.IdentityServer.Services;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Routing;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 
 namespace Duende.IdentityServer.Hosting;
 
 internal static class EndpointHelpers
 {
-    public static class OAuth2AuthorizationServerMetadataHelpers
+    public static class OAuthMetadataHelpers
     {
-        public static bool OnRouteMatched(HttpContext context, RouteValueDictionary routeValues, ILogger logger)
-        {
-            if (context.Request.PathBase.Value.IsPresent())
-            {
-                logger.LogDebug("Path must start with .well-known, but request path base is set to '{PathBase}'", context.Request.PathBase.Value.SanitizeLogParameter());
-                return false;
-            }
-
-            if (!routeValues.TryGetValue("subPath", out var subPath) || subPath == null)
-            {
-                return true;
-            }
-
-            var serverUrls = context.RequestServices.GetRequiredService<IServerUrls>();
-            serverUrls.BasePath = subPath.ToString().EnsureLeadingSlash();
-
-            return true;
-        }
+        public static bool IsMatch(HttpContext httpContext) => httpContext.Request.Path.StartsWithSegments("/.well-known/oauth-authorization-server",
+                StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/identity-server/src/IdentityServer/Hosting/EndpointHelpers.cs
+++ b/identity-server/src/IdentityServer/Hosting/EndpointHelpers.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using Duende.IdentityServer.Extensions;
+using Duende.IdentityServer.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Duende.IdentityServer.Hosting;
+
+internal static class EndpointHelpers
+{
+    public static class OAuth2AuthorizationServerMetadataHelpers
+    {
+        public static bool OnRouteMatched(HttpContext context, RouteValueDictionary routeValues, ILogger logger)
+        {
+            if (context.Request.PathBase.Value.IsPresent())
+            {
+                logger.LogDebug("Path must start with .well-known, but request path base is set to '{PathBase}'", context.Request.PathBase.Value.SanitizeLogParameter());
+                return false;
+            }
+
+            if (!routeValues.TryGetValue("subPath", out var subPath) || subPath == null)
+            {
+                return true;
+            }
+
+            var serverUrls = context.RequestServices.GetRequiredService<IServerUrls>();
+            serverUrls.BasePath = subPath.ToString().EnsureLeadingSlash();
+
+            return true;
+        }
+    }
+}

--- a/identity-server/src/IdentityServer/Hosting/EndpointRouter.cs
+++ b/identity-server/src/IdentityServer/Hosting/EndpointRouter.cs
@@ -2,11 +2,15 @@
 // See LICENSE in the project root for license information.
 
 
+using System.Collections.Concurrent;
 using Duende.IdentityServer.Configuration;
 using Duende.IdentityServer.Extensions;
 using Duende.IdentityServer.Licensing.V2;
 using Duende.IdentityServer.Logging;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
+using Microsoft.AspNetCore.Routing.Template;
 
 namespace Duende.IdentityServer.Hosting;
 
@@ -18,6 +22,8 @@ internal class EndpointRouter(
     SanitizedLogger<EndpointRouter> sanitizedLogger)
     : IEndpointRouter
 {
+    private readonly ConcurrentDictionary<string, TemplateMatcher> _routeCache = new();
+
     public IEndpointHandler Find(HttpContext context)
     {
         ArgumentNullException.ThrowIfNull(context);
@@ -34,6 +40,29 @@ internal class EndpointRouter(
                 licenseExpirationChecker.CheckExpiration();
 
                 return GetEndpointHandler(endpoint, context);
+            }
+
+            if (endpoint.UsesRouteTemplate && endpoint.Path.HasValue)
+            {
+                if (!_routeCache.TryGetValue(endpoint.Path.Value, out var matcher))
+                {
+                    var routePattern = RoutePatternFactory.Parse(endpoint.Path.Value.RemoveLeadingSlash()!);
+                    var template = TemplateParser.Parse(routePattern.RawText!);
+                    matcher = new TemplateMatcher(template, new RouteValueDictionary());
+                    _routeCache.TryAdd(endpoint.Path.Value, matcher);
+                }
+
+                var matchedValues = new RouteValueDictionary();
+                if (matcher.TryMatch(context.Request.Path, matchedValues) && (endpoint.OnRouteMatched == null || endpoint.OnRouteMatched(context, matchedValues, sanitizedLogger.ToILogger())))
+                {
+                    var endpointName = endpoint.Name;
+                    sanitizedLogger.LogDebug("Request path {path} matched to endpoint type {endpoint}", context.Request.Path, endpointName);
+
+                    requestCounter.Increment();
+                    licenseExpirationChecker.CheckExpiration();
+
+                    return GetEndpointHandler(endpoint, context);
+                }
             }
         }
 

--- a/identity-server/src/IdentityServer/Hosting/EndpointRouter.cs
+++ b/identity-server/src/IdentityServer/Hosting/EndpointRouter.cs
@@ -2,15 +2,11 @@
 // See LICENSE in the project root for license information.
 
 
-using System.Collections.Concurrent;
 using Duende.IdentityServer.Configuration;
 using Duende.IdentityServer.Extensions;
 using Duende.IdentityServer.Licensing.V2;
 using Duende.IdentityServer.Logging;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Routing;
-using Microsoft.AspNetCore.Routing.Patterns;
-using Microsoft.AspNetCore.Routing.Template;
 
 namespace Duende.IdentityServer.Hosting;
 
@@ -22,16 +18,13 @@ internal class EndpointRouter(
     SanitizedLogger<EndpointRouter> sanitizedLogger)
     : IEndpointRouter
 {
-    private readonly ConcurrentDictionary<string, TemplateMatcher> _routeCache = new();
-
     public IEndpointHandler Find(HttpContext context)
     {
         ArgumentNullException.ThrowIfNull(context);
 
         foreach (var endpoint in endpoints)
         {
-            var path = endpoint.Path;
-            if (context.Request.Path.Equals(path, StringComparison.OrdinalIgnoreCase))
+            if (endpoint.IsMatch(context))
             {
                 var endpointName = endpoint.Name;
                 sanitizedLogger.LogDebug("Request path {path} matched to endpoint type {endpoint}", context.Request.Path, endpointName);
@@ -40,29 +33,6 @@ internal class EndpointRouter(
                 licenseExpirationChecker.CheckExpiration();
 
                 return GetEndpointHandler(endpoint, context);
-            }
-
-            if (endpoint.UsesRouteTemplate && endpoint.Path.HasValue)
-            {
-                if (!_routeCache.TryGetValue(endpoint.Path.Value, out var matcher))
-                {
-                    var routePattern = RoutePatternFactory.Parse(endpoint.Path.Value.RemoveLeadingSlash()!);
-                    var template = TemplateParser.Parse(routePattern.RawText!);
-                    matcher = new TemplateMatcher(template, new RouteValueDictionary());
-                    _routeCache.TryAdd(endpoint.Path.Value, matcher);
-                }
-
-                var matchedValues = new RouteValueDictionary();
-                if (matcher.TryMatch(context.Request.Path, matchedValues) && (endpoint.OnRouteMatched == null || endpoint.OnRouteMatched(context, matchedValues, sanitizedLogger.ToILogger())))
-                {
-                    var endpointName = endpoint.Name;
-                    sanitizedLogger.LogDebug("Request path {path} matched to endpoint type {endpoint}", context.Request.Path, endpointName);
-
-                    requestCounter.Increment();
-                    licenseExpirationChecker.CheckExpiration();
-
-                    return GetEndpointHandler(endpoint, context);
-                }
             }
         }
 

--- a/identity-server/src/IdentityServer/IdentityServerConstants.cs
+++ b/identity-server/src/IdentityServer/IdentityServerConstants.cs
@@ -216,7 +216,7 @@ public static class IdentityServerConstants
         public const string CheckSession = "Checksession";
         public const string UserInfo = "Userinfo";
         public const string PushedAuthorization = "PushedAuthorization";
-        public const string OAuth2AuthorizationServerMetadata = "OAuth2AuthorizationServerMetadata";
+        public const string OAuthMetadata = "OAuthMetadata";
 
     }
 
@@ -256,7 +256,7 @@ public static class IdentityServerConstants
         public const string CheckSession = ConnectPathPrefix + "/checksession";
         public const string DeviceAuthorization = ConnectPathPrefix + "/deviceauthorization";
         public const string PushedAuthorization = ConnectPathPrefix + "/par";
-        public const string OAuth2AuthorizationServerMetadata = ".well-known/oauth-authorization-server/{*subPath}";
+        public const string OAuthMetadata = ".well-known/oauth-authorization-server";
 
 
         public const string MtlsPathPrefix = ConnectPathPrefix + "/mtls";

--- a/identity-server/src/IdentityServer/IdentityServerConstants.cs
+++ b/identity-server/src/IdentityServer/IdentityServerConstants.cs
@@ -256,7 +256,7 @@ public static class IdentityServerConstants
         public const string CheckSession = ConnectPathPrefix + "/checksession";
         public const string DeviceAuthorization = ConnectPathPrefix + "/deviceauthorization";
         public const string PushedAuthorization = ConnectPathPrefix + "/par";
-        public const string OAuth2AuthorizationServerMetadata = ".well-known/oauth-authorization-server";
+        public const string OAuth2AuthorizationServerMetadata = ".well-known/oauth-authorization-server/{*subPath}";
 
 
         public const string MtlsPathPrefix = ConnectPathPrefix + "/mtls";

--- a/identity-server/src/IdentityServer/IdentityServerConstants.cs
+++ b/identity-server/src/IdentityServer/IdentityServerConstants.cs
@@ -216,22 +216,24 @@ public static class IdentityServerConstants
         public const string CheckSession = "Checksession";
         public const string UserInfo = "Userinfo";
         public const string PushedAuthorization = "PushedAuthorization";
+        public const string OAuth2AuthorizationServerMetadata = "OAuth2AuthorizationServerMetadata";
+
     }
 
     public static class ContentSecurityPolicyHashes
     {
         /// <summary>
-        /// The hash of the inline style used on the end session endpoint. 
+        /// The hash of the inline style used on the end session endpoint.
         /// </summary>
         public const string EndSessionStyle = "sha256-e6FQZewefmod2S/5T11pTXjzE2vn3/8GRwWOs917YE4=";
 
         /// <summary>
-        /// The hash of the inline script used on the authorize endpoint. 
+        /// The hash of the inline script used on the authorize endpoint.
         /// </summary>
         public const string AuthorizeScript = "sha256-orD0/VhH8hLqrLxKHD/HUEMdwqX6/0ve7c5hspX5VJ8=";
 
         /// <summary>
-        /// The hash of the inline script used on the check session endpoint. 
+        /// The hash of the inline script used on the check session endpoint.
         /// </summary>
         public const string CheckSessionScript = "sha256-fa5rxHhZ799izGRP38+h4ud5QXNT0SFaFlh4eqDumBI=";
     }
@@ -254,6 +256,7 @@ public static class IdentityServerConstants
         public const string CheckSession = ConnectPathPrefix + "/checksession";
         public const string DeviceAuthorization = ConnectPathPrefix + "/deviceauthorization";
         public const string PushedAuthorization = ConnectPathPrefix + "/par";
+        public const string OAuth2AuthorizationServerMetadata = ".well-known/oauth-authorization-server";
 
 
         public const string MtlsPathPrefix = ConnectPathPrefix + "/mtls";

--- a/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/EndpointUsageDiagnosticEntry.cs
+++ b/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/EndpointUsageDiagnosticEntry.cs
@@ -24,6 +24,7 @@ internal class EndpointUsageDiagnosticEntry : IDiagnosticEntry, IDisposable
     private long _tokenRevocation;
     private long _token;
     private long _userInfo;
+    private long _oAuthMetadata;
     private long _other;
 
     private readonly MeterListener _meterListener;
@@ -63,6 +64,7 @@ internal class EndpointUsageDiagnosticEntry : IDiagnosticEntry, IDisposable
         writer.WriteNumber(IdentityServerConstants.ProtocolRoutePaths.Revocation.EnsureLeadingSlash(), _tokenRevocation);
         writer.WriteNumber(IdentityServerConstants.ProtocolRoutePaths.Token.EnsureLeadingSlash(), _token);
         writer.WriteNumber(IdentityServerConstants.ProtocolRoutePaths.UserInfo.EnsureLeadingSlash(), _userInfo);
+        writer.WriteNumber(IdentityServerConstants.ProtocolRoutePaths.OAuth2AuthorizationServerMetadata.EnsureLeadingSlash(), _oAuthMetadata);
         writer.WriteNumber("other", _other);
 
         writer.WriteEndObject();
@@ -134,6 +136,10 @@ internal class EndpointUsageDiagnosticEntry : IDiagnosticEntry, IDisposable
                 break;
             case IdentityServerConstants.ProtocolRoutePaths.UserInfo:
                 Interlocked.Increment(ref _userInfo);
+                break;
+            //NOTE: cannot use const because of template matching in this route
+            case { } s when s.StartsWith(".well-known/oauth-authorization-server", StringComparison.OrdinalIgnoreCase):
+                Interlocked.Increment(ref _oAuthMetadata);
                 break;
             default:
                 Interlocked.Increment(ref _other);

--- a/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/EndpointUsageDiagnosticEntry.cs
+++ b/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/EndpointUsageDiagnosticEntry.cs
@@ -64,7 +64,7 @@ internal class EndpointUsageDiagnosticEntry : IDiagnosticEntry, IDisposable
         writer.WriteNumber(IdentityServerConstants.ProtocolRoutePaths.Revocation.EnsureLeadingSlash(), _tokenRevocation);
         writer.WriteNumber(IdentityServerConstants.ProtocolRoutePaths.Token.EnsureLeadingSlash(), _token);
         writer.WriteNumber(IdentityServerConstants.ProtocolRoutePaths.UserInfo.EnsureLeadingSlash(), _userInfo);
-        writer.WriteNumber(IdentityServerConstants.ProtocolRoutePaths.OAuth2AuthorizationServerMetadata.EnsureLeadingSlash(), _oAuthMetadata);
+        writer.WriteNumber(IdentityServerConstants.ProtocolRoutePaths.OAuthMetadata.EnsureLeadingSlash(), _oAuthMetadata);
         writer.WriteNumber("other", _other);
 
         writer.WriteEndObject();
@@ -137,8 +137,8 @@ internal class EndpointUsageDiagnosticEntry : IDiagnosticEntry, IDisposable
             case IdentityServerConstants.ProtocolRoutePaths.UserInfo:
                 Interlocked.Increment(ref _userInfo);
                 break;
-            //NOTE: cannot use const because of template matching in this route
-            case { } s when s.StartsWith(".well-known/oauth-authorization-server", StringComparison.OrdinalIgnoreCase):
+            //NOTE: need to use StartsWith because this route can have additional segments
+            case { } s when s.StartsWith(IdentityServerConstants.ProtocolRoutePaths.OAuthMetadata, StringComparison.OrdinalIgnoreCase):
                 Interlocked.Increment(ref _oAuthMetadata);
                 break;
             default:

--- a/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/RegisteredImplementationsDiagnosticEntry.cs
+++ b/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticEntries/RegisteredImplementationsDiagnosticEntry.cs
@@ -143,6 +143,7 @@ internal class RegisteredImplementationsDiagnosticEntry(ServiceCollectionAccesso
                 new(typeof(IExtensionGrantValidator), []),
                 new(typeof(IIdentityProviderConfigurationValidator), [typeof(DefaultIdentityProviderConfigurationValidator)]),
                 new(typeof(IIntrospectionRequestValidator), [typeof(IntrospectionRequestValidator)]),
+                new(typeof(IIssuerPathValidator), [typeof(DefaultIssuerPathValidator)]),
                 new(typeof(IJwtRequestValidator), [typeof(JwtRequestValidator)]),
                 new(typeof(IPushedAuthorizationRequestValidator), [typeof(PushedAuthorizationRequestValidator)]),
                 new(typeof(IRedirectUriValidator), [typeof(StrictRedirectUriValidator)]),

--- a/identity-server/src/IdentityServer/Logging/ILoggerExtensions.cs
+++ b/identity-server/src/IdentityServer/Logging/ILoggerExtensions.cs
@@ -108,5 +108,22 @@ internal static class ILoggerDevExtensions
         }
     }
 
-    public static object SanitizeLogParameter(this object value) => value?.GetType() == typeof(string) ? value.ToString()?.ReplaceLineEndings(string.Empty) : value;
+    public static object SanitizeLogParameter(this object value)
+    {
+        if (value is not string s || string.IsNullOrEmpty(s))
+        {
+            return value;
+        }
+
+        var builder = new System.Text.StringBuilder(s.Length);
+        foreach (var c in s)
+        {
+            if (!char.IsControl(c))
+            {
+                builder.Append(c);
+            }
+        }
+
+        return builder.ToString();
+    }
 }

--- a/identity-server/src/IdentityServer/Logging/ILoggerExtensions.cs
+++ b/identity-server/src/IdentityServer/Logging/ILoggerExtensions.cs
@@ -115,15 +115,24 @@ internal static class ILoggerDevExtensions
             return value;
         }
 
+        s = s.ReplaceLineEndings(string.Empty);
         var builder = new System.Text.StringBuilder(s.Length);
         foreach (var c in s)
         {
-            if (!char.IsControl(c))
+            if (!IsUnsafeLogChar(c))
             {
                 builder.Append(c);
             }
         }
 
         return builder.ToString();
+
+        static bool IsUnsafeLogChar(char c)
+        {
+            return char.IsControl(c)
+                   || c == '\u0085'  // NEXT LINE
+                   || c == '\u2028'  // LINE SEPARATOR
+                   || c == '\u2029'; // PARAGRAPH SEPARATOR
+        }
     }
 }

--- a/identity-server/src/IdentityServer/Validation/Default/DefaultIssuerPathValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/Default/DefaultIssuerPathValidator.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using Duende.IdentityServer.Extensions;
+using Duende.IdentityServer.Services;
+using Microsoft.Extensions.Logging;
+
+namespace Duende.IdentityServer.Validation;
+
+public class DefaultIssuerPathValidator(IIssuerNameService issuerNameService, ILogger<DefaultIssuerPathValidator> logger) : IIssuerPathValidator
+{
+    public async Task<bool> ValidateAsync(string path)
+    {
+        //if there is no path, this is fine since the default issuer is probably being used
+        if (path.IsMissing())
+        {
+            return true;
+        }
+
+        //if there is a path, then we should be matching against an explicitly configured issuer
+        var currentIssuer = await issuerNameService.GetCurrentAsync();
+        if (!Uri.TryCreate(currentIssuer, UriKind.Absolute, out var uri))
+        {
+            logger.LogDebug("Current issuer is not a valid absolute URI: {Issuer}", currentIssuer.SanitizeLogParameter());
+            return false;
+        }
+
+        if (!string.Equals(uri.AbsolutePath, path, StringComparison.OrdinalIgnoreCase))
+        {
+            logger.LogDebug("Current issuer path '{IssuerPath}' does not match the provided path '{ProvidedPath}'", uri.AbsolutePath.SanitizeLogParameter(), path.SanitizeLogParameter());
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/identity-server/src/IdentityServer/Validation/IIssuerPathValidator.cs
+++ b/identity-server/src/IdentityServer/Validation/IIssuerPathValidator.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+namespace Duende.IdentityServer.Validation;
+
+public interface IIssuerPathValidator
+{
+    /// <summary>
+    /// Validates that the path is valid for issuer URIs used.
+    /// </summary>
+    /// <param name="path">A path component of a URI to validate against the issuer for the current request.</param>
+    /// <returns>True if the path component is valid in for the issuer in the context of the current request.</returns>
+    Task<bool> ValidateAsync(string path);
+}

--- a/identity-server/test/IdentityServer.IntegrationTests/Common/IdentityServerPipeline.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Common/IdentityServerPipeline.cs
@@ -174,7 +174,8 @@ public class IdentityServerPipeline
             .AddInMemoryApiScopes(ApiScopes)
             .AddTestUsers(Users)
             .AddDeveloperSigningCredential(persistKey: false)
-            .AddMutualTlsSecretValidators();
+            .AddMutualTlsSecretValidators()
+            .AddLicenseSummary();
 
         services.AddHttpClient(IdentityServerConstants.HttpClients.BackChannelLogoutHttpClient)
             .AddHttpMessageHandler(() => BackChannelMessageHandler);

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/OAuthMetadata/OAuthMetadataTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/OAuthMetadata/OAuthMetadataTests.cs
@@ -3,23 +3,37 @@
 
 using System.Net;
 using System.Text.Json;
+using Duende.IdentityServer.Licensing;
 using IntegrationTests.Common;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace IdentityServer.IntegrationTests.Endpoints.OAuthMetadata;
 
 public class OAuthMetadataTests
 {
-    private const string Category = "OAuth Authorization Server Metadata endpoint";
+    private const string Category = "OAuth Metadata endpoint";
 
     [Fact]
     [Trait("Category", Category)]
-    public async Task when_issuer_identifier_has_no_subpath_then_metadata_endpoint_is_at_well_known_location()
+    public async Task when_request_is_not_made_with_GET_then_405_is_returned()
     {
         var pipeline = new IdentityServerPipeline();
         pipeline.Initialize();
 
-        var result = await pipeline.BackChannelClient.GetAsync("HTTPS://SERVER/.WELL-KNOWN/OAUTH-AUTHORIZATION-SERVER");
+        var result = await pipeline.BackChannelClient.PostAsync("https://server/.well-known/oauth-authorization-server", null);
+
+        result.StatusCode.ShouldBe(HttpStatusCode.MethodNotAllowed);
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task when_issuer_identifier_has_no_subpath_then_metadata_endpoint_is_at_default_well_known_location()
+    {
+        var pipeline = new IdentityServerPipeline();
+        pipeline.Initialize();
+
+        var result = await pipeline.BackChannelClient.GetAsync("https://server/.well-known/oauth-authorization-server");
 
         var json = await result.Content.ReadAsStringAsync();
         var data = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json);
@@ -33,6 +47,7 @@ public class OAuthMetadataTests
         var pipeline = new IdentityServerPipeline();
         pipeline.OnPreConfigure += app => app.UsePathBase("/identity");
         pipeline.Initialize();
+        pipeline.Options.IssuerUri = "https://server/identity";
 
         var result = await pipeline.BackChannelClient.GetAsync("https://server/.well-known/oauth-authorization-server/identity");
 
@@ -48,6 +63,7 @@ public class OAuthMetadataTests
         var pipeline = new IdentityServerPipeline();
         pipeline.OnPreConfigure += app => app.UsePathBase("/identity");
         pipeline.Initialize();
+        pipeline.Options.IssuerUri = "https://server/identity";
 
         var result = await pipeline.BackChannelClient.GetAsync("https://server/.well-known/oauth-authorization-server/identity?query=string");
 
@@ -63,6 +79,7 @@ public class OAuthMetadataTests
         var pipeline = new IdentityServerPipeline();
         pipeline.OnPreConfigure += app => app.UsePathBase("/identity");
         pipeline.Initialize();
+        pipeline.Options.IssuerUri = "https://server/identity";
 
         var result = await pipeline.BackChannelClient.GetAsync("https://server/.well-known/oauth-authorization-server/identity#fragment");
 
@@ -73,7 +90,22 @@ public class OAuthMetadataTests
 
     [Fact]
     [Trait("Category", Category)]
-    public async Task when_issuer_has_explicitly_been_set_then_metadata_endpoint_uses_configured_issuer_for_issuer()
+    public async Task when_issuer_has_explicitly_been_set_then_metadata_endpoint_uses_configured_value_for_issuer()
+    {
+        var pipeline = new IdentityServerPipeline();
+        pipeline.Initialize();
+        pipeline.Options.IssuerUri = "https://server/explicit";
+
+        var result = await pipeline.BackChannelClient.GetAsync("https://server/.well-known/oauth-authorization-server/explicit");
+
+        var json = await result.Content.ReadAsStringAsync();
+        var data = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json);
+        data["issuer"].GetString().ShouldBe("https://server/explicit");
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task when_issuer_has_been_explicitly_set_with_subpath_and_request_for_metadata_does_not_set_subpath_after_well_known_then_404_is_returned()
     {
         var pipeline = new IdentityServerPipeline();
         pipeline.Initialize();
@@ -81,9 +113,7 @@ public class OAuthMetadataTests
 
         var result = await pipeline.BackChannelClient.GetAsync("https://server/.well-known/oauth-authorization-server");
 
-        var json = await result.Content.ReadAsStringAsync();
-        var data = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json);
-        data["issuer"].GetString().ShouldBe("https://example.com/explicit");
+        result.StatusCode.ShouldBe(HttpStatusCode.NotFound);
     }
 
     [Fact]
@@ -96,5 +126,39 @@ public class OAuthMetadataTests
         var result = await pipeline.BackChannelClient.GetAsync("https://server/identity/.well-known/oauth-authorization-server");
 
         result.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task when_issuer_identifier_has_subpath_and_request_for_metadata_uses_different_subpath_then_404_is_returned()
+    {
+        var pipeline = new IdentityServerPipeline();
+        pipeline.OnPreConfigure += app => app.UsePathBase("/identity");
+        pipeline.Initialize();
+        pipeline.Options.IssuerUri = "https://server/identity";
+
+        var result = await pipeline.BackChannelClient.GetAsync("https://server/.well-known/oauth-authorization-server/wrong");
+
+        result.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task when_issuer_has_subpath_and_request_is_valid_then_used_issuers_only_tracks_one_issuer()
+    {
+        var pipeline = new IdentityServerPipeline();
+        pipeline.OnPreConfigure += app => app.UsePathBase("/identity");
+        pipeline.Initialize();
+        pipeline.Options.IssuerUri = "https://server/identity";
+
+        var result = await pipeline.BackChannelClient.GetAsync("https://server/.well-known/oauth-authorization-server/identity");
+
+        var json = await result.Content.ReadAsStringAsync();
+        var data = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json);
+        data["issuer"].GetString().ShouldBe("https://server/identity");
+
+        var licenseUsageSummary = pipeline.Server.Services.GetRequiredService<LicenseUsageSummary>();
+        licenseUsageSummary.IssuersUsed.Count.ShouldBe(1);
+        licenseUsageSummary.IssuersUsed.ShouldBe(["https://server/identity"]);
     }
 }

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/OAuthMetadata/OAuthMetadataTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/OAuthMetadata/OAuthMetadataTests.cs
@@ -1,0 +1,100 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using System.Net;
+using System.Text.Json;
+using IntegrationTests.Common;
+using Microsoft.AspNetCore.Builder;
+
+namespace IdentityServer.IntegrationTests.Endpoints.OAuthMetadata;
+
+public class OAuthMetadataTests
+{
+    private const string Category = "OAuth Authorization Server Metadata endpoint";
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task when_issuer_identifier_has_no_subpath_then_metadata_endpoint_is_at_well_known_location()
+    {
+        var pipeline = new IdentityServerPipeline();
+        pipeline.Initialize();
+
+        var result = await pipeline.BackChannelClient.GetAsync("HTTPS://SERVER/.WELL-KNOWN/OAUTH-AUTHORIZATION-SERVER");
+
+        var json = await result.Content.ReadAsStringAsync();
+        var data = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json);
+        data["issuer"].GetString().ShouldBe("https://server");
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task when_issuer_identifier_has_subpath_then_metadata_endpoint_is_at_spec_compliant_location()
+    {
+        var pipeline = new IdentityServerPipeline();
+        pipeline.OnPreConfigure += app => app.UsePathBase("/identity");
+        pipeline.Initialize();
+
+        var result = await pipeline.BackChannelClient.GetAsync("https://server/.well-known/oauth-authorization-server/identity");
+
+        var json = await result.Content.ReadAsStringAsync();
+        var data = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json);
+        data["issuer"].GetString().ShouldBe("https://server/identity");
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task when_issuer_identifier_has_subpath_and_request_for_metadata_has_query_string_then_query_string_is_ignored_when_setting_issuer()
+    {
+        var pipeline = new IdentityServerPipeline();
+        pipeline.OnPreConfigure += app => app.UsePathBase("/identity");
+        pipeline.Initialize();
+
+        var result = await pipeline.BackChannelClient.GetAsync("https://server/.well-known/oauth-authorization-server/identity?query=string");
+
+        var json = await result.Content.ReadAsStringAsync();
+        var data = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json);
+        data["issuer"].GetString().ShouldBe("https://server/identity");
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task when_issuer_identifier_has_subpath_and_request_for_metadata_has_fragment_then_fragment_is_ignored_when_setting_issuer()
+    {
+        var pipeline = new IdentityServerPipeline();
+        pipeline.OnPreConfigure += app => app.UsePathBase("/identity");
+        pipeline.Initialize();
+
+        var result = await pipeline.BackChannelClient.GetAsync("https://server/.well-known/oauth-authorization-server/identity#fragment");
+
+        var json = await result.Content.ReadAsStringAsync();
+        var data = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json);
+        data["issuer"].GetString().ShouldBe("https://server/identity");
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task when_issuer_has_explicitly_been_set_then_metadata_endpoint_uses_configured_issuer_for_issuer()
+    {
+        var pipeline = new IdentityServerPipeline();
+        pipeline.Initialize();
+        pipeline.Options.IssuerUri = "https://example.com/explicit";
+
+        var result = await pipeline.BackChannelClient.GetAsync("https://server/.well-known/oauth-authorization-server");
+
+        var json = await result.Content.ReadAsStringAsync();
+        var data = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json);
+        data["issuer"].GetString().ShouldBe("https://example.com/explicit");
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task when_Map_is_used_then_endpoint_is_not_available_due_to_no_spec_compliant_location()
+    {
+        var pipeline = new IdentityServerPipeline();
+        pipeline.Initialize("/identity");
+
+        var result = await pipeline.BackChannelClient.GetAsync("https://server/identity/.well-known/oauth-authorization-server");
+
+        result.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+}

--- a/identity-server/test/IdentityServer.UnitTests/Hosting/EndpointHelpersTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Hosting/EndpointHelpersTests.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using Duende.IdentityServer.Hosting;
+using Duende.IdentityServer.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Testing;
+using UnitTests.Common;
+
+namespace UnitTests.Hosting;
+
+public class EndpointHelpersTests
+{
+    [Fact]
+    public void OnRouteMatched_WhenRouteDoesNotStartWithWellKnown_ReturnsFalse()
+    {
+        var routeValues = new RouteValueDictionary { { "subPath", "metadata" } };
+        var serverUrlsMock = new MockServerUrls();
+        var services = new ServiceCollection();
+        services.AddSingleton<IServerUrls>(serverUrlsMock);
+        var serviceProvider = services.BuildServiceProvider();
+        var context = new DefaultHttpContext
+        {
+            Request =
+            {
+                PathBase = new PathString("/identity")
+            },
+            RequestServices = serviceProvider
+        };
+
+        var result = EndpointHelpers.OAuth2AuthorizationServerMetadataHelpers.OnRouteMatched(context, routeValues, new FakeLogger());
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void OnRouteMatched_WhenSubPathIsValidString_SetsBasePath()
+    {
+        var routeValues = new RouteValueDictionary { { "subPath", "metadata" } };
+        var serverUrlsMock = new MockServerUrls();
+        var services = new ServiceCollection();
+        services.AddSingleton<IServerUrls>(serverUrlsMock);
+        var serviceProvider = services.BuildServiceProvider();
+        var context = new DefaultHttpContext { RequestServices = serviceProvider };
+
+        var result = EndpointHelpers.OAuth2AuthorizationServerMetadataHelpers.OnRouteMatched(context, routeValues, new FakeLogger());
+
+        result.ShouldBeTrue();
+        serverUrlsMock.BasePath.ShouldBe("/metadata");
+    }
+
+    [Fact]
+    public void OnRouteMatched_WhenSubPathIsMissing_DoesNothing()
+    {
+        var routeValues = new RouteValueDictionary();
+        var serverUrlsMock = new MockServerUrls();
+        var services = new ServiceCollection();
+        services.AddSingleton<IServerUrls>(serverUrlsMock);
+        var serviceProvider = services.BuildServiceProvider();
+        var context = new DefaultHttpContext { RequestServices = serviceProvider };
+
+        var result = EndpointHelpers.OAuth2AuthorizationServerMetadataHelpers.OnRouteMatched(context, routeValues, new FakeLogger());
+
+        result.ShouldBeTrue();
+        serverUrlsMock.BasePath.ShouldBeNull();
+    }
+
+    [Fact]
+    public void OnRouteMatched_WhenSubPathIsNotString_SetsBasePath()
+    {
+        var routeValues = new RouteValueDictionary { { "subPath", 123 } };
+        var serverUrlsMock = new MockServerUrls();
+        var services = new ServiceCollection();
+        services.AddSingleton<IServerUrls>(serverUrlsMock);
+        var serviceProvider = services.BuildServiceProvider();
+        var context = new DefaultHttpContext { RequestServices = serviceProvider };
+
+        var result = EndpointHelpers.OAuth2AuthorizationServerMetadataHelpers.OnRouteMatched(context, routeValues, new FakeLogger());
+
+        result.ShouldBeTrue();
+        serverUrlsMock.BasePath.ShouldBe("/123");
+    }
+}

--- a/identity-server/test/IdentityServer.UnitTests/Hosting/EndpointRouterTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Hosting/EndpointRouterTests.cs
@@ -110,79 +110,20 @@ public class EndpointRouterTests
         result.ShouldBeNull();
     }
 
-    [InlineData("/.well-known/oauth-authorization-server")]
-    [InlineData("/.well-known/oauth-authorization-server/identity")]
-    [Theory]
-    public void Find_should_match_route_that_uses_template(string path)
-    {
-        _endpoints.Add(new Duende.IdentityServer.Hosting.Endpoint(IdentityServerConstants.EndpointNames.OAuth2AuthorizationServerMetadata, "/.well-known/oauth-authorization-server/{*subPath}", typeof(MyEndpointHandler))
-        {
-            UsesRouteTemplate = true
-        });
-
-        var ctx = new DefaultHttpContext();
-        ctx.Request.Path = new PathString(path);
-        ctx.RequestServices = new StubServiceProvider();
-
-        var result = _subject.Find(ctx);
-
-        result.ShouldBeOfType<MyEndpointHandler>();
-    }
-
     [Fact]
-    public void Find_return_null_for_route_that_uses_template_when_path_is_incorrect()
+    public void Find_should_return_null_when_endpoint_match_function_returns_false()
     {
-        _endpoints.Add(new Duende.IdentityServer.Hosting.Endpoint(IdentityServerConstants.EndpointNames.OAuth2AuthorizationServerMetadata, "/.well-known/oauth-authorization-server/{*subPath}", typeof(MyEndpointHandler))
+        _endpoints.Add(new Duende.IdentityServer.Hosting.Endpoint(IdentityServerConstants.EndpointNames.Authorize, "/ep1", typeof(MyEndpointHandler))
         {
-            UsesRouteTemplate = true
+            IsMatch = _ => false
         });
+        _endpoints.Add(new Duende.IdentityServer.Hosting.Endpoint("ep2", "/ep2", typeof(MyOtherEndpointHandler)));
 
         var ctx = new DefaultHttpContext();
-        ctx.Request.Path = new PathString("/.not-well-known/oauth-authorization-server");
+        ctx.Request.Path = new PathString("/ep1");
         ctx.RequestServices = new StubServiceProvider();
 
         var result = _subject.Find(ctx);
-
-        result.ShouldBeNull();
-    }
-
-    [InlineData("/.well-known/oauth-authorization-server")]
-    [InlineData("/.well-known/oauth-authorization-server/identity")]
-    [Theory]
-    public void Find_should_match_route_that_uses_template_with_on_router_matched_when_on_route_matched_callback_returns_true(string path)
-    {
-        _endpoints.Add(new Duende.IdentityServer.Hosting.Endpoint(IdentityServerConstants.EndpointNames.OAuth2AuthorizationServerMetadata, "/.well-known/oauth-authorization-server/{*subPath}", typeof(MyEndpointHandler))
-        {
-            UsesRouteTemplate = true,
-            OnRouteMatched = (_, _, _) => true
-        });
-
-        var ctx = new DefaultHttpContext();
-        ctx.Request.Path = new PathString(path);
-        ctx.RequestServices = new StubServiceProvider();
-
-        var result = _subject.Find(ctx);
-
-        result.ShouldBeOfType<MyEndpointHandler>();
-    }
-
-    [InlineData("/.well-known/oauth-authorization-server")]
-    [InlineData("/.well-known/oauth-authorization-server/identity")]
-    [Theory]
-    public void Find_should_not_match_route_that_uses_template_with_on_router_matched_when_on_route_matched_callback_returns_false(string path)
-    {
-        _endpoints.Add(new Duende.IdentityServer.Hosting.Endpoint(IdentityServerConstants.EndpointNames.OAuth2AuthorizationServerMetadata, "/.well-known/oauth-authorization-server/{*subPath}", typeof(MyEndpointHandler))
-        {
-            UsesRouteTemplate = true,
-            OnRouteMatched = (_, _, _) => false
-        });
-
-        var ctx = new DefaultHttpContext();
-        ctx.Request.Path = new PathString(path);
-        ctx.RequestServices = new StubServiceProvider();
-
-        var result = _subject.Find(ctx);
-
         result.ShouldBeNull();
     }
 

--- a/identity-server/test/IdentityServer.UnitTests/Licensing/v2/DiagnosticEntries/EndpointUsageDiagnosticEntryTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Licensing/v2/DiagnosticEntries/EndpointUsageDiagnosticEntryTests.cs
@@ -41,7 +41,7 @@ public class EndpointUsageDiagnosticEntryTests
         var endpointUsage = result.RootElement.GetProperty("EndpointUsage");
         foreach (var endpoint in _endpoints)
         {
-            endpointUsage.GetProperty(endpoint).GetInt64().ShouldBe(1);
+            endpointUsage.GetProperty(endpoint.Value!).GetInt64().ShouldBe(1);
         }
     }
 
@@ -70,7 +70,7 @@ public class EndpointUsageDiagnosticEntryTests
         endpointUsage.GetProperty("other").GetInt64().ShouldBe(1);
         foreach (var endpoint in _endpoints)
         {
-            endpointUsage.GetProperty(endpoint).GetInt64().ShouldBe(0);
+            endpointUsage.GetProperty(endpoint.Value!).GetInt64().ShouldBe(0);
         }
     }
 

--- a/identity-server/test/IdentityServer.UnitTests/Validation/DefaultIssuerPathValidatorTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Validation/DefaultIssuerPathValidatorTests.cs
@@ -1,0 +1,114 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using Duende.IdentityServer.Validation;
+using Microsoft.Extensions.Logging.Testing;
+using UnitTests.Validation.Setup;
+
+namespace UnitTests.Validation;
+
+public class DefaultIssuerPathValidatorTests
+{
+    [Fact]
+    public async Task ValidateAsync_WhenIssuerPathMatches_ReturnsTrue()
+    {
+        var issuerNameService = new TestIssuerNameService("https://example.com/foo");
+        var logger = new FakeLogger<DefaultIssuerPathValidator>();
+        var subject = new DefaultIssuerPathValidator(issuerNameService, logger);
+        var path = "/foo";
+
+        var result = await subject.ValidateAsync(path);
+
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ValidateAsync_WhenPathIsEmpty_ReturnsTrue()
+    {
+        var issuerNameService = new TestIssuerNameService("https://example.com");
+        var logger = new FakeLogger<DefaultIssuerPathValidator>();
+        var subject = new DefaultIssuerPathValidator(issuerNameService, logger);
+        var path = string.Empty;
+
+        var result = await subject.ValidateAsync(path);
+
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ValidateAsync_WhenPathIsNull_ReturnsTrue()
+    {
+        var issuerNameService = new TestIssuerNameService("https://example.com");
+        var logger = new FakeLogger<DefaultIssuerPathValidator>();
+        var subject = new DefaultIssuerPathValidator(issuerNameService, logger);
+
+        var result = await subject.ValidateAsync(null);
+
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ValidateAsync_WhenPathIsDifferentCasingThanIssuer_ReturnsTrue()
+    {
+        var issuerNameService = new TestIssuerNameService("https://example.com/FOO");
+        var logger = new FakeLogger<DefaultIssuerPathValidator>();
+        var subject = new DefaultIssuerPathValidator(issuerNameService, logger);
+        var path = "/foo";
+
+        var result = await subject.ValidateAsync(path);
+
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ValidateAsync_WhenIssuerHasPortAndPathIsMatch_ReturnsTrue()
+    {
+        var issuerNameService = new TestIssuerNameService("https://example.com:5001/foo");
+        var logger = new FakeLogger<DefaultIssuerPathValidator>();
+        var subject = new DefaultIssuerPathValidator(issuerNameService, logger);
+        var path = "/foo";
+
+        var result = await subject.ValidateAsync(path);
+
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ValidateAsync_WhenIssuerHasMultipleSegmentsAndPathIsMatch_ReturnsTrue()
+    {
+        var issuerNameService = new TestIssuerNameService("https://example.com/foo/bar");
+        var logger = new FakeLogger<DefaultIssuerPathValidator>();
+        var subject = new DefaultIssuerPathValidator(issuerNameService, logger);
+        var path = "/foo/bar";
+
+        var result = await subject.ValidateAsync(path);
+
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ValidateAsync_WhenIssuerIsNotValidUri_ReturnsFalse()
+    {
+        var issuerNameService = new TestIssuerNameService("not-a-valid-uri");
+        var logger = new FakeLogger<DefaultIssuerPathValidator>();
+        var subject = new DefaultIssuerPathValidator(issuerNameService, logger);
+        var path = "/foo";
+
+        var result = await subject.ValidateAsync(path);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ValidateAsync_WhenIssuerPathDoesNotMatch_ReturnsFalse()
+    {
+        var issuerNameService = new TestIssuerNameService("https://example.com/bar");
+        var logger = new FakeLogger<DefaultIssuerPathValidator>();
+        var subject = new DefaultIssuerPathValidator(issuerNameService, logger);
+        var path = "/foo";
+
+        var result = await subject.ValidateAsync(path);
+
+        result.ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
**What issue does this PR address?**
Adds support for [RFC 8414: OAuth 2.0 Authorization Server Metadata](https://datatracker.ietf.org/doc/html/rfc8414). 

This also required adjustments to the endpoint routing to accommodate a path that isn't an exact match to support issue identifiers with path components.


**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
