### PR TITLE
fix log level for discussions/289

### DIFF
--- a/bff/src/Bff/Endpoints/Internal/BffAuthenticationService.cs
+++ b/bff/src/Bff/Endpoints/Internal/BffAuthenticationService.cs
@@ -32,7 +32,7 @@ internal class BffAuthenticationService(Decorator<IAuthenticationService> decora
                 return;
             }
 
-            logger.AuthenticatingScheme(LogLevel.Warning, scheme);
+            logger.SigningOutOfScheme(LogLevel.Debug, scheme);
             await _inner.SignOutAsync(context, frontend.OidcSchemeName, properties);
             return;
         }
@@ -49,7 +49,7 @@ internal class BffAuthenticationService(Decorator<IAuthenticationService> decora
                 return await _inner.AuthenticateAsync(context, scheme);
             }
 
-            logger.AuthenticatingScheme(LogLevel.Warning, scheme);
+            logger.AuthenticatingScheme(LogLevel.Trace, scheme);
             return await _inner.AuthenticateAsync(context, frontend.CookieSchemeName);
         }
 

--- a/bff/src/Bff/Otel/LogMessages.cs
+++ b/bff/src/Bff/Otel/LogMessages.cs
@@ -263,6 +263,9 @@ internal static partial class LogMessages
     [LoggerMessage(
         message: "Authenticating scheme: {Scheme}")]
     public static partial void AuthenticatingScheme(this ILogger logger, LogLevel logLevel, string? scheme);
+    [LoggerMessage(
+        message: "Signing out of scheme: {Scheme}")]
+    public static partial void SigningOutOfScheme(this ILogger logger, LogLevel logLevel, string? scheme);
 
     [LoggerMessage(
         message: "Setting OIDC ProtocolMessage.Prompt to 'none' for BFF silent login")]


### PR DESCRIPTION
**What issue does this PR address?**
The log level for the 'authenticating scheme' was incorrectly set to 'warning'. It should have been trace. 

fixes https://github.com/orgs/DuendeSoftware/discussions/289
fixes https://github.com/DuendeSoftware/issues/issues/539

**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
