### PR TITLE
Amend the demo claim values so that they no longer include the host name and port.

### DIFF
--- a/identity-server/templates/src/IdentityServer/Pages/TestUsers.cs
+++ b/identity-server/templates/src/IdentityServer/Pages/TestUsers.cs
@@ -36,7 +36,7 @@ public static class TestUsers
                         new Claim(JwtClaimTypes.EmailVerified, "true", ClaimValueTypes.Boolean),
                         new Claim(JwtClaimTypes.WebSite, "http://alice.example.com"),
                         new Claim(JwtClaimTypes.Address, JsonSerializer.Serialize(address), IdentityServerConstants.ClaimValueTypes.Json),
-                        new Claim(JwtClaimTypes.Picture, "https://localhost:5001/img/avatar_default.png")
+                        new Claim(JwtClaimTypes.Picture, "/img/avatar_default.png")
                     }
                 },
                 new TestUser
@@ -53,7 +53,7 @@ public static class TestUsers
                         new Claim(JwtClaimTypes.EmailVerified, "true", ClaimValueTypes.Boolean),
                         new Claim(JwtClaimTypes.WebSite, "http://bob.example.com"),
                         new Claim(JwtClaimTypes.Address, JsonSerializer.Serialize(address), IdentityServerConstants.ClaimValueTypes.Json),
-                        new Claim(JwtClaimTypes.Picture, "https://localhost:5001/img/avatar_default.png")
+                        new Claim(JwtClaimTypes.Picture, "/img/avatar_default.png")
                     }
                 },
                 new TestUser
@@ -70,7 +70,7 @@ public static class TestUsers
                         new Claim(JwtClaimTypes.EmailVerified, "true", ClaimValueTypes.Boolean),
                         new Claim(JwtClaimTypes.WebSite, "http://charles.example.com"),
                         new Claim(JwtClaimTypes.Address, JsonSerializer.Serialize(address), IdentityServerConstants.ClaimValueTypes.Json),
-                        new Claim(JwtClaimTypes.Picture, "https://localhost:5001/img/avatar_default.png"),
+                        new Claim(JwtClaimTypes.Picture, "/img/avatar_default.png"),
 
                         // Adding a role claim for admin user
                         new Claim(JwtClaimTypes.Role, "admin")


### PR DESCRIPTION
**What issue does this PR address?**
This fixes a minor issue where the demo user avatar would fail to display when the app host was running under any other port than 5001.

**Important: Any code or remarks in your Pull Request are under the following terms:**
If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
