### PR TITLE
Support for custom parameters in authorize response

### DIFF
--- a/identity-server/CHANGELOG.md
+++ b/identity-server/CHANGELOG.md
@@ -18,6 +18,8 @@
   - If the default implementation does not meet your needs, `IUiLocalesService` can be implemented and registered with DI.
 - Set the DisplayName of the activity associated with the incoming HttpRequest when IdentityServer routes are matched by @josephdecock
   This makes the IdentityServer route names appear in OTel traces.
+- Support for custom parameters in the Authorize Redirect Uri by @bhazen
+  - Adds a new `CustomParameters` property to `AuthorizeResponse` to support adding custom query parameters to the redirect uri. This will typically be used in conjunction with a custom `IAuthorizeResponseGenerator`.
 
 ## Bug Fixes
 - Reject Pushed Authorization Requests with parameters duplicated in a JAR by @wcabus

--- a/identity-server/src/IdentityServer/Extensions/AuthorizeResponseExtensions.cs
+++ b/identity-server/src/IdentityServer/Extensions/AuthorizeResponseExtensions.cs
@@ -70,6 +70,14 @@ internal static class AuthorizeResponseExtensions
             }
         }
 
+        if (response.CustomParameters != null)
+        {
+            foreach (var entry in response.CustomParameters)
+            {
+                collection.Add(entry.Key, entry.Value);
+            }
+        }
+
         return collection;
     }
 }

--- a/identity-server/src/IdentityServer/ResponseHandling/Models/AuthorizeResponse.cs
+++ b/identity-server/src/IdentityServer/ResponseHandling/Models/AuthorizeResponse.cs
@@ -22,6 +22,7 @@ public class AuthorizeResponse
     public string Code { get; set; }
     public string SessionState { get; set; }
     public string Issuer { get; set; }
+    public Dictionary<string, string> CustomParameters { get; set; } = new();
 
     public string Error { get; set; }
     public string ErrorDescription { get; set; }

--- a/identity-server/test/IdentityServer.IntegrationTests/Extensibility/CustomAuthorizeResponseGeneratorTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Extensibility/CustomAuthorizeResponseGeneratorTests.cs
@@ -1,0 +1,107 @@
+// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using System.Net;
+using Duende.IdentityModel;
+using Duende.IdentityServer.Configuration;
+using Duende.IdentityServer.IntegrationTests.Common;
+using Duende.IdentityServer.Models;
+using Duende.IdentityServer.ResponseHandling;
+using Duende.IdentityServer.Services;
+using Duende.IdentityServer.Stores;
+using Duende.IdentityServer.Validation;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Duende.IdentityServer.IntegrationTests.Extensibility;
+
+public class CustomAuthorizeResponseGeneratorTests
+{
+    private const string Category = "CustomAuthorizeResponseGeneratorTests";
+
+    private IdentityServerPipeline _mockPipeline = new IdentityServerPipeline();
+
+    public CustomAuthorizeResponseGeneratorTests()
+    {
+        _mockPipeline.OnPostConfigureServices += svcs =>
+        {
+            svcs.AddTransient<IAuthorizeResponseGenerator, CustomAuthorizeResponseGenerator>();
+        };
+
+        _mockPipeline.Clients.Add(new Client
+        {
+            ClientId = "test",
+            ClientSecrets = { new Secret("secret".Sha256()) },
+            AllowedGrantTypes = GrantTypes.Code,
+            RedirectUris = { "https://client1/callback" },
+            AllowedScopes = { "scope1", "openid", "profile" }
+        });
+
+        _mockPipeline.IdentityScopes.AddRange([
+            new IdentityResources.OpenId(),
+            new IdentityResources.Profile(),
+            new IdentityResources.Email()
+        ]);
+        _mockPipeline.ApiScopes.Add(new ApiScope("scope1"));
+        _mockPipeline.ApiResources.Add(new ApiResource("urn:res1") { Scopes = { "scope1" } });
+
+        _mockPipeline.Users.Add(new Test.TestUser
+        {
+            SubjectId = "bob",
+            Username = "bob",
+            Password = "password",
+        });
+
+        _mockPipeline.Initialize();
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task custom_parameter_should_be_in_authorize_response()
+    {
+        _mockPipeline.Subject = new IdentityServerUser("bob").CreatePrincipal();
+        _mockPipeline.BrowserClient.StopRedirectingAfter = 2;
+
+        var url = _mockPipeline.CreateAuthorizeUrl(
+            clientId: "test",
+            responseType: "code",
+            scope: "openid profile scope1",
+            redirectUri: "https://client1/callback",
+            codeChallenge: new string('a', _mockPipeline.Options.InputLengthRestrictions.CodeVerifierMinLength),
+            codeChallengeMethod: OidcConstants.CodeChallengeMethods.Sha256,
+            state: "123_state",
+            nonce: "123_nonce");
+        var response = await _mockPipeline.BrowserClient.GetAsync(url);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+        response.Headers.Location.ShouldNotBeNull();
+        response.Headers.Location.ToString().ShouldStartWith("https://client1/callback");
+
+        var authorization = new Duende.IdentityModel.Client.AuthorizeResponse(response.Headers.Location.ToString());
+        authorization.IsError.ShouldBeFalse();
+        authorization.Values.ShouldContainKeyAndValue("custom_parameter", "custom_value");
+    }
+}
+
+public class CustomAuthorizeResponseGenerator(
+    IdentityServerOptions options,
+    IClock clock,
+    ITokenService tokenService,
+    IKeyMaterialService keyMaterialService,
+    IAuthorizationCodeStore authorizationCodeStore,
+    ILogger<AuthorizeResponseGenerator> logger,
+    IEventService events)
+    : AuthorizeResponseGenerator(options, clock, tokenService, keyMaterialService, authorizationCodeStore, logger,
+        events)
+{
+    public override async Task<AuthorizeResponse> CreateResponseAsync(ValidatedAuthorizeRequest request)
+    {
+        var baseResponse = await base.CreateResponseAsync(request).ConfigureAwait(false);
+        if (!baseResponse.IsError)
+        {
+            baseResponse.CustomParameters.Add("custom_parameter", "custom_value");
+        }
+
+        return baseResponse;
+    }
+}


### PR DESCRIPTION
**What issue does this PR address?**
Adds extensibility point for custom parameters in an authorize response.


**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
