### PR TITLE
Catch potential OperationCanceledException in DiagnosticHostedService

### DIFF
--- a/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticHostedService.cs
+++ b/identity-server/src/IdentityServer/Licensing/V2/Diagnostics/DiagnosticHostedService.cs
@@ -13,17 +13,31 @@ internal class DiagnosticHostedService(DiagnosticSummary diagnosticSummary, IOpt
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         using var timer = new PeriodicTimer(options.Value.Diagnostics.LogFrequency);
-        while (!stoppingToken.IsCancellationRequested && await timer.WaitForNextTickAsync(stoppingToken))
+        try
         {
-            try
+            while (!stoppingToken.IsCancellationRequested && await timer.WaitForNextTickAsync(stoppingToken))
             {
-                await diagnosticSummary.PrintSummary();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "An error occurred while logging the diagnostic summary: {Message}", ex.Message);
+                try
+                {
+                    await diagnosticSummary.PrintSummary();
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "An error occurred while logging the diagnostic summary: {Message}",
+                        ex.Message);
+                }
             }
         }
+        catch (OperationCanceledException)
+        {
+            // When stopping this hosted service, "await timer.WaitForNextTickAsync(stoppingToken)" can throw an OperationCanceledException.
+        }
+    }
+
+    // Added for testing purposes to be able to call ExecuteAsync directly.
+    internal async Task ExecuteForTestOnly(CancellationToken stoppingToken)
+    {
+        await ExecuteAsync(stoppingToken);
     }
 
     public override async Task StopAsync(CancellationToken cancellationToken)

--- a/identity-server/test/IdentityServer.UnitTests/Licensing/v2/DiagnosticHostedServiceTests.cs
+++ b/identity-server/test/IdentityServer.UnitTests/Licensing/v2/DiagnosticHostedServiceTests.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Duende Software. All rights reserved.
+// See LICENSE in the project root for license information.
+
+using System.Text.Json;
+using Duende.IdentityServer.Configuration;
+using Duende.IdentityServer.Licensing.V2.Diagnostics;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace IdentityServer.UnitTests.Licensing.V2;
+
+public class DiagnosticHostedServiceTests
+{
+    [Fact]
+    public async Task ExecuteAsync_ShouldNotThrowOperationCancelledException()
+    {
+        var diagnosticSummaryLogger = new NullLogger<DiagnosticSummary>();
+        var firstDiagnosticEntry = new TestDiagnosticEntry();
+        var secondDiagnosticEntry = new TestDiagnosticEntry();
+        var thirdDiagnosticEntry = new TestDiagnosticEntry();
+        var entries = new List<IDiagnosticEntry>
+        {
+            firstDiagnosticEntry,
+            secondDiagnosticEntry,
+            thirdDiagnosticEntry
+        };
+        var diagnosticSummary = new DiagnosticSummary(DateTime.UtcNow, entries, new IdentityServerOptions(), new StubLoggerFactory(diagnosticSummaryLogger));
+
+        var options = Options.Create(new IdentityServerOptions());
+        var logger = new NullLogger<DiagnosticHostedService>();
+
+        var service = new DiagnosticHostedService(diagnosticSummary, options, logger);
+
+        using var cts = new CancellationTokenSource();
+        cts.CancelAfter(100);
+
+        var exception = await Record.ExceptionAsync(async () =>
+        {
+            await service.ExecuteForTestOnly(cts.Token);
+        });
+
+        exception.ShouldBeNull();
+    }
+
+    private class TestDiagnosticEntry : IDiagnosticEntry
+    {
+        public bool WasCalled { get; private set; }
+        public Task WriteAsync(DiagnosticContext context, Utf8JsonWriter writer)
+        {
+            WasCalled = true;
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
**What issue does this PR address?**

Some [testing frameworks fail](https://github.com/orgs/DuendeSoftware/discussions/348) when running integration tests on the new `DiagnosticHostedService`: when the service stops, the `PeriodicTimer` can throw an `OperationCanceledException`.

I wasn't able to simulate this in a unit test when calling the normal `StartAsync` and `StopAsync` hosted service methods, which is why I added an internal test-only method.

**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
