### PR TITLE
Improve Playwright setup by caching artifacts

### DIFF
--- a/.github/workflow-gen/Program.cs
+++ b/.github/workflow-gen/Program.cs
@@ -145,6 +145,8 @@ void GenerateCiWorkflow(Product product)
 
         playwrightJob.StepBuild(product.Solution);
 
+        playwrightJob.CachePlaywrightAssets();
+
         playwrightJob.StepInstallPlayWright();
 
         playwrightJob.StepDotNetDevCerts();

--- a/.github/workflow-gen/StepExtensions.cs
+++ b/.github/workflow-gen/StepExtensions.cs
@@ -40,9 +40,19 @@ public static class StepExtensions
             .Name("Dotnet devcerts")
             .Run("dotnet dev-certs https --trust");
 
+    public static void CachePlaywrightAssets(this Job job)
+        => job.Step("playwright-cache")
+            .Name("Cache Playwright assets")
+            .Uses("actions/cache@v4")
+            .With(
+                ("path", "~/.cache/ms-playwright"),
+                ("key", "playwright-${{ runner.os }}-${{ hashFiles('**/Hosts.Tests.csproj') }}"),
+                ("restore-keys", "playwright-${{ runner.os }}-"));
+
     public static void StepInstallPlayWright(this Job job)
         => job.Step()
             .Name("Install Playwright")
+            .If("steps.playwright-cache.outputs.cache-hit != 'true'")
             .Run("pwsh test/Hosts.Tests/bin/Release/net9.0/playwright.ps1 install --with-deps");
 
     public static void StepToolRestore(this Job job)

--- a/.github/workflows/bff-ci.yml
+++ b/.github/workflows/bff-ci.yml
@@ -143,7 +143,15 @@ jobs:
       # We do not intend to keep using Debug config after it is fixed in net10.0 rc2.
       # Re-generating the workflows with workflow-gen will overwrite this.
       run: dotnet build bff.slnf --no-restore -c Debug
+    - id: playwright-cache
+      name: Cache Playwright assets
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-${{ runner.os }}-${{ hashFiles('**/Hosts.Tests.csproj') }}
+        restore-keys: playwright-${{ runner.os }}-
     - name: Install Playwright
+      if: steps.playwright-cache.outputs.cache-hit != 'true'
       run: pwsh test/Hosts.Tests/bin/Debug/net9.0/playwright.ps1 install --with-deps
     - name: Dotnet devcerts
       run: dotnet dev-certs https --trust


### PR DESCRIPTION
**What issue does this PR address?**

Improve Playwright Installation / Setup that can take upwards of 12 minutes in certain cases by caching the artifacts for future runs.

**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
