### PR TITLE
Ensure Subject and Name Identifier Removed in External Callback

### DIFF
--- a/identity-server/hosts/UI/AspNetIdentity/Pages/ExternalLogin/Callback.cshtml.cs
+++ b/identity-server/hosts/UI/AspNetIdentity/Pages/ExternalLogin/Callback.cshtml.cs
@@ -76,7 +76,11 @@ public class Callback : PageModel
             // this might be where you might initiate a custom workflow for user registration
             // in this sample we don't show how that would be done, as our sample implementation
             // simply auto-provisions new external user
-            user = await AutoProvisionUserAsync(provider, providerUserId, externalUser.Claims);
+            //
+            // remove the user id and name identifier claims so we don't include it as an extra claim if/when we provision the user
+            var claims = externalUser.Claims.ToList();
+            claims.RemoveAll(c => c.Type is JwtClaimTypes.Subject or ClaimTypes.NameIdentifier);
+            user = await AutoProvisionUserAsync(provider, providerUserId, claims);
         }
 
         // this allows us to collect any additional claims or properties

--- a/identity-server/hosts/UI/Main/Pages/ExternalLogin/Callback.cshtml.cs
+++ b/identity-server/hosts/UI/Main/Pages/ExternalLogin/Callback.cshtml.cs
@@ -73,10 +73,10 @@ public class Callback : PageModel
             // in this sample we don't show how that would be done, as our sample implementation
             // simply auto-provisions new external user
             //
-            // remove the user id claim so we don't include it as an extra claim if/when we provision the user
+            // remove the user id and name identifier claims so we don't include it as an extra claim if/when we provision the user
             var claims = externalUser.Claims.ToList();
-            claims.Remove(userIdClaim);
-            user = _users.AutoProvisionUser(provider, providerUserId, claims.ToList());
+            claims.RemoveAll(c => c.Type is JwtClaimTypes.Subject or ClaimTypes.NameIdentifier);
+            user = _users.AutoProvisionUser(provider, providerUserId, claims);
         }
 
         // this allows us to collect any additional claims or properties

--- a/identity-server/templates/src/IdentityServer/Pages/ExternalLogin/Callback.cshtml.cs
+++ b/identity-server/templates/src/IdentityServer/Pages/ExternalLogin/Callback.cshtml.cs
@@ -72,9 +72,9 @@ public class Callback : PageModel
             // in this sample we don't show how that would be done, as our sample implementation
             // simply auto-provisions new external user
             //
-            // remove the user id claim so we don't include it as an extra claim if/when we provision the user
+            // remove the user id and name identifier claims so we don't include it as an extra claim if/when we provision the user
             var claims = externalUser.Claims.ToList();
-            claims.Remove(userIdClaim);
+            claims.RemoveAll(c => c.Type is JwtClaimTypes.Subject or ClaimTypes.NameIdentifier);
             user = _users.AutoProvisionUser(provider, providerUserId, claims.ToList());
         }
 

--- a/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/ExternalLogin/Callback.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerAspNetIdentity/Pages/ExternalLogin/Callback.cshtml.cs
@@ -72,6 +72,10 @@ public class Callback : PageModel
             // this might be where you might initiate a custom workflow for user registration
             // in this sample we don't show how that would be done, as our sample implementation
             // simply auto-provisions new external user
+            //
+            // remove the user id and name identifier claims so we don't include it as an extra claim if/when we provision the user
+            var claims = externalUser.Claims.ToList();
+            claims.RemoveAll(c => c.Type is JwtClaimTypes.Subject or ClaimTypes.NameIdentifier);
             user = await AutoProvisionUserAsync(provider, providerUserId, externalUser.Claims);
         }
 

--- a/identity-server/templates/src/IdentityServerEntityFramework/Pages/ExternalLogin/Callback.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerEntityFramework/Pages/ExternalLogin/Callback.cshtml.cs
@@ -71,10 +71,10 @@ public class Callback : PageModel
             // in this sample we don't show how that would be done, as our sample implementation
             // simply auto-provisions new external user
             //
-            // remove the user id claim so we don't include it as an extra claim if/when we provision the user
+            // remove the user id and name identifier claims so we don't include it as an extra claim if/when we provision the user
             var claims = externalUser.Claims.ToList();
-            claims.Remove(userIdClaim);
-            user = _users.AutoProvisionUser(provider, providerUserId, claims.ToList());
+            claims.RemoveAll(c => c.Type is JwtClaimTypes.Subject or ClaimTypes.NameIdentifier);
+            user = _users.AutoProvisionUser(provider, providerUserId, claims);
         }
 
         // this allows us to collect any additional claims or properties

--- a/identity-server/templates/src/IdentityServerInMem/Pages/ExternalLogin/Callback.cshtml.cs
+++ b/identity-server/templates/src/IdentityServerInMem/Pages/ExternalLogin/Callback.cshtml.cs
@@ -71,10 +71,10 @@ public class Callback : PageModel
             // in this sample we don't show how that would be done, as our sample implementation
             // simply auto-provisions new external user
             //
-            // remove the user id claim so we don't include it as an extra claim if/when we provision the user
+            // remove the user id and name identifier claims so we don't include it as an extra claim if/when we provision the user
             var claims = externalUser.Claims.ToList();
-            claims.Remove(userIdClaim);
-            user = _users.AutoProvisionUser(provider, providerUserId, claims.ToList());
+            claims.RemoveAll(c => c.Type is JwtClaimTypes.Subject or ClaimTypes.NameIdentifier);
+            user = _users.AutoProvisionUser(provider, providerUserId, claims);
         }
 
         // this allows us to collect any additional claims or properties


### PR DESCRIPTION
**What issue does this PR address?**
Ensures both subject and name identifier claims are removed in external callbacks before potentially provisioning a user.


**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
