### PR TITLE
remove valuetype from ClaimRecord

### DIFF
--- a/bff/src/Bff.Blazor/BffServerAuthenticationStateProvider.cs
+++ b/bff/src/Bff.Blazor/BffServerAuthenticationStateProvider.cs
@@ -94,8 +94,7 @@ internal sealed class BffServerAuthenticationStateProvider : RevalidatingServerA
             .Select(c => new ClaimRecord
             {
                 Type = c.Type,
-                Value = c.Value?.ToString() ?? string.Empty,
-                ValueType = c.ValueType == ClaimValueTypes.String ? null : c.ValueType
+                Value = c.Value?.ToString() ?? string.Empty
             }).ToList();
 
 

--- a/bff/src/Bff/Internal/ClaimRecord.cs
+++ b/bff/src/Bff/Internal/ClaimRecord.cs
@@ -10,11 +10,6 @@ namespace Duende.Bff.Internal;
 /// </summary>
 internal class ClaimRecord()
 {
-    /// <summary>
-    /// 
-    /// </summary>
-    /// <param name="type"></param>
-    /// <param name="value"></param>
     public ClaimRecord(string type, object value) : this()
     {
         Type = type;
@@ -33,9 +28,4 @@ internal class ClaimRecord()
     [JsonPropertyName("value")]
     public object Value { get; init; } = default!;
 
-    /// <summary>
-    /// The value type
-    /// </summary>
-    [JsonPropertyName("valueType")]
-    public string? ValueType { get; init; }
 }

--- a/bff/src/Bff/Internal/ClaimRecordExtensions.cs
+++ b/bff/src/Bff/Internal/ClaimRecordExtensions.cs
@@ -12,7 +12,7 @@ internal static class ClaimRecordExtensions
     /// </summary>
     public static ClaimsPrincipal ToClaimsPrincipal(this ClaimsPrincipalRecord principal)
     {
-        var claims = principal.Claims.Select(x => new Claim(x.Type, x.Value.ToString() ?? string.Empty, x.ValueType ?? ClaimValueTypes.String))
+        var claims = principal.Claims.Select(x => new Claim(x.Type, x.Value.ToString() ?? string.Empty))
             .ToArray();
         var id = new ClaimsIdentity(claims, principal.AuthenticationType, principal.NameClaimType,
             principal.RoleClaimType);
@@ -29,8 +29,7 @@ internal static class ClaimRecordExtensions
             x => new ClaimRecord
             {
                 Type = x.Type,
-                Value = x.Value,
-                ValueType = x.ValueType == ClaimValueTypes.String ? null : x.ValueType
+                Value = x.Value
             }).ToArray();
 
         return new ClaimsPrincipalRecord


### PR DESCRIPTION
**What issue does this PR address?**
The valuetype was rarely populated. The internal use for it is very questionable. 

<img width="512" height="96" alt="image" src="https://github.com/user-attachments/assets/e10bc21c-0b9e-46cb-9ad0-0f5b98668c33" />

So, removing it here. 


**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
