### PR TITLE
Emit telemetry event on successful token introspection

### DIFF
--- a/identity-server/CHANGELOG.md
+++ b/identity-server/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ## Bug Fixes
 - Reject Pushed Authorization Requests with parameters duplicated in a JAR by @wcabus
+- Emit Telemetry Event for Introspection Requests for Valid Tokens by @bhazen
 
 ## Code Quality
 - Fixed typo in XML doc for Client.CoordinateLifetimeWithUserSession by @wcabus

--- a/identity-server/src/IdentityServer/ResponseHandling/Default/IntrospectionResponseGenerator.cs
+++ b/identity-server/src/IdentityServer/ResponseHandling/Default/IntrospectionResponseGenerator.cs
@@ -97,6 +97,7 @@ public class IntrospectionResponseGenerator : IIntrospectionResponseGenerator
         // add scopes
         response.Add("scope", scopes.ToSpaceSeparatedString());
 
+        Telemetry.Metrics.Introspection(callerName, true);
         await Events.RaiseAsync(new TokenIntrospectionSuccessEvent(validationResult));
         return response;
     }

--- a/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Introspection/IntrospectionTests.cs
+++ b/identity-server/test/IdentityServer.IntegrationTests/Endpoints/Introspection/IntrospectionTests.cs
@@ -2,8 +2,10 @@
 // See LICENSE in the project root for license information.
 
 
+using System.Diagnostics.Metrics;
 using System.IdentityModel.Tokens.Jwt;
 using System.Net;
+using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
 using Duende.IdentityModel;
@@ -926,5 +928,104 @@ public class IntrospectionTests
         rolesClaim.ShouldContain("Geek");
     }
 
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task valid_active_token_should_increment_telemetry()
+    {
+        using var listener = StartListeningForMeasurements(Telemetry.Metrics.Counters.Introspection, out var measurements);
+        var tokenResponse = await _client.RequestClientCredentialsTokenAsync(new ClientCredentialsTokenRequest
+        {
+            Address = TokenEndpoint,
+            ClientId = "client1",
+            ClientSecret = "secret",
+            Scope = "api1"
+        });
+
+        var introspectionResponse = await _client.IntrospectTokenAsync(new TokenIntrospectionRequest
+        {
+            Address = IntrospectionEndpoint,
+            ClientId = "api1",
+            ClientSecret = "secret",
+
+            Token = tokenResponse.AccessToken
+        });
+
+        introspectionResponse.IsActive.ShouldBe(true);
+        introspectionResponse.IsError.ShouldBe(false);
+        measurements.Count.ShouldBe(1);
+        measurements[0].Name.ShouldBe(Telemetry.Metrics.Counters.Introspection);
+        measurements[0].Value.ShouldBe(1);
+        measurements[0].Tags.ShouldContain(new KeyValuePair<string, object>("active", true));
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task token_that_fails_validation_should_increment_telemetry()
+    {
+        using var listener = StartListeningForMeasurements(Telemetry.Metrics.Counters.Introspection, out var measurements);
+
+        var introspectionResponse = await _client.IntrospectTokenAsync(new TokenIntrospectionRequest
+        {
+            Address = IntrospectionEndpoint,
+            ClientId = "client1",
+            ClientSecret = "secret",
+
+            Token = "invalid"
+        });
+
+        introspectionResponse.IsActive.ShouldBe(false);
+        introspectionResponse.IsError.ShouldBe(false);
+        measurements.Count.ShouldBe(1);
+        measurements[0].Name.ShouldBe(Telemetry.Metrics.Counters.Introspection);
+        measurements[0].Value.ShouldBe(1);
+        measurements[0].Tags.ShouldContain(new KeyValuePair<string, object>("active", false));
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task token_that_results_in_validation_error_should_increment_telemetry()
+    {
+        using var listener = StartListeningForMeasurements(Telemetry.Metrics.Counters.Introspection, out var measurements);
+
+        var requestContent = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            { "client_id", "api1" },
+            { "client_secret", "secret" },
+            { "token", "" }
+        });
+        var rawIntrospectionResponse = await _client.PostAsync(IntrospectionEndpoint, requestContent);
+        var introspectionResponse = await rawIntrospectionResponse.Content.ReadFromJsonAsync<TokenIntrospectionResponse>();
+
+        introspectionResponse.IsActive.ShouldBe(false);
+        introspectionResponse.IsError.ShouldBe(false);
+        measurements.Count.ShouldBe(1);
+        measurements[0].Name.ShouldBe(Telemetry.Metrics.Counters.Introspection);
+        measurements[0].Value.ShouldBe(1);
+        measurements[0].Tags.ShouldContain(new KeyValuePair<string, object>("error", "missing_token"));
+    }
+
     private Dictionary<string, JsonElement> GetFields(TokenIntrospectionResponse response) => response.Raw.GetFields();
+
+    private static MeterListener StartListeningForMeasurements(string meterName,
+        out List<(string Name, long Value, KeyValuePair<string, object>[] Tags)> results)
+    {
+        var listener = new MeterListener();
+        List<(string Name, long Value, KeyValuePair<string, object>[] Tags)> measurements = new();
+
+        listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, _) =>
+        {
+            measurements.Add((instrument.Name, measurement, tags.ToArray()));
+        });
+
+        listener.InstrumentPublished = (instrument, meterListener) =>
+        {
+            if (instrument.Name == meterName)
+            {
+                meterListener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.Start();
+        results = measurements;
+        return listener;
+    }
 }


### PR DESCRIPTION
**What issue does this PR address?**
Adds missing telemetry event when a token introspection was successful and then token was active

**Important: Any code or remarks in your Pull Request are under the following terms:**

If You provide us with any comments, bug reports, feedback, enhancements, or modifications proposed or suggested by You for the Software, such Feedback is provided on a non-confidential basis (notwithstanding any notice to the contrary You may include in any accompanying communication), and Licensor shall have the right to use such Feedback at its discretion, including, but not limited to the incorporation of such suggested changes into the Software. You hereby grant Licensor a perpetual, irrevocable, transferable, sublicensable, nonexclusive license under all rights necessary to incorporate and use your Feedback for any purpose, including to make and sell any products and services.

(see [our license](https://duendesoftware.com/license/identityserver.pdf), section 7)
